### PR TITLE
chore: Update generator to v1.4.27

### DIFF
--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gaav::AnalyticsAdminServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAnalyticsAdminServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gaav::AnalyticsAdminServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gaav::AnalyticsAdminServiceClientBuilder builder = new gaav::AnalyticsAdminServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gaav::AnalyticsAdminServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAnalyticsAdminServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gaav::AnalyticsAdminServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gaav::AnalyticsAdminServiceClientBuilder builder = new gaav::AnalyticsAdminServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/ServiceCollectionExtensions.g.cs
@@ -44,5 +44,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gadv::BetaAnalyticsDataClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddBetaAnalyticsDataClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gadv::BetaAnalyticsDataClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gadv::BetaAnalyticsDataClientBuilder builder = new gadv::BetaAnalyticsDataClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gacv::ChatServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddChatServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gacv::ChatServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gacv::ChatServiceClientBuilder builder = new gacv::ChatServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gaesv::SubscriptionsServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSubscriptionsServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gaesv::SubscriptionsServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gaesv::SubscriptionsServiceClientBuilder builder = new gaesv::SubscriptionsServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2/ServiceCollectionExtensions.g.cs
@@ -44,6 +44,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gamv::ConferenceRecordsServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddConferenceRecordsServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gamv::ConferenceRecordsServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gamv::ConferenceRecordsServiceClientBuilder builder = new gamv::ConferenceRecordsServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gamv::SpacesServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -57,6 +75,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gamv::SpacesServiceClientBuilder builder = new gamv::SpacesServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gamv::SpacesServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSpacesServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gamv::SpacesServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gamv::SpacesServiceClientBuilder builder = new gamv::SpacesServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta/ServiceCollectionExtensions.g.cs
@@ -44,6 +44,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gamv::ConferenceRecordsServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddConferenceRecordsServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gamv::ConferenceRecordsServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gamv::ConferenceRecordsServiceClientBuilder builder = new gamv::ConferenceRecordsServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gamv::SpacesServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -57,6 +75,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gamv::SpacesServiceClientBuilder builder = new gamv::SpacesServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gamv::SpacesServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSpacesServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gamv::SpacesServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gamv::SpacesServiceClientBuilder builder = new gamv::SpacesServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gatv::TablesServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTablesServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gatv::TablesServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gatv::TablesServiceClientBuilder builder = new gatv::TablesServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ServiceCollectionExtensions.g.cs
@@ -46,6 +46,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcav::DatasetServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDatasetServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::DatasetServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::DatasetServiceClientBuilder builder = new gcav::DatasetServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>
         /// Adds a singleton <see cref="gcav::DeploymentResourcePoolServiceClient"/> to <paramref name="services"/>.
         /// </summary>
@@ -61,6 +77,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcav::DeploymentResourcePoolServiceClientBuilder builder = new gcav::DeploymentResourcePoolServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcav::DeploymentResourcePoolServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDeploymentResourcePoolServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::DeploymentResourcePoolServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::DeploymentResourcePoolServiceClientBuilder builder = new gcav::DeploymentResourcePoolServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -83,6 +117,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcav::EndpointServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddEndpointServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::EndpointServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::EndpointServiceClientBuilder builder = new gcav::EndpointServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcav::FeatureOnlineStoreAdminServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -97,6 +149,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcav::FeatureOnlineStoreAdminServiceClientBuilder builder = new gcav::FeatureOnlineStoreAdminServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcav::FeatureOnlineStoreAdminServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddFeatureOnlineStoreAdminServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::FeatureOnlineStoreAdminServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::FeatureOnlineStoreAdminServiceClientBuilder builder = new gcav::FeatureOnlineStoreAdminServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -119,6 +189,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcav::FeatureOnlineStoreServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddFeatureOnlineStoreServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::FeatureOnlineStoreServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::FeatureOnlineStoreServiceClientBuilder builder = new gcav::FeatureOnlineStoreServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcav::FeatureRegistryServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -133,6 +221,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcav::FeatureRegistryServiceClientBuilder builder = new gcav::FeatureRegistryServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcav::FeatureRegistryServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddFeatureRegistryServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::FeatureRegistryServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::FeatureRegistryServiceClientBuilder builder = new gcav::FeatureRegistryServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -155,6 +261,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcav::FeaturestoreOnlineServingServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddFeaturestoreOnlineServingServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::FeaturestoreOnlineServingServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::FeaturestoreOnlineServingServiceClientBuilder builder = new gcav::FeaturestoreOnlineServingServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcav::FeaturestoreServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -169,6 +293,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcav::FeaturestoreServiceClientBuilder builder = new gcav::FeaturestoreServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcav::FeaturestoreServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddFeaturestoreServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::FeaturestoreServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::FeaturestoreServiceClientBuilder builder = new gcav::FeaturestoreServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -191,6 +333,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcav::GenAiTuningServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddGenAiTuningServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::GenAiTuningServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::GenAiTuningServiceClientBuilder builder = new gcav::GenAiTuningServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcav::IndexEndpointServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -205,6 +365,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcav::IndexEndpointServiceClientBuilder builder = new gcav::IndexEndpointServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcav::IndexEndpointServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddIndexEndpointServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::IndexEndpointServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::IndexEndpointServiceClientBuilder builder = new gcav::IndexEndpointServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -224,6 +402,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcav::IndexServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddIndexServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::IndexServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::IndexServiceClientBuilder builder = new gcav::IndexServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcav::JobServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -237,6 +431,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcav::JobServiceClientBuilder builder = new gcav::JobServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcav::JobServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddJobServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::JobServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::JobServiceClientBuilder builder = new gcav::JobServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -258,6 +468,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcav::LlmUtilityServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddLlmUtilityServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::LlmUtilityServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::LlmUtilityServiceClientBuilder builder = new gcav::LlmUtilityServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcav::MatchServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -271,6 +499,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcav::MatchServiceClientBuilder builder = new gcav::MatchServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcav::MatchServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddMatchServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::MatchServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::MatchServiceClientBuilder builder = new gcav::MatchServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -293,6 +537,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcav::MetadataServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddMetadataServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::MetadataServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::MetadataServiceClientBuilder builder = new gcav::MetadataServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcav::MigrationServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -307,6 +569,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcav::MigrationServiceClientBuilder builder = new gcav::MigrationServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcav::MigrationServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddMigrationServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::MigrationServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::MigrationServiceClientBuilder builder = new gcav::MigrationServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -328,6 +608,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcav::ModelGardenServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddModelGardenServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::ModelGardenServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::ModelGardenServiceClientBuilder builder = new gcav::ModelGardenServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcav::ModelServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -341,6 +639,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcav::ModelServiceClientBuilder builder = new gcav::ModelServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcav::ModelServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddModelServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::ModelServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::ModelServiceClientBuilder builder = new gcav::ModelServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -363,6 +677,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcav::NotebookServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddNotebookServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::NotebookServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::NotebookServiceClientBuilder builder = new gcav::NotebookServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcav::PersistentResourceServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -377,6 +709,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcav::PersistentResourceServiceClientBuilder builder = new gcav::PersistentResourceServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcav::PersistentResourceServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddPersistentResourceServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::PersistentResourceServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::PersistentResourceServiceClientBuilder builder = new gcav::PersistentResourceServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -399,6 +749,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcav::PipelineServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddPipelineServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::PipelineServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::PipelineServiceClientBuilder builder = new gcav::PipelineServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcav::PredictionServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -413,6 +781,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcav::PredictionServiceClientBuilder builder = new gcav::PredictionServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcav::PredictionServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddPredictionServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::PredictionServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::PredictionServiceClientBuilder builder = new gcav::PredictionServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -435,6 +821,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcav::ScheduleServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddScheduleServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::ScheduleServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::ScheduleServiceClientBuilder builder = new gcav::ScheduleServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcav::SpecialistPoolServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -449,6 +853,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcav::SpecialistPoolServiceClientBuilder builder = new gcav::SpecialistPoolServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcav::SpecialistPoolServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSpecialistPoolServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::SpecialistPoolServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::SpecialistPoolServiceClientBuilder builder = new gcav::SpecialistPoolServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -470,6 +892,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcav::TensorboardServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTensorboardServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::TensorboardServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::TensorboardServiceClientBuilder builder = new gcav::TensorboardServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcav::VizierServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -483,6 +923,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcav::VizierServiceClientBuilder builder = new gcav::VizierServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcav::VizierServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddVizierServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::VizierServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::VizierServiceClientBuilder builder = new gcav::VizierServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcav::AccessApprovalServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAccessApprovalServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::AccessApprovalServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::AccessApprovalServiceClientBuilder builder = new gcav::AccessApprovalServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcav::AdvisoryNotificationsServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAdvisoryNotificationsServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::AdvisoryNotificationsServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::AdvisoryNotificationsServiceClientBuilder builder = new gcav::AdvisoryNotificationsServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcav::AlloyDBAdminClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAlloyDBAdminClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::AlloyDBAdminClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::AlloyDBAdminClientBuilder builder = new gcav::AlloyDBAdminClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcav::AlloyDBAdminClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAlloyDBAdminClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::AlloyDBAdminClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::AlloyDBAdminClientBuilder builder = new gcav::AlloyDBAdminClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcav::AlloyDBAdminClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAlloyDBAdminClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::AlloyDBAdminClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::AlloyDBAdminClientBuilder builder = new gcav::AlloyDBAdminClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcav::ApiGatewayServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddApiGatewayServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::ApiGatewayServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::ApiGatewayServiceClientBuilder builder = new gcav::ApiGatewayServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcav::ApiKeysClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddApiKeysClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::ApiKeysClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::ApiKeysClientBuilder builder = new gcav::ApiKeysClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1/ServiceCollectionExtensions.g.cs
@@ -44,6 +44,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcav::ConnectionServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddConnectionServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::ConnectionServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::ConnectionServiceClientBuilder builder = new gcav::ConnectionServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcav::TetherClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -57,6 +75,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcav::TetherClientBuilder builder = new gcav::TetherClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcav::TetherClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTetherClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::TetherClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::TetherClientBuilder builder = new gcav::TetherClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1/ServiceCollectionExtensions.g.cs
@@ -46,6 +46,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcav::ProvisioningClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddProvisioningClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::ProvisioningClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::ProvisioningClientBuilder builder = new gcav::ProvisioningClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcav::RegistryClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -59,6 +75,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcav::RegistryClientBuilder builder = new gcav::RegistryClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcav::RegistryClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegistryClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::RegistryClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::RegistryClientBuilder builder = new gcav::RegistryClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/ServiceCollectionExtensions.g.cs
@@ -44,6 +44,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcav::ApplicationsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddApplicationsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::ApplicationsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::ApplicationsClientBuilder builder = new gcav::ApplicationsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>
         /// Adds a singleton <see cref="gcav::AuthorizedCertificatesClient"/> to <paramref name="services"/>.
         /// </summary>
@@ -59,6 +75,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcav::AuthorizedCertificatesClientBuilder builder = new gcav::AuthorizedCertificatesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcav::AuthorizedCertificatesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAuthorizedCertificatesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::AuthorizedCertificatesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::AuthorizedCertificatesClientBuilder builder = new gcav::AuthorizedCertificatesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -80,6 +114,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcav::AuthorizedDomainsClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAuthorizedDomainsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::AuthorizedDomainsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::AuthorizedDomainsClientBuilder builder = new gcav::AuthorizedDomainsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcav::DomainMappingsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -93,6 +145,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcav::DomainMappingsClientBuilder builder = new gcav::DomainMappingsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcav::DomainMappingsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDomainMappingsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::DomainMappingsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::DomainMappingsClientBuilder builder = new gcav::DomainMappingsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -112,6 +180,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcav::FirewallClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddFirewallClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::FirewallClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::FirewallClientBuilder builder = new gcav::FirewallClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcav::InstancesClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -125,6 +209,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcav::InstancesClientBuilder builder = new gcav::InstancesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcav::InstancesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddInstancesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::InstancesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::InstancesClientBuilder builder = new gcav::InstancesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -144,6 +244,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcav::ServicesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddServicesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::ServicesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::ServicesClientBuilder builder = new gcav::ServicesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcav::VersionsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -157,6 +273,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcav::VersionsClientBuilder builder = new gcav::VersionsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcav::VersionsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddVersionsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::VersionsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::VersionsClientBuilder builder = new gcav::VersionsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcav::AppHubClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAppHubClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::AppHubClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::AppHubClientBuilder builder = new gcav::AppHubClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/ServiceCollectionExtensions.g.cs
@@ -46,5 +46,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcav::ArtifactRegistryClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddArtifactRegistryClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::ArtifactRegistryClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::ArtifactRegistryClientBuilder builder = new gcav::ArtifactRegistryClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/ServiceCollectionExtensions.g.cs
@@ -46,5 +46,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcav::ArtifactRegistryClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddArtifactRegistryClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::ArtifactRegistryClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::ArtifactRegistryClientBuilder builder = new gcav::ArtifactRegistryClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcav::AssetServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAssetServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::AssetServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::AssetServiceClientBuilder builder = new gcav::AssetServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcav::AssuredWorkloadsServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAssuredWorkloadsServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::AssuredWorkloadsServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::AssuredWorkloadsServiceClientBuilder builder = new gcav::AssuredWorkloadsServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcav::AssuredWorkloadsServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAssuredWorkloadsServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::AssuredWorkloadsServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::AssuredWorkloadsServiceClientBuilder builder = new gcav::AssuredWorkloadsServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/ServiceCollectionExtensions.g.cs
@@ -44,6 +44,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcav::AutoMlClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAutoMlClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::AutoMlClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::AutoMlClientBuilder builder = new gcav::AutoMlClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>
         /// Adds a singleton <see cref="gcav::PredictionServiceClient"/> to <paramref name="services"/>.
         /// </summary>
@@ -59,6 +75,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcav::PredictionServiceClientBuilder builder = new gcav::PredictionServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcav::PredictionServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddPredictionServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcav::PredictionServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcav::PredictionServiceClientBuilder builder = new gcav::PredictionServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcbv::BackupDRClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddBackupDRClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbv::BackupDRClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbv::BackupDRClientBuilder builder = new gcbv::BackupDRClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/ServiceCollectionExtensions.g.cs
@@ -47,5 +47,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcbv::BareMetalSolutionClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddBareMetalSolutionClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbv::BareMetalSolutionClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbv::BareMetalSolutionClientBuilder builder = new gcbv::BareMetalSolutionClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/ServiceCollectionExtensions.g.cs
@@ -44,5 +44,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcbv::BatchServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddBatchServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbv::BatchServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbv::BatchServiceClientBuilder builder = new gcbv::BatchServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/ServiceCollectionExtensions.g.cs
@@ -44,5 +44,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcbv::BatchServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddBatchServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbv::BatchServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbv::BatchServiceClientBuilder builder = new gcbv::BatchServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1/ServiceCollectionExtensions.g.cs
@@ -47,5 +47,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcbav::AppConnectionsServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAppConnectionsServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbav::AppConnectionsServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbav::AppConnectionsServiceClientBuilder builder = new gcbav::AppConnectionsServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1/ServiceCollectionExtensions.g.cs
@@ -47,5 +47,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcbav::AppConnectorsServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAppConnectorsServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbav::AppConnectorsServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbav::AppConnectorsServiceClientBuilder builder = new gcbav::AppConnectorsServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1/ServiceCollectionExtensions.g.cs
@@ -47,5 +47,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcbav::AppGatewaysServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAppGatewaysServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbav::AppGatewaysServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbav::AppGatewaysServiceClientBuilder builder = new gcbav::AppGatewaysServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1/ServiceCollectionExtensions.g.cs
@@ -47,5 +47,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcbcv::ClientGatewaysServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddClientGatewaysServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbcv::ClientGatewaysServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbcv::ClientGatewaysServiceClientBuilder builder = new gcbcv::ClientGatewaysServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1/ServiceCollectionExtensions.g.cs
@@ -44,5 +44,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcbav::AnalyticsHubServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAnalyticsHubServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbav::AnalyticsHubServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbav::AnalyticsHubServiceClientBuilder builder = new gcbav::AnalyticsHubServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcbcv::ConnectionServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddConnectionServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbcv::ConnectionServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbcv::ConnectionServiceClientBuilder builder = new gcbcv::ConnectionServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcbdv::AnalyticsHubServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAnalyticsHubServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbdv::AnalyticsHubServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbdv::AnalyticsHubServiceClientBuilder builder = new gcbdv::AnalyticsHubServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcbdv::DataPolicyServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDataPolicyServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbdv::DataPolicyServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbdv::DataPolicyServiceClientBuilder builder = new gcbdv::DataPolicyServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcbdv::DataPolicyServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDataPolicyServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbdv::DataPolicyServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbdv::DataPolicyServiceClientBuilder builder = new gcbdv::DataPolicyServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcbdv::DataTransferServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDataTransferServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbdv::DataTransferServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbdv::DataTransferServiceClientBuilder builder = new gcbdv::DataTransferServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcbmv::MigrationServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddMigrationServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbmv::MigrationServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbmv::MigrationServiceClientBuilder builder = new gcbmv::MigrationServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcbrv::ReservationServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddReservationServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbrv::ReservationServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbrv::ReservationServiceClientBuilder builder = new gcbrv::ReservationServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/ServiceCollectionExtensions.g.cs
@@ -42,6 +42,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcbsv::BigQueryReadClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddBigQueryReadClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbsv::BigQueryReadClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbsv::BigQueryReadClientBuilder builder = new gcbsv::BigQueryReadClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcbsv::BigQueryWriteClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -55,6 +71,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcbsv::BigQueryWriteClientBuilder builder = new gcbsv::BigQueryWriteClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcbsv::BigQueryWriteClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddBigQueryWriteClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbsv::BigQueryWriteClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbsv::BigQueryWriteClientBuilder builder = new gcbsv::BigQueryWriteClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/ServiceCollectionExtensions.g.cs
@@ -47,6 +47,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcbav::BigtableInstanceAdminClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddBigtableInstanceAdminClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbav::BigtableInstanceAdminClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbav::BigtableInstanceAdminClientBuilder builder = new gcbav::BigtableInstanceAdminClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcbav::BigtableTableAdminClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -61,6 +79,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcbav::BigtableTableAdminClientBuilder builder = new gcbav::BigtableTableAdminClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcbav::BigtableTableAdminClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddBigtableTableAdminClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbav::BigtableTableAdminClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbav::BigtableTableAdminClientBuilder builder = new gcbav::BigtableTableAdminClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcbv::BigtableServiceApiClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddBigtableServiceApiClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbv::BigtableServiceApiClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbv::BigtableServiceApiClientBuilder builder = new gcbv::BigtableServiceApiClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcbbv::BudgetServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddBudgetServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbbv::BudgetServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbbv::BudgetServiceClientBuilder builder = new gcbbv::BudgetServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcbbv::BudgetServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddBudgetServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbbv::BudgetServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbbv::BudgetServiceClientBuilder builder = new gcbbv::BudgetServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/ServiceCollectionExtensions.g.cs
@@ -42,6 +42,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcbv::CloudBillingClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCloudBillingClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbv::CloudBillingClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbv::CloudBillingClientBuilder builder = new gcbv::CloudBillingClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcbv::CloudCatalogClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -55,6 +71,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcbv::CloudCatalogClientBuilder builder = new gcbv::CloudCatalogClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcbv::CloudCatalogClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCloudCatalogClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbv::CloudCatalogClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbv::CloudCatalogClientBuilder builder = new gcbv::CloudCatalogClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1/ServiceCollectionExtensions.g.cs
@@ -44,6 +44,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcbv::BinauthzManagementServiceV1Client"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddBinauthzManagementServiceV1Client(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbv::BinauthzManagementServiceV1ClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbv::BinauthzManagementServiceV1ClientBuilder builder = new gcbv::BinauthzManagementServiceV1ClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcbv::SystemPolicyV1Client"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -57,6 +75,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcbv::SystemPolicyV1ClientBuilder builder = new gcbv::SystemPolicyV1ClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcbv::SystemPolicyV1Client"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSystemPolicyV1Client(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbv::SystemPolicyV1ClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbv::SystemPolicyV1ClientBuilder builder = new gcbv::SystemPolicyV1ClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -75,6 +109,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcbv::ValidationHelperV1ClientBuilder builder = new gcbv::ValidationHelperV1ClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcbv::ValidationHelperV1Client"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddValidationHelperV1Client(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbv::ValidationHelperV1ClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbv::ValidationHelperV1ClientBuilder builder = new gcbv::ValidationHelperV1ClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -45,6 +45,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcbv::BinauthzManagementServiceV1Beta1Client"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddBinauthzManagementServiceV1Beta1Client(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbv::BinauthzManagementServiceV1Beta1ClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbv::BinauthzManagementServiceV1Beta1ClientBuilder builder = new gcbv::BinauthzManagementServiceV1Beta1ClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcbv::SystemPolicyV1Beta1Client"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -59,6 +77,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcbv::SystemPolicyV1Beta1ClientBuilder builder = new gcbv::SystemPolicyV1Beta1ClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcbv::SystemPolicyV1Beta1Client"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSystemPolicyV1Beta1Client(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcbv::SystemPolicyV1Beta1ClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcbv::SystemPolicyV1Beta1ClientBuilder builder = new gcbv::SystemPolicyV1Beta1ClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/ServiceCollectionExtensions.g.cs
@@ -46,5 +46,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::CertificateManagerClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCertificateManagerClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::CertificateManagerClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::CertificateManagerClientBuilder builder = new gccv::CertificateManagerClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/ServiceCollectionExtensions.g.cs
@@ -48,6 +48,25 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gccv::CloudChannelReportsServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        [sys::ObsoleteAttribute]
+        public static IServiceCollection AddCloudChannelReportsServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::CloudChannelReportsServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::CloudChannelReportsServiceClientBuilder builder = new gccv::CloudChannelReportsServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gccv::CloudChannelServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -62,6 +81,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::CloudChannelServiceClientBuilder builder = new gccv::CloudChannelServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::CloudChannelServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCloudChannelServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::CloudChannelServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::CloudChannelServiceClientBuilder builder = new gccv::CloudChannelServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gccv::CloudBuildClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCloudBuildClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::CloudBuildClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::CloudBuildClientBuilder builder = new gccv::CloudBuildClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2/ServiceCollectionExtensions.g.cs
@@ -47,5 +47,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::RepositoryManagerClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRepositoryManagerClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RepositoryManagerClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RepositoryManagerClientBuilder builder = new gccv::RepositoryManagerClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/ServiceCollectionExtensions.g.cs
@@ -45,6 +45,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gccv::CloudControlsPartnerCoreClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCloudControlsPartnerCoreClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::CloudControlsPartnerCoreClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::CloudControlsPartnerCoreClientBuilder builder = new gccv::CloudControlsPartnerCoreClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gccv::CloudControlsPartnerMonitoringClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -59,6 +77,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::CloudControlsPartnerMonitoringClientBuilder builder = new gccv::CloudControlsPartnerMonitoringClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::CloudControlsPartnerMonitoringClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCloudControlsPartnerMonitoringClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::CloudControlsPartnerMonitoringClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::CloudControlsPartnerMonitoringClientBuilder builder = new gccv::CloudControlsPartnerMonitoringClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/ServiceCollectionExtensions.g.cs
@@ -45,6 +45,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gccv::CloudControlsPartnerCoreClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCloudControlsPartnerCoreClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::CloudControlsPartnerCoreClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::CloudControlsPartnerCoreClientBuilder builder = new gccv::CloudControlsPartnerCoreClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gccv::CloudControlsPartnerMonitoringClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -59,6 +77,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::CloudControlsPartnerMonitoringClientBuilder builder = new gccv::CloudControlsPartnerMonitoringClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::CloudControlsPartnerMonitoringClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCloudControlsPartnerMonitoringClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::CloudControlsPartnerMonitoringClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::CloudControlsPartnerMonitoringClientBuilder builder = new gccv::CloudControlsPartnerMonitoringClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1/ServiceCollectionExtensions.g.cs
@@ -47,5 +47,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::DataMigrationServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDataMigrationServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::DataMigrationServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::DataMigrationServiceClientBuilder builder = new gccv::DataMigrationServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gccv::CloudQuotasClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCloudQuotasClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::CloudQuotasClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::CloudQuotasClientBuilder builder = new gccv::CloudQuotasClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcccpv::ConsumerProcurementServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddConsumerProcurementServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcccpv::ConsumerProcurementServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcccpv::ConsumerProcurementServiceClientBuilder builder = new gcccpv::ConsumerProcurementServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ServiceCollectionExtensions.g.cs
@@ -45,6 +45,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::AcceleratorTypesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAcceleratorTypesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::AcceleratorTypesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::AcceleratorTypesClientBuilder builder = new gccv::AcceleratorTypesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::AddressesClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -58,6 +76,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::AddressesClientBuilder builder = new gccv::AddressesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gccv::AddressesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAddressesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::AddressesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::AddressesClientBuilder builder = new gccv::AddressesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -77,6 +111,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gccv::AutoscalersClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAutoscalersClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::AutoscalersClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::AutoscalersClientBuilder builder = new gccv::AutoscalersClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::BackendBucketsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -90,6 +140,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::BackendBucketsClientBuilder builder = new gccv::BackendBucketsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gccv::BackendBucketsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddBackendBucketsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::BackendBucketsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::BackendBucketsClientBuilder builder = new gccv::BackendBucketsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -111,6 +177,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::BackendServicesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddBackendServicesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::BackendServicesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::BackendServicesClientBuilder builder = new gccv::BackendServicesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::DiskTypesClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -127,6 +211,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gccv::DiskTypesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDiskTypesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::DiskTypesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::DiskTypesClientBuilder builder = new gccv::DiskTypesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::DisksClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -140,6 +240,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::DisksClientBuilder builder = new gccv::DisksClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gccv::DisksClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDisksClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::DisksClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::DisksClientBuilder builder = new gccv::DisksClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -162,6 +278,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gccv::ExternalVpnGatewaysClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddExternalVpnGatewaysClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::ExternalVpnGatewaysClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::ExternalVpnGatewaysClientBuilder builder = new gccv::ExternalVpnGatewaysClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gccv::FirewallPoliciesClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -179,6 +313,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::FirewallPoliciesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddFirewallPoliciesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::FirewallPoliciesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::FirewallPoliciesClientBuilder builder = new gccv::FirewallPoliciesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::FirewallsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -192,6 +344,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::FirewallsClientBuilder builder = new gccv::FirewallsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gccv::FirewallsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddFirewallsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::FirewallsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::FirewallsClientBuilder builder = new gccv::FirewallsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -214,6 +382,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gccv::ForwardingRulesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddForwardingRulesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::ForwardingRulesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::ForwardingRulesClientBuilder builder = new gccv::ForwardingRulesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gccv::GlobalAddressesClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -228,6 +414,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::GlobalAddressesClientBuilder builder = new gccv::GlobalAddressesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::GlobalAddressesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddGlobalAddressesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::GlobalAddressesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::GlobalAddressesClientBuilder builder = new gccv::GlobalAddressesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -250,6 +454,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gccv::GlobalForwardingRulesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddGlobalForwardingRulesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::GlobalForwardingRulesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::GlobalForwardingRulesClientBuilder builder = new gccv::GlobalForwardingRulesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gccv::GlobalNetworkEndpointGroupsClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -264,6 +486,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::GlobalNetworkEndpointGroupsClientBuilder builder = new gccv::GlobalNetworkEndpointGroupsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::GlobalNetworkEndpointGroupsClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddGlobalNetworkEndpointGroupsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::GlobalNetworkEndpointGroupsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::GlobalNetworkEndpointGroupsClientBuilder builder = new gccv::GlobalNetworkEndpointGroupsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -286,6 +526,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gccv::GlobalOperationsClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddGlobalOperationsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::GlobalOperationsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::GlobalOperationsClientBuilder builder = new gccv::GlobalOperationsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gccv::GlobalOrganizationOperationsClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -300,6 +558,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::GlobalOrganizationOperationsClientBuilder builder = new gccv::GlobalOrganizationOperationsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::GlobalOrganizationOperationsClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddGlobalOrganizationOperationsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::GlobalOrganizationOperationsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::GlobalOrganizationOperationsClientBuilder builder = new gccv::GlobalOrganizationOperationsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -321,6 +597,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::GlobalPublicDelegatedPrefixesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddGlobalPublicDelegatedPrefixesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::GlobalPublicDelegatedPrefixesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::GlobalPublicDelegatedPrefixesClientBuilder builder = new gccv::GlobalPublicDelegatedPrefixesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::HealthChecksClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -334,6 +628,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::HealthChecksClientBuilder builder = new gccv::HealthChecksClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gccv::HealthChecksClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddHealthChecksClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::HealthChecksClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::HealthChecksClientBuilder builder = new gccv::HealthChecksClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -355,6 +665,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::ImageFamilyViewsClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddImageFamilyViewsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::ImageFamilyViewsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::ImageFamilyViewsClientBuilder builder = new gccv::ImageFamilyViewsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::ImagesClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -368,6 +696,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::ImagesClientBuilder builder = new gccv::ImagesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gccv::ImagesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddImagesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::ImagesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::ImagesClientBuilder builder = new gccv::ImagesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -389,6 +733,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::InstanceGroupManagersClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddInstanceGroupManagersClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::InstanceGroupManagersClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::InstanceGroupManagersClientBuilder builder = new gccv::InstanceGroupManagersClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::InstanceGroupsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -402,6 +764,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::InstanceGroupsClientBuilder builder = new gccv::InstanceGroupsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gccv::InstanceGroupsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddInstanceGroupsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::InstanceGroupsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::InstanceGroupsClientBuilder builder = new gccv::InstanceGroupsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -423,6 +801,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::InstanceTemplatesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddInstanceTemplatesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::InstanceTemplatesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::InstanceTemplatesClientBuilder builder = new gccv::InstanceTemplatesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::InstancesClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -436,6 +832,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::InstancesClientBuilder builder = new gccv::InstancesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gccv::InstancesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddInstancesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::InstancesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::InstancesClientBuilder builder = new gccv::InstancesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -458,6 +870,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gccv::InstantSnapshotsClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddInstantSnapshotsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::InstantSnapshotsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::InstantSnapshotsClientBuilder builder = new gccv::InstantSnapshotsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gccv::InterconnectAttachmentsClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -472,6 +902,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::InterconnectAttachmentsClientBuilder builder = new gccv::InterconnectAttachmentsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::InterconnectAttachmentsClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddInterconnectAttachmentsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::InterconnectAttachmentsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::InterconnectAttachmentsClientBuilder builder = new gccv::InterconnectAttachmentsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -494,6 +942,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gccv::InterconnectLocationsClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddInterconnectLocationsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::InterconnectLocationsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::InterconnectLocationsClientBuilder builder = new gccv::InterconnectLocationsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gccv::InterconnectRemoteLocationsClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -508,6 +974,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::InterconnectRemoteLocationsClientBuilder builder = new gccv::InterconnectRemoteLocationsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::InterconnectRemoteLocationsClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddInterconnectRemoteLocationsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::InterconnectRemoteLocationsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::InterconnectRemoteLocationsClientBuilder builder = new gccv::InterconnectRemoteLocationsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -527,6 +1011,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gccv::InterconnectsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddInterconnectsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::InterconnectsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::InterconnectsClientBuilder builder = new gccv::InterconnectsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::LicenseCodesClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -540,6 +1040,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::LicenseCodesClientBuilder builder = new gccv::LicenseCodesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gccv::LicenseCodesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddLicenseCodesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::LicenseCodesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::LicenseCodesClientBuilder builder = new gccv::LicenseCodesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -559,6 +1075,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gccv::LicensesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddLicensesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::LicensesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::LicensesClientBuilder builder = new gccv::LicensesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::MachineImagesClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -575,6 +1107,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gccv::MachineImagesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddMachineImagesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::MachineImagesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::MachineImagesClientBuilder builder = new gccv::MachineImagesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::MachineTypesClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -588,6 +1136,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::MachineTypesClientBuilder builder = new gccv::MachineTypesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gccv::MachineTypesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddMachineTypesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::MachineTypesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::MachineTypesClientBuilder builder = new gccv::MachineTypesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -610,6 +1174,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gccv::NetworkAttachmentsClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddNetworkAttachmentsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::NetworkAttachmentsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::NetworkAttachmentsClientBuilder builder = new gccv::NetworkAttachmentsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gccv::NetworkEdgeSecurityServicesClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -624,6 +1206,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::NetworkEdgeSecurityServicesClientBuilder builder = new gccv::NetworkEdgeSecurityServicesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::NetworkEdgeSecurityServicesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddNetworkEdgeSecurityServicesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::NetworkEdgeSecurityServicesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::NetworkEdgeSecurityServicesClientBuilder builder = new gccv::NetworkEdgeSecurityServicesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -646,6 +1246,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gccv::NetworkEndpointGroupsClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddNetworkEndpointGroupsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::NetworkEndpointGroupsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::NetworkEndpointGroupsClientBuilder builder = new gccv::NetworkEndpointGroupsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gccv::NetworkFirewallPoliciesClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -660,6 +1278,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::NetworkFirewallPoliciesClientBuilder builder = new gccv::NetworkFirewallPoliciesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::NetworkFirewallPoliciesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddNetworkFirewallPoliciesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::NetworkFirewallPoliciesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::NetworkFirewallPoliciesClientBuilder builder = new gccv::NetworkFirewallPoliciesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -679,6 +1315,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gccv::NetworksClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddNetworksClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::NetworksClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::NetworksClientBuilder builder = new gccv::NetworksClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::NodeGroupsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -692,6 +1344,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::NodeGroupsClientBuilder builder = new gccv::NodeGroupsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gccv::NodeGroupsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddNodeGroupsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::NodeGroupsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::NodeGroupsClientBuilder builder = new gccv::NodeGroupsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -711,6 +1379,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gccv::NodeTemplatesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddNodeTemplatesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::NodeTemplatesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::NodeTemplatesClientBuilder builder = new gccv::NodeTemplatesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::NodeTypesClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -724,6 +1408,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::NodeTypesClientBuilder builder = new gccv::NodeTypesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gccv::NodeTypesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddNodeTypesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::NodeTypesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::NodeTypesClientBuilder builder = new gccv::NodeTypesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -745,6 +1445,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::PacketMirroringsClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddPacketMirroringsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::PacketMirroringsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::PacketMirroringsClientBuilder builder = new gccv::PacketMirroringsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::ProjectsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -758,6 +1476,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::ProjectsClientBuilder builder = new gccv::ProjectsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gccv::ProjectsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddProjectsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::ProjectsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::ProjectsClientBuilder builder = new gccv::ProjectsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -780,6 +1514,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gccv::PublicAdvertisedPrefixesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddPublicAdvertisedPrefixesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::PublicAdvertisedPrefixesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::PublicAdvertisedPrefixesClientBuilder builder = new gccv::PublicAdvertisedPrefixesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gccv::PublicDelegatedPrefixesClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -794,6 +1546,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::PublicDelegatedPrefixesClientBuilder builder = new gccv::PublicDelegatedPrefixesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::PublicDelegatedPrefixesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddPublicDelegatedPrefixesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::PublicDelegatedPrefixesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::PublicDelegatedPrefixesClientBuilder builder = new gccv::PublicDelegatedPrefixesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -816,6 +1586,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gccv::RegionAutoscalersClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegionAutoscalersClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RegionAutoscalersClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RegionAutoscalersClientBuilder builder = new gccv::RegionAutoscalersClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gccv::RegionBackendServicesClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -830,6 +1618,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::RegionBackendServicesClientBuilder builder = new gccv::RegionBackendServicesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::RegionBackendServicesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegionBackendServicesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RegionBackendServicesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RegionBackendServicesClientBuilder builder = new gccv::RegionBackendServicesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -852,6 +1658,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gccv::RegionCommitmentsClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegionCommitmentsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RegionCommitmentsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RegionCommitmentsClientBuilder builder = new gccv::RegionCommitmentsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gccv::RegionDiskTypesClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -869,6 +1693,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::RegionDiskTypesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegionDiskTypesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RegionDiskTypesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RegionDiskTypesClientBuilder builder = new gccv::RegionDiskTypesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::RegionDisksClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -882,6 +1724,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::RegionDisksClientBuilder builder = new gccv::RegionDisksClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gccv::RegionDisksClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegionDisksClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RegionDisksClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RegionDisksClientBuilder builder = new gccv::RegionDisksClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -904,6 +1762,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gccv::RegionHealthCheckServicesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegionHealthCheckServicesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RegionHealthCheckServicesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RegionHealthCheckServicesClientBuilder builder = new gccv::RegionHealthCheckServicesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gccv::RegionHealthChecksClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -918,6 +1794,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::RegionHealthChecksClientBuilder builder = new gccv::RegionHealthChecksClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::RegionHealthChecksClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegionHealthChecksClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RegionHealthChecksClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RegionHealthChecksClientBuilder builder = new gccv::RegionHealthChecksClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -940,6 +1834,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gccv::RegionInstanceGroupManagersClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegionInstanceGroupManagersClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RegionInstanceGroupManagersClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RegionInstanceGroupManagersClientBuilder builder = new gccv::RegionInstanceGroupManagersClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gccv::RegionInstanceGroupsClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -954,6 +1866,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::RegionInstanceGroupsClientBuilder builder = new gccv::RegionInstanceGroupsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::RegionInstanceGroupsClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegionInstanceGroupsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RegionInstanceGroupsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RegionInstanceGroupsClientBuilder builder = new gccv::RegionInstanceGroupsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -976,6 +1906,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gccv::RegionInstanceTemplatesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegionInstanceTemplatesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RegionInstanceTemplatesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RegionInstanceTemplatesClientBuilder builder = new gccv::RegionInstanceTemplatesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gccv::RegionInstancesClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -990,6 +1938,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::RegionInstancesClientBuilder builder = new gccv::RegionInstancesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::RegionInstancesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegionInstancesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RegionInstancesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RegionInstancesClientBuilder builder = new gccv::RegionInstancesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -1012,6 +1978,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gccv::RegionInstantSnapshotsClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegionInstantSnapshotsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RegionInstantSnapshotsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RegionInstantSnapshotsClientBuilder builder = new gccv::RegionInstantSnapshotsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gccv::RegionNetworkEndpointGroupsClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -1026,6 +2010,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::RegionNetworkEndpointGroupsClientBuilder builder = new gccv::RegionNetworkEndpointGroupsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::RegionNetworkEndpointGroupsClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegionNetworkEndpointGroupsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RegionNetworkEndpointGroupsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RegionNetworkEndpointGroupsClientBuilder builder = new gccv::RegionNetworkEndpointGroupsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -1048,6 +2050,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gccv::RegionNetworkFirewallPoliciesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegionNetworkFirewallPoliciesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RegionNetworkFirewallPoliciesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RegionNetworkFirewallPoliciesClientBuilder builder = new gccv::RegionNetworkFirewallPoliciesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gccv::RegionNotificationEndpointsClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -1062,6 +2082,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::RegionNotificationEndpointsClientBuilder builder = new gccv::RegionNotificationEndpointsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::RegionNotificationEndpointsClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegionNotificationEndpointsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RegionNotificationEndpointsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RegionNotificationEndpointsClientBuilder builder = new gccv::RegionNotificationEndpointsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -1084,6 +2122,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gccv::RegionOperationsClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegionOperationsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RegionOperationsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RegionOperationsClientBuilder builder = new gccv::RegionOperationsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gccv::RegionSecurityPoliciesClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -1098,6 +2154,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::RegionSecurityPoliciesClientBuilder builder = new gccv::RegionSecurityPoliciesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::RegionSecurityPoliciesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegionSecurityPoliciesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RegionSecurityPoliciesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RegionSecurityPoliciesClientBuilder builder = new gccv::RegionSecurityPoliciesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -1120,6 +2194,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gccv::RegionSslCertificatesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegionSslCertificatesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RegionSslCertificatesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RegionSslCertificatesClientBuilder builder = new gccv::RegionSslCertificatesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gccv::RegionSslPoliciesClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -1134,6 +2226,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::RegionSslPoliciesClientBuilder builder = new gccv::RegionSslPoliciesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::RegionSslPoliciesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegionSslPoliciesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RegionSslPoliciesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RegionSslPoliciesClientBuilder builder = new gccv::RegionSslPoliciesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -1156,6 +2266,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gccv::RegionTargetHttpProxiesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegionTargetHttpProxiesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RegionTargetHttpProxiesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RegionTargetHttpProxiesClientBuilder builder = new gccv::RegionTargetHttpProxiesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gccv::RegionTargetHttpsProxiesClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -1170,6 +2298,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::RegionTargetHttpsProxiesClientBuilder builder = new gccv::RegionTargetHttpsProxiesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::RegionTargetHttpsProxiesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegionTargetHttpsProxiesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RegionTargetHttpsProxiesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RegionTargetHttpsProxiesClientBuilder builder = new gccv::RegionTargetHttpsProxiesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -1191,6 +2337,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::RegionTargetTcpProxiesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegionTargetTcpProxiesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RegionTargetTcpProxiesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RegionTargetTcpProxiesClientBuilder builder = new gccv::RegionTargetTcpProxiesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::RegionUrlMapsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -1204,6 +2368,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::RegionUrlMapsClientBuilder builder = new gccv::RegionUrlMapsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gccv::RegionUrlMapsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegionUrlMapsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RegionUrlMapsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RegionUrlMapsClientBuilder builder = new gccv::RegionUrlMapsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -1223,6 +2403,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gccv::RegionZonesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegionZonesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RegionZonesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RegionZonesClientBuilder builder = new gccv::RegionZonesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::RegionsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -1239,6 +2435,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gccv::RegionsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegionsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RegionsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RegionsClientBuilder builder = new gccv::RegionsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::ReservationsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -1252,6 +2464,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::ReservationsClientBuilder builder = new gccv::ReservationsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gccv::ReservationsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddReservationsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::ReservationsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::ReservationsClientBuilder builder = new gccv::ReservationsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -1273,6 +2501,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::ResourcePoliciesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddResourcePoliciesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::ResourcePoliciesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::ResourcePoliciesClientBuilder builder = new gccv::ResourcePoliciesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::RoutersClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -1289,6 +2535,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gccv::RoutersClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRoutersClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RoutersClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RoutersClientBuilder builder = new gccv::RoutersClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::RoutesClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -1302,6 +2564,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::RoutesClientBuilder builder = new gccv::RoutesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gccv::RoutesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRoutesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::RoutesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::RoutesClientBuilder builder = new gccv::RoutesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -1324,6 +2602,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gccv::SecurityPoliciesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSecurityPoliciesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::SecurityPoliciesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::SecurityPoliciesClientBuilder builder = new gccv::SecurityPoliciesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gccv::ServiceAttachmentsClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -1338,6 +2634,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::ServiceAttachmentsClientBuilder builder = new gccv::ServiceAttachmentsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::ServiceAttachmentsClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddServiceAttachmentsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::ServiceAttachmentsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::ServiceAttachmentsClientBuilder builder = new gccv::ServiceAttachmentsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -1359,6 +2673,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::SnapshotSettingsServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSnapshotSettingsServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::SnapshotSettingsServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::SnapshotSettingsServiceClientBuilder builder = new gccv::SnapshotSettingsServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::SnapshotsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -1372,6 +2704,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::SnapshotsClientBuilder builder = new gccv::SnapshotsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gccv::SnapshotsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSnapshotsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::SnapshotsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::SnapshotsClientBuilder builder = new gccv::SnapshotsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -1393,6 +2741,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::SslCertificatesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSslCertificatesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::SslCertificatesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::SslCertificatesClientBuilder builder = new gccv::SslCertificatesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::SslPoliciesClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -1409,6 +2775,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gccv::SslPoliciesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSslPoliciesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::SslPoliciesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::SslPoliciesClientBuilder builder = new gccv::SslPoliciesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::SubnetworksClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -1422,6 +2804,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::SubnetworksClientBuilder builder = new gccv::SubnetworksClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gccv::SubnetworksClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSubnetworksClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::SubnetworksClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::SubnetworksClientBuilder builder = new gccv::SubnetworksClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -1444,6 +2842,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gccv::TargetGrpcProxiesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTargetGrpcProxiesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::TargetGrpcProxiesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::TargetGrpcProxiesClientBuilder builder = new gccv::TargetGrpcProxiesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gccv::TargetHttpProxiesClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -1458,6 +2874,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::TargetHttpProxiesClientBuilder builder = new gccv::TargetHttpProxiesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::TargetHttpProxiesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTargetHttpProxiesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::TargetHttpProxiesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::TargetHttpProxiesClientBuilder builder = new gccv::TargetHttpProxiesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -1480,6 +2914,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gccv::TargetHttpsProxiesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTargetHttpsProxiesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::TargetHttpsProxiesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::TargetHttpsProxiesClientBuilder builder = new gccv::TargetHttpsProxiesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gccv::TargetInstancesClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -1497,6 +2949,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::TargetInstancesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTargetInstancesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::TargetInstancesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::TargetInstancesClientBuilder builder = new gccv::TargetInstancesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::TargetPoolsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -1510,6 +2980,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::TargetPoolsClientBuilder builder = new gccv::TargetPoolsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gccv::TargetPoolsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTargetPoolsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::TargetPoolsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::TargetPoolsClientBuilder builder = new gccv::TargetPoolsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -1532,6 +3018,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gccv::TargetSslProxiesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTargetSslProxiesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::TargetSslProxiesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::TargetSslProxiesClientBuilder builder = new gccv::TargetSslProxiesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gccv::TargetTcpProxiesClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -1546,6 +3050,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::TargetTcpProxiesClientBuilder builder = new gccv::TargetTcpProxiesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::TargetTcpProxiesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTargetTcpProxiesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::TargetTcpProxiesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::TargetTcpProxiesClientBuilder builder = new gccv::TargetTcpProxiesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -1567,6 +3089,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::TargetVpnGatewaysClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTargetVpnGatewaysClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::TargetVpnGatewaysClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::TargetVpnGatewaysClientBuilder builder = new gccv::TargetVpnGatewaysClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::UrlMapsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -1580,6 +3120,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::UrlMapsClientBuilder builder = new gccv::UrlMapsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gccv::UrlMapsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddUrlMapsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::UrlMapsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::UrlMapsClientBuilder builder = new gccv::UrlMapsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -1599,6 +3155,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gccv::VpnGatewaysClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddVpnGatewaysClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::VpnGatewaysClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::VpnGatewaysClientBuilder builder = new gccv::VpnGatewaysClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::VpnTunnelsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -1612,6 +3184,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::VpnTunnelsClientBuilder builder = new gccv::VpnTunnelsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gccv::VpnTunnelsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddVpnTunnelsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::VpnTunnelsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::VpnTunnelsClientBuilder builder = new gccv::VpnTunnelsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -1631,6 +3219,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gccv::ZoneOperationsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddZoneOperationsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::ZoneOperationsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::ZoneOperationsClientBuilder builder = new gccv::ZoneOperationsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gccv::ZonesClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -1644,6 +3248,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gccv::ZonesClientBuilder builder = new gccv::ZonesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gccv::ZonesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddZonesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::ZonesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::ZonesClientBuilder builder = new gccv::ZonesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::ConfidentialComputingClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddConfidentialComputingClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::ConfidentialComputingClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::ConfidentialComputingClientBuilder builder = new gccv::ConfidentialComputingClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::ConfidentialComputingClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddConfidentialComputingClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::ConfidentialComputingClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::ConfidentialComputingClientBuilder builder = new gccv::ConfidentialComputingClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gccv::ConfigClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddConfigClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::ConfigClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::ConfigClientBuilder builder = new gccv::ConfigClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gccv::ConnectorsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddConnectorsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::ConnectorsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::ConnectorsClientBuilder builder = new gccv::ConnectorsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gccv::ContactCenterInsightsClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddContactCenterInsightsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::ContactCenterInsightsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::ContactCenterInsightsClientBuilder builder = new gccv::ContactCenterInsightsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gccv::ClusterManagerClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddClusterManagerClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gccv::ClusterManagerClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gccv::ClusterManagerClientBuilder builder = new gccv::ClusterManagerClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcdlv::LineageClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddLineageClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdlv::LineageClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdlv::LineageClientBuilder builder = new gcdlv::LineageClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/ServiceCollectionExtensions.g.cs
@@ -45,6 +45,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcdv::DataCatalogClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDataCatalogClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::DataCatalogClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::DataCatalogClientBuilder builder = new gcdv::DataCatalogClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>
         /// Adds a singleton <see cref="gcdv::PolicyTagManagerClient"/> to <paramref name="services"/>.
         /// </summary>
@@ -64,6 +80,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcdv::PolicyTagManagerClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddPolicyTagManagerClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::PolicyTagManagerClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::PolicyTagManagerClientBuilder builder = new gcdv::PolicyTagManagerClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcdv::PolicyTagManagerSerializationClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -78,6 +112,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::PolicyTagManagerSerializationClientBuilder builder = new gcdv::PolicyTagManagerSerializationClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::PolicyTagManagerSerializationClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddPolicyTagManagerSerializationClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::PolicyTagManagerSerializationClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::PolicyTagManagerSerializationClientBuilder builder = new gcdv::PolicyTagManagerSerializationClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcdv::DataFusionClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDataFusionClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::DataFusionClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::DataFusionClientBuilder builder = new gcdv::DataFusionClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.DataLabeling.V1Beta1/Google.Cloud.DataLabeling.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.DataLabeling.V1Beta1/Google.Cloud.DataLabeling.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::DataLabelingServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDataLabelingServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::DataLabelingServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::DataLabelingServiceClientBuilder builder = new gcdv::DataLabelingServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/ServiceCollectionExtensions.g.cs
@@ -44,6 +44,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::FlexTemplatesServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddFlexTemplatesServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::FlexTemplatesServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::FlexTemplatesServiceClientBuilder builder = new gcdv::FlexTemplatesServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::JobsV1Beta3Client"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -57,6 +75,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::JobsV1Beta3ClientBuilder builder = new gcdv::JobsV1Beta3ClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdv::JobsV1Beta3Client"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddJobsV1Beta3Client(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::JobsV1Beta3ClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::JobsV1Beta3ClientBuilder builder = new gcdv::JobsV1Beta3ClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -78,6 +112,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::MessagesV1Beta3Client"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddMessagesV1Beta3Client(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::MessagesV1Beta3ClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::MessagesV1Beta3ClientBuilder builder = new gcdv::MessagesV1Beta3ClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::MetricsV1Beta3Client"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -91,6 +143,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::MetricsV1Beta3ClientBuilder builder = new gcdv::MetricsV1Beta3ClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdv::MetricsV1Beta3Client"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddMetricsV1Beta3Client(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::MetricsV1Beta3ClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::MetricsV1Beta3ClientBuilder builder = new gcdv::MetricsV1Beta3ClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -113,6 +181,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcdv::SnapshotsV1Beta3Client"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSnapshotsV1Beta3Client(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::SnapshotsV1Beta3ClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::SnapshotsV1Beta3ClientBuilder builder = new gcdv::SnapshotsV1Beta3ClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcdv::TemplatesServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -127,6 +213,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::TemplatesServiceClientBuilder builder = new gcdv::TemplatesServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::TemplatesServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTemplatesServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::TemplatesServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::TemplatesServiceClientBuilder builder = new gcdv::TemplatesServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -44,5 +44,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcdv::DataformClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDataformClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::DataformClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::DataformClientBuilder builder = new gcdv::DataformClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/ServiceCollectionExtensions.g.cs
@@ -46,6 +46,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcdv::CatalogServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCatalogServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::CatalogServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::CatalogServiceClientBuilder builder = new gcdv::CatalogServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::ContentServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -59,6 +75,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::ContentServiceClientBuilder builder = new gcdv::ContentServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdv::ContentServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddContentServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::ContentServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::ContentServiceClientBuilder builder = new gcdv::ContentServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -81,6 +113,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcdv::DataScanServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDataScanServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::DataScanServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::DataScanServiceClientBuilder builder = new gcdv::DataScanServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcdv::DataTaxonomyServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -95,6 +145,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::DataTaxonomyServiceClientBuilder builder = new gcdv::DataTaxonomyServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::DataTaxonomyServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDataTaxonomyServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::DataTaxonomyServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::DataTaxonomyServiceClientBuilder builder = new gcdv::DataTaxonomyServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -117,6 +185,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcdv::DataplexServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDataplexServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::DataplexServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::DataplexServiceClientBuilder builder = new gcdv::DataplexServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcdv::MetadataServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -131,6 +217,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::MetadataServiceClientBuilder builder = new gcdv::MetadataServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::MetadataServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddMetadataServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::MetadataServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::MetadataServiceClientBuilder builder = new gcdv::MetadataServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/ServiceCollectionExtensions.g.cs
@@ -48,6 +48,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcdv::AutoscalingPolicyServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAutoscalingPolicyServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::AutoscalingPolicyServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::AutoscalingPolicyServiceClientBuilder builder = new gcdv::AutoscalingPolicyServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcdv::BatchControllerClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -62,6 +80,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::BatchControllerClientBuilder builder = new gcdv::BatchControllerClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::BatchControllerClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddBatchControllerClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::BatchControllerClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::BatchControllerClientBuilder builder = new gcdv::BatchControllerClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -83,6 +119,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::ClusterControllerClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddClusterControllerClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::ClusterControllerClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::ClusterControllerClientBuilder builder = new gcdv::ClusterControllerClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::JobControllerClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -96,6 +150,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::JobControllerClientBuilder builder = new gcdv::JobControllerClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdv::JobControllerClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddJobControllerClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::JobControllerClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::JobControllerClientBuilder builder = new gcdv::JobControllerClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -118,6 +188,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcdv::NodeGroupControllerClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddNodeGroupControllerClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::NodeGroupControllerClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::NodeGroupControllerClientBuilder builder = new gcdv::NodeGroupControllerClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcdv::SessionControllerClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -132,6 +220,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::SessionControllerClientBuilder builder = new gcdv::SessionControllerClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::SessionControllerClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSessionControllerClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::SessionControllerClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::SessionControllerClientBuilder builder = new gcdv::SessionControllerClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -154,6 +260,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcdv::SessionTemplateControllerClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSessionTemplateControllerClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::SessionTemplateControllerClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::SessionTemplateControllerClientBuilder builder = new gcdv::SessionTemplateControllerClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcdv::WorkflowTemplateServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -168,6 +292,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::WorkflowTemplateServiceClientBuilder builder = new gcdv::WorkflowTemplateServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::WorkflowTemplateServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddWorkflowTemplateServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::WorkflowTemplateServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::WorkflowTemplateServiceClientBuilder builder = new gcdv::WorkflowTemplateServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcdav::DatastoreAdminClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDatastoreAdminClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdav::DatastoreAdminClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdav::DatastoreAdminClientBuilder builder = new gcdav::DatastoreAdminClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcdv::DatastoreClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDatastoreClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::DatastoreClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::DatastoreClientBuilder builder = new gcdv::DatastoreClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcdv::DatastreamClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDatastreamClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::DatastreamClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::DatastreamClientBuilder builder = new gcdv::DatastreamClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcdv::DatastreamClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDatastreamClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::DatastreamClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::DatastreamClientBuilder builder = new gcdv::DatastreamClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcdv::CloudDeployClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCloudDeployClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::CloudDeployClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::CloudDeployClientBuilder builder = new gcdv::CloudDeployClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcdcv::ContainerAnalysisClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddContainerAnalysisClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdcv::ContainerAnalysisClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdcv::ContainerAnalysisClientBuilder builder = new gcdcv::ContainerAnalysisClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/ServiceCollectionExtensions.g.cs
@@ -45,6 +45,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcdcv::AgentsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAgentsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdcv::AgentsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdcv::AgentsClientBuilder builder = new gcdcv::AgentsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdcv::ChangelogsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -58,6 +74,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdcv::ChangelogsClientBuilder builder = new gcdcv::ChangelogsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdcv::ChangelogsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddChangelogsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdcv::ChangelogsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdcv::ChangelogsClientBuilder builder = new gcdcv::ChangelogsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -77,6 +109,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcdcv::DeploymentsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDeploymentsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdcv::DeploymentsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdcv::DeploymentsClientBuilder builder = new gcdcv::DeploymentsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdcv::EntityTypesClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -90,6 +138,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdcv::EntityTypesClientBuilder builder = new gcdcv::EntityTypesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdcv::EntityTypesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddEntityTypesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdcv::EntityTypesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdcv::EntityTypesClientBuilder builder = new gcdcv::EntityTypesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -109,6 +173,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcdcv::EnvironmentsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddEnvironmentsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdcv::EnvironmentsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdcv::EnvironmentsClientBuilder builder = new gcdcv::EnvironmentsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdcv::ExperimentsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -122,6 +202,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdcv::ExperimentsClientBuilder builder = new gcdcv::ExperimentsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdcv::ExperimentsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddExperimentsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdcv::ExperimentsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdcv::ExperimentsClientBuilder builder = new gcdcv::ExperimentsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -141,6 +237,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcdcv::FlowsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddFlowsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdcv::FlowsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdcv::FlowsClientBuilder builder = new gcdcv::FlowsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdcv::GeneratorsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -154,6 +266,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdcv::GeneratorsClientBuilder builder = new gcdcv::GeneratorsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdcv::GeneratorsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddGeneratorsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdcv::GeneratorsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdcv::GeneratorsClientBuilder builder = new gcdcv::GeneratorsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -173,6 +301,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcdcv::IntentsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddIntentsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdcv::IntentsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdcv::IntentsClientBuilder builder = new gcdcv::IntentsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdcv::PagesClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -186,6 +330,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdcv::PagesClientBuilder builder = new gcdcv::PagesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdcv::PagesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddPagesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdcv::PagesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdcv::PagesClientBuilder builder = new gcdcv::PagesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -208,6 +368,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcdcv::SecuritySettingsServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSecuritySettingsServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdcv::SecuritySettingsServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdcv::SecuritySettingsServiceClientBuilder builder = new gcdcv::SecuritySettingsServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcdcv::SessionEntityTypesClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -222,6 +400,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdcv::SessionEntityTypesClientBuilder builder = new gcdcv::SessionEntityTypesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcdcv::SessionEntityTypesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSessionEntityTypesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdcv::SessionEntityTypesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdcv::SessionEntityTypesClientBuilder builder = new gcdcv::SessionEntityTypesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -241,6 +437,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcdcv::SessionsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSessionsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdcv::SessionsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdcv::SessionsClientBuilder builder = new gcdcv::SessionsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdcv::TestCasesClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -254,6 +466,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdcv::TestCasesClientBuilder builder = new gcdcv::TestCasesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdcv::TestCasesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTestCasesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdcv::TestCasesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdcv::TestCasesClientBuilder builder = new gcdcv::TestCasesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -275,6 +503,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcdcv::TransitionRouteGroupsClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTransitionRouteGroupsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdcv::TransitionRouteGroupsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdcv::TransitionRouteGroupsClientBuilder builder = new gcdcv::TransitionRouteGroupsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdcv::VersionsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -291,6 +537,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcdcv::VersionsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddVersionsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdcv::VersionsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdcv::VersionsClientBuilder builder = new gcdcv::VersionsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdcv::WebhooksClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -304,6 +566,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdcv::WebhooksClientBuilder builder = new gcdcv::WebhooksClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdcv::WebhooksClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddWebhooksClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdcv::WebhooksClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdcv::WebhooksClientBuilder builder = new gcdcv::WebhooksClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ServiceCollectionExtensions.g.cs
@@ -45,6 +45,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcdv::AgentsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAgentsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::AgentsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::AgentsClientBuilder builder = new gcdv::AgentsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::AnswerRecordsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -61,6 +77,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcdv::AnswerRecordsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAnswerRecordsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::AnswerRecordsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::AnswerRecordsClientBuilder builder = new gcdv::AnswerRecordsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::ContextsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -74,6 +106,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::ContextsClientBuilder builder = new gcdv::ContextsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdv::ContextsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddContextsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::ContextsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::ContextsClientBuilder builder = new gcdv::ContextsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -96,6 +144,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcdv::ConversationDatasetsClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddConversationDatasetsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::ConversationDatasetsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::ConversationDatasetsClientBuilder builder = new gcdv::ConversationDatasetsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcdv::ConversationModelsClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -110,6 +176,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::ConversationModelsClientBuilder builder = new gcdv::ConversationModelsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::ConversationModelsClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddConversationModelsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::ConversationModelsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::ConversationModelsClientBuilder builder = new gcdv::ConversationModelsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -131,6 +215,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::ConversationProfilesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddConversationProfilesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::ConversationProfilesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::ConversationProfilesClientBuilder builder = new gcdv::ConversationProfilesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::ConversationsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -144,6 +246,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::ConversationsClientBuilder builder = new gcdv::ConversationsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdv::ConversationsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddConversationsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::ConversationsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::ConversationsClientBuilder builder = new gcdv::ConversationsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -163,6 +281,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcdv::DocumentsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDocumentsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::DocumentsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::DocumentsClientBuilder builder = new gcdv::DocumentsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::EntityTypesClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -176,6 +310,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::EntityTypesClientBuilder builder = new gcdv::EntityTypesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdv::EntityTypesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddEntityTypesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::EntityTypesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::EntityTypesClientBuilder builder = new gcdv::EntityTypesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -195,6 +345,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcdv::EnvironmentsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddEnvironmentsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::EnvironmentsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::EnvironmentsClientBuilder builder = new gcdv::EnvironmentsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::FulfillmentsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -208,6 +374,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::FulfillmentsClientBuilder builder = new gcdv::FulfillmentsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdv::FulfillmentsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddFulfillmentsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::FulfillmentsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::FulfillmentsClientBuilder builder = new gcdv::FulfillmentsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -227,6 +409,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcdv::IntentsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddIntentsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::IntentsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::IntentsClientBuilder builder = new gcdv::IntentsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::KnowledgeBasesClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -243,6 +441,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcdv::KnowledgeBasesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddKnowledgeBasesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::KnowledgeBasesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::KnowledgeBasesClientBuilder builder = new gcdv::KnowledgeBasesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::ParticipantsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -256,6 +470,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::ParticipantsClientBuilder builder = new gcdv::ParticipantsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdv::ParticipantsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddParticipantsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::ParticipantsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::ParticipantsClientBuilder builder = new gcdv::ParticipantsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -277,6 +507,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::SessionEntityTypesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSessionEntityTypesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::SessionEntityTypesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::SessionEntityTypesClientBuilder builder = new gcdv::SessionEntityTypesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::SessionsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -293,6 +541,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcdv::SessionsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSessionsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::SessionsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::SessionsClientBuilder builder = new gcdv::SessionsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::VersionsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -306,6 +570,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::VersionsClientBuilder builder = new gcdv::VersionsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdv::VersionsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddVersionsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::VersionsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::VersionsClientBuilder builder = new gcdv::VersionsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/ServiceCollectionExtensions.g.cs
@@ -45,6 +45,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcdv::AgentsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAgentsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::AgentsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::AgentsClientBuilder builder = new gcdv::AgentsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::AnswerRecordsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -61,6 +77,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcdv::AnswerRecordsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAnswerRecordsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::AnswerRecordsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::AnswerRecordsClientBuilder builder = new gcdv::AnswerRecordsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::ContextsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -74,6 +106,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::ContextsClientBuilder builder = new gcdv::ContextsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdv::ContextsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddContextsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::ContextsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::ContextsClientBuilder builder = new gcdv::ContextsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -95,6 +143,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::ConversationProfilesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddConversationProfilesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::ConversationProfilesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::ConversationProfilesClientBuilder builder = new gcdv::ConversationProfilesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::ConversationsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -108,6 +174,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::ConversationsClientBuilder builder = new gcdv::ConversationsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdv::ConversationsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddConversationsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::ConversationsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::ConversationsClientBuilder builder = new gcdv::ConversationsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -127,6 +209,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcdv::DocumentsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDocumentsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::DocumentsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::DocumentsClientBuilder builder = new gcdv::DocumentsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::EntityTypesClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -140,6 +238,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::EntityTypesClientBuilder builder = new gcdv::EntityTypesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdv::EntityTypesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddEntityTypesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::EntityTypesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::EntityTypesClientBuilder builder = new gcdv::EntityTypesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -159,6 +273,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcdv::EnvironmentsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddEnvironmentsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::EnvironmentsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::EnvironmentsClientBuilder builder = new gcdv::EnvironmentsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::FulfillmentsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -172,6 +302,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::FulfillmentsClientBuilder builder = new gcdv::FulfillmentsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdv::FulfillmentsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddFulfillmentsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::FulfillmentsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::FulfillmentsClientBuilder builder = new gcdv::FulfillmentsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -191,6 +337,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcdv::IntentsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddIntentsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::IntentsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::IntentsClientBuilder builder = new gcdv::IntentsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::KnowledgeBasesClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -207,6 +369,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcdv::KnowledgeBasesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddKnowledgeBasesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::KnowledgeBasesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::KnowledgeBasesClientBuilder builder = new gcdv::KnowledgeBasesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::ParticipantsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -220,6 +398,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::ParticipantsClientBuilder builder = new gcdv::ParticipantsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdv::ParticipantsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddParticipantsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::ParticipantsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::ParticipantsClientBuilder builder = new gcdv::ParticipantsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -241,6 +435,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::SessionEntityTypesClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSessionEntityTypesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::SessionEntityTypesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::SessionEntityTypesClientBuilder builder = new gcdv::SessionEntityTypesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::SessionsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -257,6 +469,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcdv::SessionsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSessionsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::SessionsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::SessionsClientBuilder builder = new gcdv::SessionsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::VersionsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -270,6 +498,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::VersionsClientBuilder builder = new gcdv::VersionsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdv::VersionsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddVersionsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::VersionsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::VersionsClientBuilder builder = new gcdv::VersionsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ServiceCollectionExtensions.g.cs
@@ -48,6 +48,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcdv::CompletionServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCompletionServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::CompletionServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::CompletionServiceClientBuilder builder = new gcdv::CompletionServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcdv::ConversationalSearchServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -62,6 +80,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::ConversationalSearchServiceClientBuilder builder = new gcdv::ConversationalSearchServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::ConversationalSearchServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddConversationalSearchServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::ConversationalSearchServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::ConversationalSearchServiceClientBuilder builder = new gcdv::ConversationalSearchServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -84,6 +120,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcdv::DataStoreServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDataStoreServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::DataStoreServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::DataStoreServiceClientBuilder builder = new gcdv::DataStoreServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcdv::DocumentServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -101,6 +155,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::DocumentServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDocumentServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::DocumentServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::DocumentServiceClientBuilder builder = new gcdv::DocumentServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::EngineServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -114,6 +186,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::EngineServiceClientBuilder builder = new gcdv::EngineServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdv::EngineServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddEngineServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::EngineServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::EngineServiceClientBuilder builder = new gcdv::EngineServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -135,6 +223,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::RecommendationServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRecommendationServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::RecommendationServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::RecommendationServiceClientBuilder builder = new gcdv::RecommendationServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::SchemaServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -151,6 +257,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcdv::SchemaServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSchemaServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::SchemaServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::SchemaServiceClientBuilder builder = new gcdv::SchemaServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::SearchServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -164,6 +286,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::SearchServiceClientBuilder builder = new gcdv::SearchServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdv::SearchServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSearchServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::SearchServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::SearchServiceClientBuilder builder = new gcdv::SearchServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -186,6 +324,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcdv::SiteSearchEngineServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSiteSearchEngineServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::SiteSearchEngineServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::SiteSearchEngineServiceClientBuilder builder = new gcdv::SiteSearchEngineServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcdv::UserEventServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -200,6 +356,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::UserEventServiceClientBuilder builder = new gcdv::UserEventServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::UserEventServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddUserEventServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::UserEventServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::UserEventServiceClientBuilder builder = new gcdv::UserEventServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ServiceCollectionExtensions.g.cs
@@ -48,6 +48,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcdv::CompletionServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCompletionServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::CompletionServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::CompletionServiceClientBuilder builder = new gcdv::CompletionServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcdv::ConversationalSearchServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -62,6 +80,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::ConversationalSearchServiceClientBuilder builder = new gcdv::ConversationalSearchServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::ConversationalSearchServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddConversationalSearchServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::ConversationalSearchServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::ConversationalSearchServiceClientBuilder builder = new gcdv::ConversationalSearchServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -84,6 +120,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcdv::DataStoreServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDataStoreServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::DataStoreServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::DataStoreServiceClientBuilder builder = new gcdv::DataStoreServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcdv::DocumentServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -101,6 +155,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::DocumentServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDocumentServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::DocumentServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::DocumentServiceClientBuilder builder = new gcdv::DocumentServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::EngineServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -114,6 +186,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::EngineServiceClientBuilder builder = new gcdv::EngineServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdv::EngineServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddEngineServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::EngineServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::EngineServiceClientBuilder builder = new gcdv::EngineServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -135,6 +223,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::GroundedGenerationServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddGroundedGenerationServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::GroundedGenerationServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::GroundedGenerationServiceClientBuilder builder = new gcdv::GroundedGenerationServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::RankServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -148,6 +254,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::RankServiceClientBuilder builder = new gcdv::RankServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdv::RankServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRankServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::RankServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::RankServiceClientBuilder builder = new gcdv::RankServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -169,6 +291,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::RecommendationServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRecommendationServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::RecommendationServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::RecommendationServiceClientBuilder builder = new gcdv::RecommendationServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::SchemaServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -185,6 +325,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcdv::SchemaServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSchemaServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::SchemaServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::SchemaServiceClientBuilder builder = new gcdv::SchemaServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcdv::SearchServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -198,6 +354,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::SearchServiceClientBuilder builder = new gcdv::SearchServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcdv::SearchServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSearchServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::SearchServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::SearchServiceClientBuilder builder = new gcdv::SearchServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -220,6 +392,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcdv::SearchTuningServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSearchTuningServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::SearchTuningServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::SearchTuningServiceClientBuilder builder = new gcdv::SearchTuningServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcdv::ServingConfigServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -234,6 +424,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::ServingConfigServiceClientBuilder builder = new gcdv::ServingConfigServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::ServingConfigServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddServingConfigServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::ServingConfigServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::ServingConfigServiceClientBuilder builder = new gcdv::ServingConfigServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -256,6 +464,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcdv::SiteSearchEngineServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSiteSearchEngineServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::SiteSearchEngineServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::SiteSearchEngineServiceClientBuilder builder = new gcdv::SiteSearchEngineServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcdv::UserEventServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -270,6 +496,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::UserEventServiceClientBuilder builder = new gcdv::UserEventServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::UserEventServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddUserEventServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::UserEventServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::UserEventServiceClientBuilder builder = new gcdv::UserEventServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/ServiceCollectionExtensions.g.cs
@@ -42,5 +42,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcdv::DlpServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDlpServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::DlpServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::DlpServiceClientBuilder builder = new gcdv::DlpServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/ServiceCollectionExtensions.g.cs
@@ -46,5 +46,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::DocumentProcessorServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDocumentProcessorServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::DocumentProcessorServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::DocumentProcessorServiceClientBuilder builder = new gcdv::DocumentProcessorServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/ServiceCollectionExtensions.g.cs
@@ -48,6 +48,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcdv::DocumentProcessorServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDocumentProcessorServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::DocumentProcessorServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::DocumentProcessorServiceClientBuilder builder = new gcdv::DocumentProcessorServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcdv::DocumentServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -62,6 +80,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcdv::DocumentServiceClientBuilder builder = new gcdv::DocumentServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcdv::DocumentServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDocumentServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::DocumentServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::DocumentServiceClientBuilder builder = new gcdv::DocumentServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcdv::DomainsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDomainsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::DomainsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::DomainsClientBuilder builder = new gcdv::DomainsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcdv::DomainsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDomainsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcdv::DomainsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcdv::DomainsClientBuilder builder = new gcdv::DomainsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1/ServiceCollectionExtensions.g.cs
@@ -44,5 +44,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcev::EdgeNetworkClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddEdgeNetworkClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcev::EdgeNetworkClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcev::EdgeNetworkClientBuilder builder = new gcev::EdgeNetworkClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcev::EnterpriseKnowledgeGraphServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddEnterpriseKnowledgeGraphServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcev::EnterpriseKnowledgeGraphServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcev::EnterpriseKnowledgeGraphServiceClientBuilder builder = new gcev::EnterpriseKnowledgeGraphServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -45,6 +45,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcev::ErrorGroupServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddErrorGroupServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcev::ErrorGroupServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcev::ErrorGroupServiceClientBuilder builder = new gcev::ErrorGroupServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcev::ErrorStatsServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -63,6 +81,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcev::ErrorStatsServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddErrorStatsServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcev::ErrorStatsServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcev::ErrorStatsServiceClientBuilder builder = new gcev::ErrorStatsServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcev::ReportErrorsServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -77,6 +113,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcev::ReportErrorsServiceClientBuilder builder = new gcev::ReportErrorsServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcev::ReportErrorsServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddReportErrorsServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcev::ReportErrorsServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcev::ReportErrorsServiceClientBuilder builder = new gcev::ReportErrorsServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcev::EssentialContactsServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddEssentialContactsServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcev::EssentialContactsServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcev::EssentialContactsServiceClientBuilder builder = new gcev::EssentialContactsServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcepv::PublisherClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddPublisherClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcepv::PublisherClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcepv::PublisherClientBuilder builder = new gcepv::PublisherClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcev::EventarcClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddEventarcClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcev::EventarcClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcev::EventarcClientBuilder builder = new gcev::EventarcClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1/ServiceCollectionExtensions.g.cs
@@ -46,5 +46,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcfv::CloudFilestoreManagerClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCloudFilestoreManagerClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcfv::CloudFilestoreManagerClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcfv::CloudFilestoreManagerClientBuilder builder = new gcfv::CloudFilestoreManagerClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/ServiceCollectionExtensions.g.cs
@@ -46,5 +46,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcfav::FirestoreAdminClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddFirestoreAdminClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcfav::FirestoreAdminClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcfav::FirestoreAdminClientBuilder builder = new gcfav::FirestoreAdminClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/ServiceCollectionExtensions.g.cs
@@ -42,5 +42,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcfv::FirestoreClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddFirestoreClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcfv::FirestoreClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcfv::FirestoreClientBuilder builder = new gcfv::FirestoreClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1/ServiceCollectionExtensions.g.cs
@@ -47,5 +47,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcfv::CloudFunctionsServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCloudFunctionsServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcfv::CloudFunctionsServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcfv::CloudFunctionsServiceClientBuilder builder = new gcfv::CloudFunctionsServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2/ServiceCollectionExtensions.g.cs
@@ -47,5 +47,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcfv::FunctionServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddFunctionServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcfv::FunctionServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcfv::FunctionServiceClientBuilder builder = new gcfv::FunctionServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta/ServiceCollectionExtensions.g.cs
@@ -47,5 +47,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcfv::FunctionServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddFunctionServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcfv::FunctionServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcfv::FunctionServiceClientBuilder builder = new gcfv::FunctionServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcgv::GSuiteAddOnsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddGSuiteAddOnsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcgv::GSuiteAddOnsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcgv::GSuiteAddOnsClientBuilder builder = new gcgv::GSuiteAddOnsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcgv::BackupForGKEClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddBackupForGKEClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcgv::BackupForGKEClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcgv::BackupForGKEClientBuilder builder = new gcgv::BackupForGKEClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.GkeConnect.Gateway.V1Beta1/Google.Cloud.GkeConnect.Gateway.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.GkeConnect.Gateway.V1Beta1/Google.Cloud.GkeConnect.Gateway.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcggv::GatewayServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddGatewayServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcggv::GatewayServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcggv::GatewayServiceClientBuilder builder = new gcggv::GatewayServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcgv::GkeHubClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddGkeHubClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcgv::GkeHubClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcgv::GkeHubClientBuilder builder = new gcgv::GkeHubClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -47,5 +47,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcgv::GkeHubMembershipServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddGkeHubMembershipServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcgv::GkeHubMembershipServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcgv::GkeHubMembershipServiceClientBuilder builder = new gcgv::GkeHubMembershipServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/ServiceCollectionExtensions.g.cs
@@ -46,6 +46,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcgv::AttachedClustersClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAttachedClustersClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcgv::AttachedClustersClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcgv::AttachedClustersClientBuilder builder = new gcgv::AttachedClustersClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcgv::AwsClustersClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -62,6 +80,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcgv::AwsClustersClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAwsClustersClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcgv::AwsClustersClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcgv::AwsClustersClientBuilder builder = new gcgv::AwsClustersClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcgv::AzureClustersClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -75,6 +109,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcgv::AzureClustersClientBuilder builder = new gcgv::AzureClustersClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcgv::AzureClustersClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAzureClustersClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcgv::AzureClustersClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcgv::AzureClustersClientBuilder builder = new gcgv::AzureClustersClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gciav::IAMClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddIAMClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gciav::IAMClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gciav::IAMClientBuilder builder = new gciav::IAMClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcicv::IAMCredentialsClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddIAMCredentialsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcicv::IAMCredentialsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcicv::IAMCredentialsClientBuilder builder = new gcicv::IAMCredentialsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gciv::IAMPolicyClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddIAMPolicyClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gciv::IAMPolicyClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gciv::IAMPolicyClientBuilder builder = new gciv::IAMPolicyClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gciv::PoliciesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddPoliciesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gciv::PoliciesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gciv::PoliciesClientBuilder builder = new gciv::PoliciesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/ServiceCollectionExtensions.g.cs
@@ -45,6 +45,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gciv::IdentityAwareProxyAdminServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddIdentityAwareProxyAdminServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gciv::IdentityAwareProxyAdminServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gciv::IdentityAwareProxyAdminServiceClientBuilder builder = new gciv::IdentityAwareProxyAdminServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gciv::IdentityAwareProxyOAuthServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -59,6 +77,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gciv::IdentityAwareProxyOAuthServiceClientBuilder builder = new gciv::IdentityAwareProxyOAuthServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gciv::IdentityAwareProxyOAuthServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddIdentityAwareProxyOAuthServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gciv::IdentityAwareProxyOAuthServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gciv::IdentityAwareProxyOAuthServiceClientBuilder builder = new gciv::IdentityAwareProxyOAuthServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gciv::IDSClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddIDSClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gciv::IDSClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gciv::IDSClientBuilder builder = new gciv::IDSClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1/ServiceCollectionExtensions.g.cs
@@ -45,6 +45,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gckiv::KeyDashboardServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddKeyDashboardServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gckiv::KeyDashboardServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gckiv::KeyDashboardServiceClientBuilder builder = new gckiv::KeyDashboardServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gckiv::KeyTrackingServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -59,6 +77,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gckiv::KeyTrackingServiceClientBuilder builder = new gckiv::KeyTrackingServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gckiv::KeyTrackingServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddKeyTrackingServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gckiv::KeyTrackingServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gckiv::KeyTrackingServiceClientBuilder builder = new gckiv::KeyTrackingServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/ServiceCollectionExtensions.g.cs
@@ -45,6 +45,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gckv::EkmServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddEkmServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gckv::EkmServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gckv::EkmServiceClientBuilder builder = new gckv::EkmServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>
         /// Adds a singleton <see cref="gckv::KeyManagementServiceClient"/> to <paramref name="services"/>.
         /// </summary>
@@ -60,6 +76,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gckv::KeyManagementServiceClientBuilder builder = new gckv::KeyManagementServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gckv::KeyManagementServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddKeyManagementServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gckv::KeyManagementServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gckv::KeyManagementServiceClientBuilder builder = new gckv::KeyManagementServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gclv::LanguageServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddLanguageServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gclv::LanguageServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gclv::LanguageServiceClientBuilder builder = new gclv::LanguageServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gclv::LanguageServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddLanguageServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gclv::LanguageServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gclv::LanguageServiceClientBuilder builder = new gclv::LanguageServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta/ServiceCollectionExtensions.g.cs
@@ -46,5 +46,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gclv::WorkflowsServiceV2BetaClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddWorkflowsServiceV2BetaClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gclv::WorkflowsServiceV2BetaClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gclv::WorkflowsServiceV2BetaClientBuilder builder = new gclv::WorkflowsServiceV2BetaClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Location/Google.Cloud.Location/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Location/Google.Cloud.Location/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcl::LocationsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddLocationsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcl::LocationsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcl::LocationsClientBuilder builder = new gcl::LocationsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/ServiceCollectionExtensions.g.cs
@@ -47,6 +47,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gclv::ConfigServiceV2Client"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddConfigServiceV2Client(this IServiceCollection services, sys::Action<sys::IServiceProvider, gclv::ConfigServiceV2ClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gclv::ConfigServiceV2ClientBuilder builder = new gclv::ConfigServiceV2ClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gclv::LoggingServiceV2Client"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -65,6 +83,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gclv::LoggingServiceV2Client"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddLoggingServiceV2Client(this IServiceCollection services, sys::Action<sys::IServiceProvider, gclv::LoggingServiceV2ClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gclv::LoggingServiceV2ClientBuilder builder = new gclv::LoggingServiceV2ClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gclv::MetricsServiceV2Client"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -79,6 +115,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gclv::MetricsServiceV2ClientBuilder builder = new gclv::MetricsServiceV2ClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gclv::MetricsServiceV2Client"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddMetricsServiceV2Client(this IServiceCollection services, sys::Action<sys::IServiceProvider, gclv::MetricsServiceV2ClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gclv::MetricsServiceV2ClientBuilder builder = new gclv::MetricsServiceV2ClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcmv::ManagedIdentitiesServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddManagedIdentitiesServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcmv::ManagedIdentitiesServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcmv::ManagedIdentitiesServiceClientBuilder builder = new gcmv::ManagedIdentitiesServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.MediaTranslation.V1Beta1/Google.Cloud.MediaTranslation.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.MediaTranslation.V1Beta1/Google.Cloud.MediaTranslation.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcmv::SpeechTranslationServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSpeechTranslationServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcmv::SpeechTranslationServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcmv::SpeechTranslationServiceClientBuilder builder = new gcmv::SpeechTranslationServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1/ServiceCollectionExtensions.g.cs
@@ -44,5 +44,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcmv::CloudMemcacheClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCloudMemcacheClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcmv::CloudMemcacheClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcmv::CloudMemcacheClientBuilder builder = new gcmv::CloudMemcacheClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2/ServiceCollectionExtensions.g.cs
@@ -44,5 +44,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcmv::CloudMemcacheClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCloudMemcacheClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcmv::CloudMemcacheClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcmv::CloudMemcacheClientBuilder builder = new gcmv::CloudMemcacheClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/ServiceCollectionExtensions.g.cs
@@ -49,6 +49,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcmv::DataprocMetastoreClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDataprocMetastoreClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcmv::DataprocMetastoreClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcmv::DataprocMetastoreClientBuilder builder = new gcmv::DataprocMetastoreClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcmv::DataprocMetastoreFederationClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -63,6 +81,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcmv::DataprocMetastoreFederationClientBuilder builder = new gcmv::DataprocMetastoreFederationClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcmv::DataprocMetastoreFederationClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDataprocMetastoreFederationClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcmv::DataprocMetastoreFederationClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcmv::DataprocMetastoreFederationClientBuilder builder = new gcmv::DataprocMetastoreFederationClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/ServiceCollectionExtensions.g.cs
@@ -49,6 +49,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcmv::DataprocMetastoreClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDataprocMetastoreClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcmv::DataprocMetastoreClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcmv::DataprocMetastoreClientBuilder builder = new gcmv::DataprocMetastoreClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcmv::DataprocMetastoreFederationClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -63,6 +81,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcmv::DataprocMetastoreFederationClientBuilder builder = new gcmv::DataprocMetastoreFederationClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcmv::DataprocMetastoreFederationClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDataprocMetastoreFederationClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcmv::DataprocMetastoreFederationClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcmv::DataprocMetastoreFederationClientBuilder builder = new gcmv::DataprocMetastoreFederationClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/ServiceCollectionExtensions.g.cs
@@ -49,6 +49,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcmv::DataprocMetastoreClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDataprocMetastoreClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcmv::DataprocMetastoreClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcmv::DataprocMetastoreClientBuilder builder = new gcmv::DataprocMetastoreClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcmv::DataprocMetastoreFederationClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -63,6 +81,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcmv::DataprocMetastoreFederationClientBuilder builder = new gcmv::DataprocMetastoreFederationClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcmv::DataprocMetastoreFederationClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDataprocMetastoreFederationClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcmv::DataprocMetastoreFederationClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcmv::DataprocMetastoreFederationClientBuilder builder = new gcmv::DataprocMetastoreFederationClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1/ServiceCollectionExtensions.g.cs
@@ -46,5 +46,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcmv::MigrationCenterClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddMigrationCenterClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcmv::MigrationCenterClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcmv::MigrationCenterClientBuilder builder = new gcmv::MigrationCenterClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/ServiceCollectionExtensions.g.cs
@@ -44,6 +44,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcmv::AlertPolicyServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAlertPolicyServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcmv::AlertPolicyServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcmv::AlertPolicyServiceClientBuilder builder = new gcmv::AlertPolicyServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcmv::GroupServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -60,6 +78,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcmv::GroupServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddGroupServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcmv::GroupServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcmv::GroupServiceClientBuilder builder = new gcmv::GroupServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcmv::MetricServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -73,6 +107,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcmv::MetricServiceClientBuilder builder = new gcmv::MetricServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcmv::MetricServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddMetricServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcmv::MetricServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcmv::MetricServiceClientBuilder builder = new gcmv::MetricServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -94,6 +144,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcmv::NotificationChannelServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddNotificationChannelServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcmv::NotificationChannelServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcmv::NotificationChannelServiceClientBuilder builder = new gcmv::NotificationChannelServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcmv::QueryServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -107,6 +175,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcmv::QueryServiceClientBuilder builder = new gcmv::QueryServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcmv::QueryServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddQueryServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcmv::QueryServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcmv::QueryServiceClientBuilder builder = new gcmv::QueryServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -128,6 +212,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcmv::ServiceMonitoringServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddServiceMonitoringServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcmv::ServiceMonitoringServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcmv::ServiceMonitoringServiceClientBuilder builder = new gcmv::ServiceMonitoringServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcmv::SnoozeServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -141,6 +243,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcmv::SnoozeServiceClientBuilder builder = new gcmv::SnoozeServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcmv::SnoozeServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSnoozeServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcmv::SnoozeServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcmv::SnoozeServiceClientBuilder builder = new gcmv::SnoozeServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -159,6 +277,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcmv::UptimeCheckServiceClientBuilder builder = new gcmv::UptimeCheckServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcmv::UptimeCheckServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddUptimeCheckServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcmv::UptimeCheckServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcmv::UptimeCheckServiceClientBuilder builder = new gcmv::UptimeCheckServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/ServiceCollectionExtensions.g.cs
@@ -44,5 +44,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcnv::NetAppClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddNetAppClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcnv::NetAppClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcnv::NetAppClientBuilder builder = new gcnv::NetAppClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/ServiceCollectionExtensions.g.cs
@@ -46,6 +46,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcnv::HubServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddHubServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcnv::HubServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcnv::HubServiceClientBuilder builder = new gcnv::HubServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>
         /// Adds a singleton <see cref="gcnv::PolicyBasedRoutingServiceClient"/> to <paramref name="services"/>.
         /// </summary>
@@ -61,6 +77,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcnv::PolicyBasedRoutingServiceClientBuilder builder = new gcnv::PolicyBasedRoutingServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcnv::PolicyBasedRoutingServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddPolicyBasedRoutingServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcnv::PolicyBasedRoutingServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcnv::PolicyBasedRoutingServiceClientBuilder builder = new gcnv::PolicyBasedRoutingServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcnv::HubServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddHubServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcnv::HubServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcnv::HubServiceClientBuilder builder = new gcnv::HubServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/ServiceCollectionExtensions.g.cs
@@ -47,5 +47,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcnv::ReachabilityServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddReachabilityServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcnv::ReachabilityServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcnv::ReachabilityServiceClientBuilder builder = new gcnv::ReachabilityServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -47,5 +47,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcnv::NetworkSecurityClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddNetworkSecurityClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcnv::NetworkSecurityClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcnv::NetworkSecurityClientBuilder builder = new gcnv::NetworkSecurityClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/ServiceCollectionExtensions.g.cs
@@ -49,6 +49,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcnv::ManagedNotebookServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddManagedNotebookServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcnv::ManagedNotebookServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcnv::ManagedNotebookServiceClientBuilder builder = new gcnv::ManagedNotebookServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcnv::NotebookServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -63,6 +81,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcnv::NotebookServiceClientBuilder builder = new gcnv::NotebookServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcnv::NotebookServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddNotebookServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcnv::NotebookServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcnv::NotebookServiceClientBuilder builder = new gcnv::NotebookServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -47,5 +47,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcnv::NotebookServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddNotebookServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcnv::NotebookServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcnv::NotebookServiceClientBuilder builder = new gcnv::NotebookServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2/ServiceCollectionExtensions.g.cs
@@ -47,5 +47,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcnv::NotebookServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddNotebookServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcnv::NotebookServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcnv::NotebookServiceClientBuilder builder = new gcnv::NotebookServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Optimization.V1/Google.Cloud.Optimization.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Optimization.V1/Google.Cloud.Optimization.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcov::FleetRoutingClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddFleetRoutingClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcov::FleetRoutingClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcov::FleetRoutingClientBuilder builder = new gcov::FleetRoutingClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/ServiceCollectionExtensions.g.cs
@@ -44,6 +44,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcoasv::EnvironmentsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddEnvironmentsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcoasv::EnvironmentsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcoasv::EnvironmentsClientBuilder builder = new gcoasv::EnvironmentsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>
         /// Adds a singleton <see cref="gcoasv::ImageVersionsClient"/> to <paramref name="services"/>.
         /// </summary>
@@ -59,6 +75,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcoasv::ImageVersionsClientBuilder builder = new gcoasv::ImageVersionsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcoasv::ImageVersionsClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddImageVersionsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcoasv::ImageVersionsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcoasv::ImageVersionsClientBuilder builder = new gcoasv::ImageVersionsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcov::OrgPolicyClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddOrgPolicyClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcov::OrgPolicyClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcov::OrgPolicyClientBuilder builder = new gcov::OrgPolicyClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/ServiceCollectionExtensions.g.cs
@@ -47,6 +47,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcov::OsConfigServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddOsConfigServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcov::OsConfigServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcov::OsConfigServiceClientBuilder builder = new gcov::OsConfigServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcov::OsConfigZonalServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -61,6 +79,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcov::OsConfigZonalServiceClientBuilder builder = new gcov::OsConfigZonalServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcov::OsConfigZonalServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddOsConfigZonalServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcov::OsConfigZonalServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcov::OsConfigZonalServiceClientBuilder builder = new gcov::OsConfigZonalServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcov::OsConfigZonalServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddOsConfigZonalServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcov::OsConfigZonalServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcov::OsConfigZonalServiceClientBuilder builder = new gcov::OsConfigZonalServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcov::OsLoginServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddOsLoginServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcov::OsLoginServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcov::OsLoginServiceClientBuilder builder = new gcov::OsLoginServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcov::OsLoginServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddOsLoginServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcov::OsLoginServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcov::OsLoginServiceClientBuilder builder = new gcov::OsLoginServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta/ServiceCollectionExtensions.g.cs
@@ -44,5 +44,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcpv::ParallelstoreClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddParallelstoreClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcpv::ParallelstoreClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcpv::ParallelstoreClientBuilder builder = new gcpv::ParallelstoreClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcpv::PhishingProtectionServiceV1Beta1Client"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddPhishingProtectionServiceV1Beta1Client(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcpv::PhishingProtectionServiceV1Beta1ClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcpv::PhishingProtectionServiceV1Beta1ClientBuilder builder = new gcpv::PhishingProtectionServiceV1Beta1ClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcpv::SimulatorClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSimulatorClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcpv::SimulatorClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcpv::SimulatorClientBuilder builder = new gcpv::SimulatorClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/Google.Cloud.PolicyTroubleshooter.Iam.V3/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/Google.Cloud.PolicyTroubleshooter.Iam.V3/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcpiv::PolicyTroubleshooterClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddPolicyTroubleshooterClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcpiv::PolicyTroubleshooterClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcpiv::PolicyTroubleshooterClientBuilder builder = new gcpiv::PolicyTroubleshooterClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcpv::IamCheckerClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddIamCheckerClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcpv::IamCheckerClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcpv::IamCheckerClientBuilder builder = new gcpv::IamCheckerClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcpv::PrivateCatalogClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddPrivateCatalogClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcpv::PrivateCatalogClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcpv::PrivateCatalogClientBuilder builder = new gcpv::PrivateCatalogClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2/ServiceCollectionExtensions.g.cs
@@ -42,6 +42,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcpv::ExportServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddExportServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcpv::ExportServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcpv::ExportServiceClientBuilder builder = new gcpv::ExportServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>
         /// Adds a singleton <see cref="gcpv::ProfilerServiceClient"/> to <paramref name="services"/>.
         /// </summary>
@@ -57,6 +73,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcpv::ProfilerServiceClientBuilder builder = new gcpv::ProfilerServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcpv::ProfilerServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddProfilerServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcpv::ProfilerServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcpv::ProfilerServiceClientBuilder builder = new gcpv::ProfilerServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/ServiceCollectionExtensions.g.cs
@@ -46,6 +46,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcpv::PublisherServiceApiClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddPublisherServiceApiClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcpv::PublisherServiceApiClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcpv::PublisherServiceApiClientBuilder builder = new gcpv::PublisherServiceApiClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcpv::SchemaServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -59,6 +77,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcpv::SchemaServiceClientBuilder builder = new gcpv::SchemaServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcpv::SchemaServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSchemaServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcpv::SchemaServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcpv::SchemaServiceClientBuilder builder = new gcpv::SchemaServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -77,6 +111,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcpv::SubscriberServiceApiClientBuilder builder = new gcpv::SubscriberServiceApiClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcpv::SubscriberServiceApiClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSubscriberServiceApiClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcpv::SubscriberServiceApiClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcpv::SubscriberServiceApiClientBuilder builder = new gcpv::SubscriberServiceApiClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1/ServiceCollectionExtensions.g.cs
@@ -46,5 +46,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcrv::RapidMigrationAssessmentClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRapidMigrationAssessmentClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::RapidMigrationAssessmentClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::RapidMigrationAssessmentClientBuilder builder = new gcrv::RapidMigrationAssessmentClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcrv::RecaptchaEnterpriseServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRecaptchaEnterpriseServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::RecaptchaEnterpriseServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::RecaptchaEnterpriseServiceClientBuilder builder = new gcrv::RecaptchaEnterpriseServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcrv::RecaptchaEnterpriseServiceV1Beta1Client"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRecaptchaEnterpriseServiceV1Beta1Client(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::RecaptchaEnterpriseServiceV1Beta1ClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::RecaptchaEnterpriseServiceV1Beta1ClientBuilder builder = new gcrv::RecaptchaEnterpriseServiceV1Beta1ClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -44,6 +44,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcrv::CatalogServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCatalogServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::CatalogServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::CatalogServiceClientBuilder builder = new gcrv::CatalogServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>
         /// Adds a singleton <see cref="gcrv::PredictionApiKeyRegistryClient"/> to <paramref name="services"/>.
         /// </summary>
@@ -59,6 +75,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcrv::PredictionApiKeyRegistryClientBuilder builder = new gcrv::PredictionApiKeyRegistryClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcrv::PredictionApiKeyRegistryClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddPredictionApiKeyRegistryClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::PredictionApiKeyRegistryClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::PredictionApiKeyRegistryClientBuilder builder = new gcrv::PredictionApiKeyRegistryClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -81,6 +115,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcrv::PredictionServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddPredictionServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::PredictionServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::PredictionServiceClientBuilder builder = new gcrv::PredictionServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcrv::UserEventServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -95,6 +147,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcrv::UserEventServiceClientBuilder builder = new gcrv::UserEventServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcrv::UserEventServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddUserEventServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::UserEventServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::UserEventServiceClientBuilder builder = new gcrv::UserEventServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcrv::RecommenderClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRecommenderClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::RecommenderClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::RecommenderClientBuilder builder = new gcrv::RecommenderClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1/ServiceCollectionExtensions.g.cs
@@ -46,5 +46,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcrcv::CloudRedisClusterClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCloudRedisClusterClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrcv::CloudRedisClusterClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrcv::CloudRedisClusterClientBuilder builder = new gcrcv::CloudRedisClusterClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/ServiceCollectionExtensions.g.cs
@@ -44,5 +44,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcrv::CloudRedisClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCloudRedisClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::CloudRedisClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::CloudRedisClientBuilder builder = new gcrv::CloudRedisClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcrv::CloudRedisClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCloudRedisClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::CloudRedisClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::CloudRedisClientBuilder builder = new gcrv::CloudRedisClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/ServiceCollectionExtensions.g.cs
@@ -44,6 +44,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcrv::FoldersClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddFoldersClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::FoldersClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::FoldersClientBuilder builder = new gcrv::FoldersClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcrv::OrganizationsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -57,6 +73,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcrv::OrganizationsClientBuilder builder = new gcrv::OrganizationsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcrv::OrganizationsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddOrganizationsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::OrganizationsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::OrganizationsClientBuilder builder = new gcrv::OrganizationsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -76,6 +108,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcrv::ProjectsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddProjectsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::ProjectsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::ProjectsClientBuilder builder = new gcrv::ProjectsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcrv::TagBindingsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -89,6 +137,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcrv::TagBindingsClientBuilder builder = new gcrv::TagBindingsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcrv::TagBindingsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTagBindingsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::TagBindingsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::TagBindingsClientBuilder builder = new gcrv::TagBindingsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -108,6 +172,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcrv::TagHoldsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTagHoldsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::TagHoldsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::TagHoldsClientBuilder builder = new gcrv::TagHoldsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcrv::TagKeysClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -124,6 +204,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcrv::TagKeysClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTagKeysClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::TagKeysClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::TagKeysClientBuilder builder = new gcrv::TagKeysClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcrv::TagValuesClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -137,6 +233,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcrv::TagValuesClientBuilder builder = new gcrv::TagValuesClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcrv::TagValuesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTagValuesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::TagValuesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::TagValuesClientBuilder builder = new gcrv::TagValuesClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.ResourceSettings.V1/Google.Cloud.ResourceSettings.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ResourceSettings.V1/Google.Cloud.ResourceSettings.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcrv::ResourceSettingsServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddResourceSettingsServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::ResourceSettingsServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::ResourceSettingsServiceClientBuilder builder = new gcrv::ResourceSettingsServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ServiceCollectionExtensions.g.cs
@@ -47,6 +47,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcrv::AnalyticsServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAnalyticsServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::AnalyticsServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::AnalyticsServiceClientBuilder builder = new gcrv::AnalyticsServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcrv::CatalogServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -60,6 +78,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcrv::CatalogServiceClientBuilder builder = new gcrv::CatalogServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcrv::CatalogServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCatalogServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::CatalogServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::CatalogServiceClientBuilder builder = new gcrv::CatalogServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -81,6 +115,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcrv::CompletionServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCompletionServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::CompletionServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::CompletionServiceClientBuilder builder = new gcrv::CompletionServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcrv::ControlServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -97,6 +149,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcrv::ControlServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddControlServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::ControlServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::ControlServiceClientBuilder builder = new gcrv::ControlServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcrv::ModelServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -110,6 +178,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcrv::ModelServiceClientBuilder builder = new gcrv::ModelServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcrv::ModelServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddModelServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::ModelServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::ModelServiceClientBuilder builder = new gcrv::ModelServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -131,6 +215,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcrv::PredictionServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddPredictionServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::PredictionServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::PredictionServiceClientBuilder builder = new gcrv::PredictionServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcrv::ProductServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -147,6 +249,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcrv::ProductServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddProductServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::ProductServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::ProductServiceClientBuilder builder = new gcrv::ProductServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcrv::SearchServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -160,6 +278,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcrv::SearchServiceClientBuilder builder = new gcrv::SearchServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcrv::SearchServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSearchServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::SearchServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::SearchServiceClientBuilder builder = new gcrv::SearchServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -182,6 +316,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcrv::ServingConfigServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddServingConfigServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::ServingConfigServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::ServingConfigServiceClientBuilder builder = new gcrv::ServingConfigServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcrv::UserEventServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -196,6 +348,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcrv::UserEventServiceClientBuilder builder = new gcrv::UserEventServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcrv::UserEventServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddUserEventServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::UserEventServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::UserEventServiceClientBuilder builder = new gcrv::UserEventServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/ServiceCollectionExtensions.g.cs
@@ -45,6 +45,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcrv::ExecutionsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddExecutionsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::ExecutionsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::ExecutionsClientBuilder builder = new gcrv::ExecutionsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcrv::JobsClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -58,6 +74,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcrv::JobsClientBuilder builder = new gcrv::JobsClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcrv::JobsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddJobsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::JobsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::JobsClientBuilder builder = new gcrv::JobsClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -77,6 +109,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcrv::RevisionsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRevisionsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::RevisionsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::RevisionsClientBuilder builder = new gcrv::RevisionsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcrv::ServicesClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -93,6 +141,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcrv::ServicesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddServicesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::ServicesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::ServicesClientBuilder builder = new gcrv::ServicesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcrv::TasksClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -106,6 +170,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcrv::TasksClientBuilder builder = new gcrv::TasksClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcrv::TasksClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTasksClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcrv::TasksClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcrv::TasksClientBuilder builder = new gcrv::TasksClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcsv::CloudSchedulerClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCloudSchedulerClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::CloudSchedulerClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::CloudSchedulerClientBuilder builder = new gcsv::CloudSchedulerClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcsv::SecretManagerServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSecretManagerServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::SecretManagerServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::SecretManagerServiceClientBuilder builder = new gcsv::SecretManagerServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcsv::SecretManagerServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSecretManagerServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::SecretManagerServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::SecretManagerServiceClientBuilder builder = new gcsv::SecretManagerServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcsv::SecretManagerServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSecretManagerServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::SecretManagerServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::SecretManagerServiceClientBuilder builder = new gcsv::SecretManagerServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.SecureSourceManager.V1/Google.Cloud.SecureSourceManager.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.SecureSourceManager.V1/Google.Cloud.SecureSourceManager.V1/ServiceCollectionExtensions.g.cs
@@ -47,5 +47,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcsv::SecureSourceManagerClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSecureSourceManagerClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::SecureSourceManagerClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::SecureSourceManagerClientBuilder builder = new gcsv::SecureSourceManagerClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/ServiceCollectionExtensions.g.cs
@@ -47,5 +47,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcspv::CertificateAuthorityServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCertificateAuthorityServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcspv::CertificateAuthorityServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcspv::CertificateAuthorityServiceClientBuilder builder = new gcspv::CertificateAuthorityServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -44,5 +44,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcspv::PublicCertificateAuthorityServiceClient"/> to <paramref name="services"/>
+        /// .
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddPublicCertificateAuthorityServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcspv::PublicCertificateAuthorityServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcspv::PublicCertificateAuthorityServiceClientBuilder builder = new gcspv::PublicCertificateAuthorityServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcssv::SecurityCenterSettingsServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSecurityCenterSettingsServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcssv::SecurityCenterSettingsServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcssv::SecurityCenterSettingsServiceClientBuilder builder = new gcssv::SecurityCenterSettingsServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcsv::SecurityCenterClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSecurityCenterClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::SecurityCenterClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::SecurityCenterClientBuilder builder = new gcsv::SecurityCenterClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcsv::SecurityCenterClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSecurityCenterClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::SecurityCenterClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::SecurityCenterClientBuilder builder = new gcsv::SecurityCenterClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcsv::SecurityCenterClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSecurityCenterClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::SecurityCenterClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::SecurityCenterClientBuilder builder = new gcsv::SecurityCenterClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcsv::SecurityCenterManagementClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSecurityCenterManagementClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::SecurityCenterManagementClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::SecurityCenterManagementClientBuilder builder = new gcsv::SecurityCenterManagementClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1/ServiceCollectionExtensions.g.cs
@@ -45,6 +45,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gcsv::QuotaControllerClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddQuotaControllerClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::QuotaControllerClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::QuotaControllerClientBuilder builder = new gcsv::QuotaControllerClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gcsv::ServiceControllerClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -59,6 +77,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcsv::ServiceControllerClientBuilder builder = new gcsv::ServiceControllerClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcsv::ServiceControllerClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddServiceControllerClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::ServiceControllerClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::ServiceControllerClientBuilder builder = new gcsv::ServiceControllerClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/ServiceCollectionExtensions.g.cs
@@ -44,6 +44,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcsv::LookupServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddLookupServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::LookupServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::LookupServiceClientBuilder builder = new gcsv::LookupServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>
         /// Adds a singleton <see cref="gcsv::RegistrationServiceClient"/> to <paramref name="services"/>.
         /// </summary>
@@ -59,6 +75,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcsv::RegistrationServiceClientBuilder builder = new gcsv::RegistrationServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcsv::RegistrationServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegistrationServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::RegistrationServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::RegistrationServiceClientBuilder builder = new gcsv::RegistrationServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -44,6 +44,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcsv::LookupServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddLookupServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::LookupServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::LookupServiceClientBuilder builder = new gcsv::LookupServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>
         /// Adds a singleton <see cref="gcsv::RegistrationServiceClient"/> to <paramref name="services"/>.
         /// </summary>
@@ -59,6 +75,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcsv::RegistrationServiceClientBuilder builder = new gcsv::RegistrationServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcsv::RegistrationServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegistrationServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::RegistrationServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::RegistrationServiceClientBuilder builder = new gcsv::RegistrationServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcsv::ServiceHealthClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddServiceHealthClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::ServiceHealthClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::ServiceHealthClientBuilder builder = new gcsv::ServiceHealthClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1/ServiceCollectionExtensions.g.cs
@@ -44,5 +44,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcsv::ServiceManagerClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddServiceManagerClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::ServiceManagerClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::ServiceManagerClientBuilder builder = new gcsv::ServiceManagerClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcsv::ServiceUsageClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddServiceUsageClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::ServiceUsageClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::ServiceUsageClientBuilder builder = new gcsv::ServiceUsageClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1/ServiceCollectionExtensions.g.cs
@@ -44,5 +44,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcsv::CloudShellServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCloudShellServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::CloudShellServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::CloudShellServiceClientBuilder builder = new gcsv::CloudShellServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcsadv::DatabaseAdminClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDatabaseAdminClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsadv::DatabaseAdminClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsadv::DatabaseAdminClientBuilder builder = new gcsadv::DatabaseAdminClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcsaiv::InstanceAdminClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddInstanceAdminClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsaiv::InstanceAdminClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsaiv::InstanceAdminClientBuilder builder = new gcsaiv::InstanceAdminClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcsv::SpannerClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSpannerClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::SpannerClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::SpannerClientBuilder builder = new gcsv::SpannerClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/ServiceCollectionExtensions.g.cs
@@ -44,6 +44,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcsv::AdaptationClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAdaptationClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::AdaptationClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::AdaptationClientBuilder builder = new gcsv::AdaptationClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcsv::SpeechClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -57,6 +73,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcsv::SpeechClientBuilder builder = new gcsv::SpeechClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcsv::SpeechClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSpeechClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::SpeechClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::SpeechClientBuilder builder = new gcsv::SpeechClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/ServiceCollectionExtensions.g.cs
@@ -44,6 +44,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcsv::AdaptationClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAdaptationClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::AdaptationClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::AdaptationClientBuilder builder = new gcsv::AdaptationClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcsv::SpeechClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -57,6 +73,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcsv::SpeechClientBuilder builder = new gcsv::SpeechClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcsv::SpeechClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSpeechClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::SpeechClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::SpeechClientBuilder builder = new gcsv::SpeechClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2/ServiceCollectionExtensions.g.cs
@@ -44,5 +44,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcsv::SpeechClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddSpeechClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::SpeechClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::SpeechClientBuilder builder = new gcsv::SpeechClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2/ServiceCollectionExtensions.g.cs
@@ -44,5 +44,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcscv::StorageControlClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddStorageControlClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcscv::StorageControlClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcscv::StorageControlClientBuilder builder = new gcscv::StorageControlClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Storage.V2/Google.Cloud.Storage.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Storage.V2/Google.Cloud.Storage.V2/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcsv::StorageClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddStorageClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::StorageClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::StorageClientBuilder builder = new gcsv::StorageClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcsv::StorageInsightsClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddStorageInsightsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::StorageInsightsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::StorageInsightsClientBuilder builder = new gcsv::StorageInsightsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcsv::StorageTransferServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddStorageTransferServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::StorageTransferServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::StorageTransferServiceClientBuilder builder = new gcsv::StorageTransferServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2/ServiceCollectionExtensions.g.cs
@@ -44,6 +44,24 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>
+        /// Adds a singleton <see cref="gcsv::CaseAttachmentServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCaseAttachmentServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::CaseAttachmentServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::CaseAttachmentServiceClientBuilder builder = new gcsv::CaseAttachmentServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcsv::CaseServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -60,6 +78,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcsv::CaseServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCaseServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::CaseServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::CaseServiceClientBuilder builder = new gcsv::CaseServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcsv::CommentServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -73,6 +107,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcsv::CommentServiceClientBuilder builder = new gcsv::CommentServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcsv::CommentServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCommentServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcsv::CommentServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcsv::CommentServiceClientBuilder builder = new gcsv::CommentServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/ServiceCollectionExtensions.g.cs
@@ -44,6 +44,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gctv::CompanyServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCompanyServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gctv::CompanyServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gctv::CompanyServiceClientBuilder builder = new gctv::CompanyServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gctv::CompletionClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -57,6 +73,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gctv::CompletionClientBuilder builder = new gctv::CompletionClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gctv::CompletionClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCompletionClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gctv::CompletionClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gctv::CompletionClientBuilder builder = new gctv::CompletionClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -76,6 +108,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gctv::EventServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddEventServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gctv::EventServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gctv::EventServiceClientBuilder builder = new gctv::EventServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gctv::JobServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -92,6 +140,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gctv::JobServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddJobServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gctv::JobServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gctv::JobServiceClientBuilder builder = new gctv::JobServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gctv::TenantServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -105,6 +169,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gctv::TenantServiceClientBuilder builder = new gctv::TenantServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gctv::TenantServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTenantServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gctv::TenantServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gctv::TenantServiceClientBuilder builder = new gctv::TenantServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/ServiceCollectionExtensions.g.cs
@@ -44,6 +44,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gctv::CompanyServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCompanyServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gctv::CompanyServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gctv::CompanyServiceClientBuilder builder = new gctv::CompanyServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gctv::CompletionClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -57,6 +73,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gctv::CompletionClientBuilder builder = new gctv::CompletionClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gctv::CompletionClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCompletionClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gctv::CompletionClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gctv::CompletionClientBuilder builder = new gctv::CompletionClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -76,6 +108,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gctv::EventServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddEventServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gctv::EventServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gctv::EventServiceClientBuilder builder = new gctv::EventServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gctv::JobServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -92,6 +140,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gctv::JobServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddJobServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gctv::JobServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gctv::JobServiceClientBuilder builder = new gctv::JobServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gctv::TenantServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -105,6 +169,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gctv::TenantServiceClientBuilder builder = new gctv::TenantServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gctv::TenantServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTenantServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gctv::TenantServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gctv::TenantServiceClientBuilder builder = new gctv::TenantServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gctv::CloudTasksClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCloudTasksClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gctv::CloudTasksClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gctv::CloudTasksClientBuilder builder = new gctv::CloudTasksClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gctv::CloudTasksClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCloudTasksClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gctv::CloudTasksClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gctv::CloudTasksClientBuilder builder = new gctv::CloudTasksClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1/ServiceCollectionExtensions.g.cs
@@ -46,5 +46,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gctv::TelcoAutomationClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTelcoAutomationClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gctv::TelcoAutomationClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gctv::TelcoAutomationClientBuilder builder = new gctv::TelcoAutomationClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/ServiceCollectionExtensions.g.cs
@@ -44,6 +44,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gctv::TextToSpeechClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTextToSpeechClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gctv::TextToSpeechClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gctv::TextToSpeechClientBuilder builder = new gctv::TextToSpeechClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>
         /// Adds a singleton <see cref="gctv::TextToSpeechLongAudioSynthesizeClient"/> to <paramref name="services"/>.
         /// </summary>
@@ -59,6 +75,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gctv::TextToSpeechLongAudioSynthesizeClientBuilder builder = new gctv::TextToSpeechLongAudioSynthesizeClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gctv::TextToSpeechLongAudioSynthesizeClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTextToSpeechLongAudioSynthesizeClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gctv::TextToSpeechLongAudioSynthesizeClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gctv::TextToSpeechLongAudioSynthesizeClientBuilder builder = new gctv::TextToSpeechLongAudioSynthesizeClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -44,6 +44,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gctv::TextToSpeechClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTextToSpeechClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gctv::TextToSpeechClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gctv::TextToSpeechClientBuilder builder = new gctv::TextToSpeechClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>
         /// Adds a singleton <see cref="gctv::TextToSpeechLongAudioSynthesizeClient"/> to <paramref name="services"/>.
         /// </summary>
@@ -59,6 +75,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gctv::TextToSpeechLongAudioSynthesizeClientBuilder builder = new gctv::TextToSpeechLongAudioSynthesizeClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gctv::TextToSpeechLongAudioSynthesizeClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTextToSpeechLongAudioSynthesizeClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gctv::TextToSpeechLongAudioSynthesizeClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gctv::TextToSpeechLongAudioSynthesizeClientBuilder builder = new gctv::TextToSpeechLongAudioSynthesizeClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1/ServiceCollectionExtensions.g.cs
@@ -44,5 +44,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gctv::TpuClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTpuClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gctv::TpuClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gctv::TpuClientBuilder builder = new gctv::TpuClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gctv::TraceServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTraceServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gctv::TraceServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gctv::TraceServiceClientBuilder builder = new gctv::TraceServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gctv::TraceServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTraceServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gctv::TraceServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gctv::TraceServiceClientBuilder builder = new gctv::TraceServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gctv::TranslationServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTranslationServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gctv::TranslationServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gctv::TranslationServiceClientBuilder builder = new gctv::TranslationServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcvv::VmMigrationClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddVmMigrationClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcvv::VmMigrationClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcvv::VmMigrationClientBuilder builder = new gcvv::VmMigrationClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1/ServiceCollectionExtensions.g.cs
@@ -46,5 +46,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcvlv::LivestreamServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddLivestreamServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcvlv::LivestreamServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcvlv::LivestreamServiceClientBuilder builder = new gcvlv::LivestreamServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcvsv::VideoStitcherServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddVideoStitcherServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcvsv::VideoStitcherServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcvsv::VideoStitcherServiceClientBuilder builder = new gcvsv::VideoStitcherServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcvtv::TranscoderServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTranscoderServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcvtv::TranscoderServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcvtv::TranscoderServiceClientBuilder builder = new gcvtv::TranscoderServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcvv::VideoIntelligenceServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddVideoIntelligenceServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcvv::VideoIntelligenceServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcvv::VideoIntelligenceServiceClientBuilder builder = new gcvv::VideoIntelligenceServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ServiceCollectionExtensions.g.cs
@@ -44,6 +44,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gcvv::ImageAnnotatorClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddImageAnnotatorClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcvv::ImageAnnotatorClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcvv::ImageAnnotatorClientBuilder builder = new gcvv::ImageAnnotatorClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gcvv::ProductSearchClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -57,6 +73,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gcvv::ProductSearchClientBuilder builder = new gcvv::ProductSearchClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gcvv::ProductSearchClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddProductSearchClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcvv::ProductSearchClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcvv::ProductSearchClientBuilder builder = new gcvv::ProductSearchClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcvv::VmwareEngineClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddVmwareEngineClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcvv::VmwareEngineClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcvv::VmwareEngineClientBuilder builder = new gcvv::VmwareEngineClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1/ServiceCollectionExtensions.g.cs
@@ -46,5 +46,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcvv::VpcAccessServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddVpcAccessServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcvv::VpcAccessServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcvv::VpcAccessServiceClientBuilder builder = new gcvv::VpcAccessServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcwv::WebRiskServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddWebRiskServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcwv::WebRiskServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcwv::WebRiskServiceClientBuilder builder = new gcwv::WebRiskServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcwv::WebRiskServiceV1Beta1Client"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddWebRiskServiceV1Beta1Client(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcwv::WebRiskServiceV1Beta1ClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcwv::WebRiskServiceV1Beta1ClientBuilder builder = new gcwv::WebRiskServiceV1Beta1ClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gcwv::WebSecurityScannerClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddWebSecurityScannerClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcwv::WebSecurityScannerClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcwv::WebSecurityScannerClientBuilder builder = new gcwv::WebSecurityScannerClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcwev::ExecutionsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddExecutionsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcwev::ExecutionsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcwev::ExecutionsClientBuilder builder = new gcwev::ExecutionsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcwev::ExecutionsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddExecutionsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcwev::ExecutionsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcwev::ExecutionsClientBuilder builder = new gcwev::ExecutionsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1/ServiceCollectionExtensions.g.cs
@@ -44,5 +44,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcwv::WorkflowsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddWorkflowsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcwv::WorkflowsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcwv::WorkflowsClientBuilder builder = new gcwv::WorkflowsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcwv::WorkflowsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddWorkflowsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcwv::WorkflowsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcwv::WorkflowsClientBuilder builder = new gcwv::WorkflowsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gcwv::WorkstationsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddWorkstationsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gcwv::WorkstationsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gcwv::WorkstationsClientBuilder builder = new gcwv::WorkstationsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1/ServiceCollectionExtensions.g.cs
@@ -45,5 +45,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="giav::AccessContextManagerClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAccessContextManagerClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, giav::AccessContextManagerClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                giav::AccessContextManagerClientBuilder builder = new giav::AccessContextManagerClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.LongRunning/Google.LongRunning/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="lro::OperationsClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddOperationsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, lro::OperationsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                lro::OperationsClientBuilder builder = new lro::OperationsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gmav::AddressValidationClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAddressValidationClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gmav::AddressValidationClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gmav::AddressValidationClientBuilder builder = new gmav::AddressValidationClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gmfdv::DeliveryServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddDeliveryServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gmfdv::DeliveryServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gmfdv::DeliveryServiceClientBuilder builder = new gmfdv::DeliveryServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/ServiceCollectionExtensions.g.cs
@@ -42,6 +42,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 return builder.Build(provider);
             });
 
+        /// <summary>Adds a singleton <see cref="gmfv::TripServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddTripServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gmfv::TripServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gmfv::TripServiceClientBuilder builder = new gmfv::TripServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
         /// <summary>Adds a singleton <see cref="gmfv::VehicleServiceClient"/> to <paramref name="services"/>.</summary>
         /// <param name="services">
         /// The service collection to add the client to. The services are used to configure the client when requested.
@@ -55,6 +71,22 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gmfv::VehicleServiceClientBuilder builder = new gmfv::VehicleServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>Adds a singleton <see cref="gmfv::VehicleServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddVehicleServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gmfv::VehicleServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gmfv::VehicleServiceClientBuilder builder = new gmfv::VehicleServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gmmv::MapsPlatformDatasetsClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddMapsPlatformDatasetsClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gmmv::MapsPlatformDatasetsClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gmmv::MapsPlatformDatasetsClientBuilder builder = new gmmv::MapsPlatformDatasetsClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Maps.MapsPlatformDatasets.V1Alpha/Google.Maps.MapsPlatformDatasets.V1Alpha/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1Alpha/Google.Maps.MapsPlatformDatasets.V1Alpha/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gmmv::MapsPlatformDatasetsV1AlphaClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddMapsPlatformDatasetsV1AlphaClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gmmv::MapsPlatformDatasetsV1AlphaClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gmmv::MapsPlatformDatasetsV1AlphaClientBuilder builder = new gmmv::MapsPlatformDatasetsV1AlphaClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gmpv::PlacesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddPlacesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gmpv::PlacesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gmpv::PlacesClientBuilder builder = new gmpv::PlacesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gmrv::RoutesClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRoutesClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gmrv::RoutesClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gmrv::RoutesClientBuilder builder = new gmrv::RoutesClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/ServiceCollectionExtensions.g.cs
@@ -45,6 +45,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gscv::AccountLabelsServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAccountLabelsServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gscv::AccountLabelsServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gscv::AccountLabelsServiceClientBuilder builder = new gscv::AccountLabelsServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gscv::AccountsServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -59,6 +77,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gscv::AccountsServiceClientBuilder builder = new gscv::AccountsServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gscv::AccountsServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddAccountsServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gscv::AccountsServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gscv::AccountsServiceClientBuilder builder = new gscv::AccountsServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
 
@@ -81,6 +117,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gscv::CssProductInputsServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCssProductInputsServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gscv::CssProductInputsServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gscv::CssProductInputsServiceClientBuilder builder = new gscv::CssProductInputsServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gscv::CssProductsServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -95,6 +149,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gscv::CssProductsServiceClientBuilder builder = new gscv::CssProductsServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gscv::CssProductsServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddCssProductsServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gscv::CssProductsServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gscv::CssProductsServiceClientBuilder builder = new gscv::CssProductsServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gsmcv::ConversionSourcesServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddConversionSourcesServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gsmcv::ConversionSourcesServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gsmcv::ConversionSourcesServiceClientBuilder builder = new gsmcv::ConversionSourcesServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta/ServiceCollectionExtensions.g.cs
@@ -45,6 +45,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gsmiv::LocalInventoryServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddLocalInventoryServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gsmiv::LocalInventoryServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gsmiv::LocalInventoryServiceClientBuilder builder = new gsmiv::LocalInventoryServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gsmiv::RegionalInventoryServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -59,6 +77,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gsmiv::RegionalInventoryServiceClientBuilder builder = new gsmiv::RegionalInventoryServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gsmiv::RegionalInventoryServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddRegionalInventoryServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gsmiv::RegionalInventoryServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gsmiv::RegionalInventoryServiceClientBuilder builder = new gsmiv::RegionalInventoryServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta/ServiceCollectionExtensions.g.cs
@@ -45,6 +45,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gsmlv::LfpInventoryServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddLfpInventoryServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gsmlv::LfpInventoryServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gsmlv::LfpInventoryServiceClientBuilder builder = new gsmlv::LfpInventoryServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gsmlv::LfpSaleServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -63,6 +81,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
         /// <summary>
+        /// Adds a singleton <see cref="gsmlv::LfpSaleServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddLfpSaleServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gsmlv::LfpSaleServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gsmlv::LfpSaleServiceClientBuilder builder = new gsmlv::LfpSaleServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
         /// Adds a singleton <see cref="gsmlv::LfpStoreServiceClient"/> to <paramref name="services"/>.
         /// </summary>
         /// <param name="services">
@@ -77,6 +113,24 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 gsmlv::LfpStoreServiceClientBuilder builder = new gsmlv::LfpStoreServiceClientBuilder();
                 action?.Invoke(builder);
+                return builder.Build(provider);
+            });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gsmlv::LfpStoreServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddLfpStoreServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gsmlv::LfpStoreServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gsmlv::LfpStoreServiceClientBuilder builder = new gsmlv::LfpStoreServiceClientBuilder();
+                action?.Invoke(provider, builder);
                 return builder.Build(provider);
             });
     }

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta/ServiceCollectionExtensions.g.cs
@@ -43,5 +43,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>
+        /// Adds a singleton <see cref="gsmnv::NotificationsApiServiceClient"/> to <paramref name="services"/>.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddNotificationsApiServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gsmnv::NotificationsApiServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gsmnv::NotificationsApiServiceClientBuilder builder = new gsmnv::NotificationsApiServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Shopping.Merchant.Quota.V1Beta/Google.Shopping.Merchant.Quota.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1Beta/Google.Shopping.Merchant.Quota.V1Beta/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gsmqv::QuotaServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddQuotaServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gsmqv::QuotaServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gsmqv::QuotaServiceClientBuilder builder = new gsmqv::QuotaServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Google.Shopping.Merchant.Reports.V1Beta/Google.Shopping.Merchant.Reports.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.Reports.V1Beta/Google.Shopping.Merchant.Reports.V1Beta/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gsmrv::ReportServiceClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddReportServiceClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gsmrv::ReportServiceClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gsmrv::ReportServiceClientBuilder builder = new gsmrv::ReportServiceClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/apis/Grafeas.V1/Grafeas.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1/ServiceCollectionExtensions.g.cs
@@ -41,5 +41,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 action?.Invoke(builder);
                 return builder.Build(provider);
             });
+
+        /// <summary>Adds a singleton <see cref="gv::GrafeasClient"/> to <paramref name="services"/>.</summary>
+        /// <param name="services">
+        /// The service collection to add the client to. The services are used to configure the client when requested.
+        /// </param>
+        /// <param name="action">
+        /// An optional action to invoke on the client builder. This is invoked before services from
+        /// <paramref name="services"/> are used.
+        /// </param>
+        public static IServiceCollection AddGrafeasClient(this IServiceCollection services, sys::Action<sys::IServiceProvider, gv::GrafeasClientBuilder> action) =>
+            services.AddSingleton(provider =>
+            {
+                gv::GrafeasClientBuilder builder = new gv::GrafeasClientBuilder();
+                action?.Invoke(provider, builder);
+                return builder.Build(provider);
+            });
     }
 }

--- a/toolversions.sh
+++ b/toolversions.sh
@@ -13,7 +13,7 @@ declare -r DOTCOVER_VERSION=2019.3.4
 declare -r REPORTGENERATOR_VERSION=2.4.5.0
 declare -r PROTOC_VERSION=3.25.2
 declare -r GRPC_VERSION=2.60.0
-declare -r GAPIC_GENERATOR_VERSION=1.4.26
+declare -r GAPIC_GENERATOR_VERSION=1.4.27
 
 # Tools that only run under Windows (at the moment)
 declare -r DOTCOVER=$TOOL_PACKAGES/JetBrains.dotCover.CommandLineTools.$DOTCOVER_VERSION/tools/dotCover.exe


### PR DESCRIPTION
The regeneration highlighted a couple of APIs where the API catalog transport values are out of sync with Bazel - I'll address those separately.