### PR TITLE
chore: Update transports that have been changed in Bazel files

### DIFF
--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2064,7 +2064,8 @@
       "shortName": "discoveryengine",
       "serviceConfigFile": "discoveryengine_v1.yaml",
       "restNumericEnums": true,
-      "includeCommonResourcesProto": true
+      "includeCommonResourcesProto": true,
+      "transport": "grpc+rest"
     },
     {
       "id": "Google.Cloud.DiscoveryEngine.V1Beta",
@@ -5729,7 +5730,8 @@
       "shortName": "merchantapi",
       "serviceConfigFile": "merchantapi_v1beta.yaml",
       "restNumericEnums": true,
-      "includeCommonResourcesProto": true
+      "includeCommonResourcesProto": true,
+      "transport": "grpc+rest"
     },
     {
       "id": "Google.Shopping.Merchant.Lfp.V1Beta",


### PR DESCRIPTION
(We could potentially do this in the OwlBot script, but it's harder than it might seem - and eventually the transports should be in the service config anyway.)