### PR TITLE
Release Google.Cloud.Config.V1 version 1.5.0

### DIFF
--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1/Google.Cloud.Config.V1.csproj
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1/Google.Cloud.Config.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.4.0</Version>
+    <Version>1.5.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Infrastructure Manager API, which creates and manages Google Cloud Platform resources and infrastructure.</Description>

--- a/apis/Google.Cloud.Config.V1/docs/history.md
+++ b/apis/Google.Cloud.Config.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 1.5.0, released 2024-04-29
+
+### New features
+
+- Infrastructure manager supports 1.2.3, 1.3.10, 1.4.7, 1.5.7 versions of Terraform when creating a preview of a deployment ([commit 6bc09e9](https://github.com/googleapis/google-cloud-dotnet/commit/6bc09e9f58284ac8a8c7ed69970e1f86de16b447))
+- Annotations are now supported to help client tools identify deployments during automation ([commit 6bc09e9](https://github.com/googleapis/google-cloud-dotnet/commit/6bc09e9f58284ac8a8c7ed69970e1f86de16b447))
+
 ## Version 1.4.0, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1494,7 +1494,7 @@
     },
     {
       "id": "Google.Cloud.Config.V1",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "type": "grpc",
       "productName": "Infrastructure Manager",
       "productUrl": "https://cloud.google.com/infrastructure-manager/docs/overview",


### PR DESCRIPTION

Changes in this release:

### New features

- Infrastructure manager supports 1.2.3, 1.3.10, 1.4.7, 1.5.7 versions of Terraform when creating a preview of a deployment ([commit 6bc09e9](https://github.com/googleapis/google-cloud-dotnet/commit/6bc09e9f58284ac8a8c7ed69970e1f86de16b447))
- Annotations are now supported to help client tools identify deployments during automation ([commit 6bc09e9](https://github.com/googleapis/google-cloud-dotnet/commit/6bc09e9f58284ac8a8c7ed69970e1f86de16b447))
