### PR TITLE
Release Firestore libraries version 3.7.0

### DIFF
--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.6.0</Version>
+    <Version>3.7.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Low-level Google client library to access the Firestore API. Users are recommended to use the Google.Cloud.Firestore package instead.</Description>

--- a/apis/Google.Cloud.Firestore.V1/docs/history.md
+++ b/apis/Google.Cloud.Firestore.V1/docs/history.md
@@ -4,6 +4,12 @@ This package is primarily a dependency of Google.Cloud.Firestore. See the
 [Google.Cloud.Firestore version history](https://googleapis.dev/dotnet/Google.Cloud.Firestore/latest/history.html)
 for more details.
 
+## Version 3.7.0, released 2024-05-03
+
+### New features
+
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
 ## Version 3.6.0, released 2024-03-27
 
 ### New features

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.6.0</Version>
+    <Version>3.7.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Firestore API.</Description>

--- a/apis/Google.Cloud.Firestore/docs/history.md
+++ b/apis/Google.Cloud.Firestore/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.7.0, released 2024-05-03
+
+### Bug fixes
+
+- Retry more exceptions during transactions ([commit 027dd8b](https://github.com/googleapis/google-cloud-dotnet/commit/027dd8bc1fc2f638aa7305f996dc4a49ecc1ee41))
+
 ## Version 3.6.0, released 2024-03-27
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2388,7 +2388,7 @@
       "productName": "Firestore",
       "productUrl": "https://firebase.google.com/docs/firestore/",
       "listingDescription": "Firestore high-level library",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "type": "other",
       "metadataType": "GAPIC_MANUAL",
       "description": "Recommended Google client library to access the Firestore API.",
@@ -2419,7 +2419,7 @@
       "productName": "Firestore",
       "productUrl": "https://firebase.google.com",
       "listingDescription": "Firestore low-level API access",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "type": "grpc",
       "description": "Low-level Google client library to access the Firestore API. Users are recommended to use the Google.Cloud.Firestore package instead.",
       "tags": [

--- a/tools/Google.Cloud.Tools.ReleaseManager/History/overrides.json
+++ b/tools/Google.Cloud.Tools.ReleaseManager/History/overrides.json
@@ -43,4 +43,5 @@
   "5008946": "feat: Enable REST transport in selected APIs. Set GrpcAdapter=RestGrpcAdapter.Default in the client builder to use this transport",
   "aa471c9": "skip", // Enable requesting numeric enums
   "3927b62": "skip", // Regenerate all APIs with new generator; no user-significant API changes
+  "022fab2": "feat: Add IServiceCollection extension methods for client registration where an IServiceProvider is required."
 }


### PR DESCRIPTION

Changes in Google.Cloud.Firestore version 3.7.0:

### Bug fixes

- Retry more exceptions during transactions ([commit 027dd8b](https://github.com/googleapis/google-cloud-dotnet/commit/027dd8bc1fc2f638aa7305f996dc4a49ecc1ee41))

Changes in Google.Cloud.Firestore.V1 version 3.7.0:

### New features

- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))

Packages in this release:
- Release Google.Cloud.Firestore version 3.7.0
- Release Google.Cloud.Firestore.V1 version 3.7.0
