### PR TITLE
Release Google.Cloud.Dataplex.V1 version 3.0.0

### DIFF
--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.csproj
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.15.0</Version>
+    <Version>3.0.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataplex API, which is used to manage the lifecycle of data lakes.</Description>

--- a/apis/Google.Cloud.Dataplex.V1/docs/history.md
+++ b/apis/Google.Cloud.Dataplex.V1/docs/history.md
@@ -1,5 +1,26 @@
 # Version history
 
+## Version 3.0.0, released 2024-05-08
+
+### Bug fixes
+
+- **BREAKING CHANGE** An existing field `entry` is removed from message `.google.cloud.dataplex.v1.SearchEntriesResult` ([commit 7b1c647](https://github.com/googleapis/google-cloud-dotnet/commit/7b1c6470d13702eb16fd436ac74855b7718d908e))
+- **BREAKING CHANGE** An existing field `display_name` is removed from message `.google.cloud.dataplex.v1.SearchEntriesResult` ([commit 7b1c647](https://github.com/googleapis/google-cloud-dotnet/commit/7b1c6470d13702eb16fd436ac74855b7718d908e))
+- **BREAKING CHANGE** An existing field `entry_type` is removed from message `.google.cloud.dataplex.v1.SearchEntriesResult` ([commit 7b1c647](https://github.com/googleapis/google-cloud-dotnet/commit/7b1c6470d13702eb16fd436ac74855b7718d908e))
+- **BREAKING CHANGE** An existing field `modify_time` is removed from message `.google.cloud.dataplex.v1.SearchEntriesResult` ([commit 7b1c647](https://github.com/googleapis/google-cloud-dotnet/commit/7b1c6470d13702eb16fd436ac74855b7718d908e))
+- **BREAKING CHANGE** An existing field `fully_qualified_name` is removed from message `.google.cloud.dataplex.v1.SearchEntriesResult` ([commit 7b1c647](https://github.com/googleapis/google-cloud-dotnet/commit/7b1c6470d13702eb16fd436ac74855b7718d908e))
+- **BREAKING CHANGE** An existing field `description` is removed from message `.google.cloud.dataplex.v1.SearchEntriesResult` ([commit 7b1c647](https://github.com/googleapis/google-cloud-dotnet/commit/7b1c6470d13702eb16fd436ac74855b7718d908e))
+- **BREAKING CHANGE** An existing field `relative_resource` is removed from message `.google.cloud.dataplex.v1.SearchEntriesResult` ([commit 7b1c647](https://github.com/googleapis/google-cloud-dotnet/commit/7b1c6470d13702eb16fd436ac74855b7718d908e))
+
+### New features
+
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
+### Documentation improvements
+
+- A comment for field `aspects` in message `.google.cloud.dataplex.v1.Entry` is changed ([commit 7b1c647](https://github.com/googleapis/google-cloud-dotnet/commit/7b1c6470d13702eb16fd436ac74855b7718d908e))
+- A comment for field `filter` in message `.google.cloud.dataplex.v1.ListEntriesRequest` is changed ([commit 7b1c647](https://github.com/googleapis/google-cloud-dotnet/commit/7b1c6470d13702eb16fd436ac74855b7718d908e))
+
 ## Version 2.15.0, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1718,7 +1718,7 @@
     },
     {
       "id": "Google.Cloud.Dataplex.V1",
-      "version": "2.15.0",
+      "version": "3.0.0",
       "type": "grpc",
       "productName": "Cloud Dataplex",
       "productUrl": "https://cloud.google.com/dataplex/docs",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** An existing field `entry` is removed from message `.google.cloud.dataplex.v1.SearchEntriesResult` ([commit 7b1c647](https://github.com/googleapis/google-cloud-dotnet/commit/7b1c6470d13702eb16fd436ac74855b7718d908e))
- **BREAKING CHANGE** An existing field `display_name` is removed from message `.google.cloud.dataplex.v1.SearchEntriesResult` ([commit 7b1c647](https://github.com/googleapis/google-cloud-dotnet/commit/7b1c6470d13702eb16fd436ac74855b7718d908e))
- **BREAKING CHANGE** An existing field `entry_type` is removed from message `.google.cloud.dataplex.v1.SearchEntriesResult` ([commit 7b1c647](https://github.com/googleapis/google-cloud-dotnet/commit/7b1c6470d13702eb16fd436ac74855b7718d908e))
- **BREAKING CHANGE** An existing field `modify_time` is removed from message `.google.cloud.dataplex.v1.SearchEntriesResult` ([commit 7b1c647](https://github.com/googleapis/google-cloud-dotnet/commit/7b1c6470d13702eb16fd436ac74855b7718d908e))
- **BREAKING CHANGE** An existing field `fully_qualified_name` is removed from message `.google.cloud.dataplex.v1.SearchEntriesResult` ([commit 7b1c647](https://github.com/googleapis/google-cloud-dotnet/commit/7b1c6470d13702eb16fd436ac74855b7718d908e))
- **BREAKING CHANGE** An existing field `description` is removed from message `.google.cloud.dataplex.v1.SearchEntriesResult` ([commit 7b1c647](https://github.com/googleapis/google-cloud-dotnet/commit/7b1c6470d13702eb16fd436ac74855b7718d908e))
- **BREAKING CHANGE** An existing field `relative_resource` is removed from message `.google.cloud.dataplex.v1.SearchEntriesResult` ([commit 7b1c647](https://github.com/googleapis/google-cloud-dotnet/commit/7b1c6470d13702eb16fd436ac74855b7718d908e))

### New features

- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))

### Documentation improvements

- A comment for field `aspects` in message `.google.cloud.dataplex.v1.Entry` is changed ([commit 7b1c647](https://github.com/googleapis/google-cloud-dotnet/commit/7b1c6470d13702eb16fd436ac74855b7718d908e))
- A comment for field `filter` in message `.google.cloud.dataplex.v1.ListEntriesRequest` is changed ([commit 7b1c647](https://github.com/googleapis/google-cloud-dotnet/commit/7b1c6470d13702eb16fd436ac74855b7718d908e))
