### PR TITLE
Release Google.Cloud.AlloyDb.V1Alpha version 1.0.0-alpha08

### DIFF
--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.csproj
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha07</Version>
+    <Version>1.0.0-alpha08</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AlloyDB API (v1alpha). AlloyDB for PostgreSQL is an open source-compatible database service that provides a powerful option for migrating, modernizing, or building commercial-grade applications.</Description>

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-alpha08, released 2024-05-08
+
+### New features
+
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
 ## Version 1.0.0-alpha07, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -256,7 +256,7 @@
     },
     {
       "id": "Google.Cloud.AlloyDb.V1Alpha",
-      "version": "1.0.0-alpha07",
+      "version": "1.0.0-alpha08",
       "type": "grpc",
       "productName": "AlloyDB",
       "productUrl": "https://cloud.google.com/alloydb/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
