### PR TITLE
Release Google.Cloud.CloudControlsPartner.V1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.csproj
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Controls Partner API (v1) which provides insights about your customers and their Assured Workloads based on your Sovereign Controls by Partners offering.</Description>

--- a/apis/Google.Cloud.CloudControlsPartner.V1/docs/history.md
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2024-05-08
+
+### New features
+
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
 ## Version 1.0.0-beta01, released 2024-04-18
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1309,7 +1309,7 @@
     },
     {
       "id": "Google.Cloud.CloudControlsPartner.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Cloud Controls Partner",
       "productUrl": "https://cloud.google.com/sovereign-controls-by-partners/docs/sovereign-partners/reference/rest",


### PR DESCRIPTION

Changes in this release:

### New features

- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
