### PR TITLE
Release Google.Cloud.Dataform.V1Beta1 version 1.0.0-beta06

### DIFF
--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.csproj
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta05</Version>
+    <Version>1.0.0-beta06</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataform API (v1beta1) which allows you to develop and operationalize scalable data transformations pipelines in BigQuery using SQL.</Description>

--- a/apis/Google.Cloud.Dataform.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Dataform.V1Beta1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta06, released 2024-05-08
+
+### New features
+
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
 ## Version 1.0.0-beta05, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1693,7 +1693,7 @@
     },
     {
       "id": "Google.Cloud.Dataform.V1Beta1",
-      "version": "1.0.0-beta05",
+      "version": "1.0.0-beta06",
       "type": "grpc",
       "productName": "Dataform",
       "productUrl": "https://cloud.google.com/dataform",


### PR DESCRIPTION

Changes in this release:

### New features

- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
