### PR TITLE
Release Google.Cloud.Deploy.V1 version 2.16.0

### DIFF
--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.15.0</Version>
+    <Version>2.16.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Deploy API, which automates delivery of your applications to a series of target environments in a defined sequence.</Description>

--- a/apis/Google.Cloud.Deploy.V1/docs/history.md
+++ b/apis/Google.Cloud.Deploy.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.16.0, released 2024-05-08
+
+### New features
+
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
+### Documentation improvements
+
+- Small corrections to Cloud Deploy API documentation ([commit b2e5459](https://github.com/googleapis/google-cloud-dotnet/commit/b2e54591eb14e8ea6ad017e8f9593bc4bda0baf8))
+
 ## Version 2.15.0, released 2024-04-22
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1860,7 +1860,7 @@
     },
     {
       "id": "Google.Cloud.Deploy.V1",
-      "version": "2.15.0",
+      "version": "2.16.0",
       "type": "grpc",
       "productName": "Google Cloud Deploy",
       "productUrl": "https://cloud.google.com/deploy/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))

### Documentation improvements

- Small corrections to Cloud Deploy API documentation ([commit b2e5459](https://github.com/googleapis/google-cloud-dotnet/commit/b2e54591eb14e8ea6ad017e8f9593bc4bda0baf8))
