### PR TITLE
Release Google.Cloud.DiscoveryEngine.V1 version 1.0.0-beta06

### DIFF
--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.csproj
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta05</Version>
+    <Version>1.0.0-beta06</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Discovery Engine API (v1). Discovery Engine powers high-quality content recommendations on your digital properties for Discovery for Media.</Description>

--- a/apis/Google.Cloud.DiscoveryEngine.V1/docs/history.md
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta06, released 2024-05-08
+
+### New features
+
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
 ## Version 1.0.0-beta05, released 2024-04-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2046,7 +2046,7 @@
     },
     {
       "id": "Google.Cloud.DiscoveryEngine.V1",
-      "version": "1.0.0-beta05",
+      "version": "1.0.0-beta06",
       "type": "grpc",
       "productName": "Discovery Engine",
       "productUrl": "https://cloud.google.com/discovery-engine/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
