### PR TITLE
Release Google.Cloud.Dlp.V2 version 2.16.0

### DIFF
--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.csproj
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.15.0</Version>
+    <Version>2.16.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Data Loss Prevention API, which provides methods for detection of privacy-sensitive fragments in text, images, and Google Cloud Platform storage repositories.</Description>

--- a/apis/Google.Cloud.Dlp.V2/docs/history.md
+++ b/apis/Google.Cloud.Dlp.V2/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+## Version 2.16.0, released 2024-05-08
+
+### New features
+
+- Add RPCs for deleting TableDataProfiles ([commit 4c44194](https://github.com/googleapis/google-cloud-dotnet/commit/4c44194c2aa30cb7ff16aae08d31225f297563dc))
+- Add RPCs for enabling discovery of Cloud SQL ([commit 4c44194](https://github.com/googleapis/google-cloud-dotnet/commit/4c44194c2aa30cb7ff16aae08d31225f297563dc))
+- Add field to InspectJobs num_rows_processed for BigQuery inspect jobs ([commit 4c44194](https://github.com/googleapis/google-cloud-dotnet/commit/4c44194c2aa30cb7ff16aae08d31225f297563dc))
+- Add new countries for supported detectors ([commit 4c44194](https://github.com/googleapis/google-cloud-dotnet/commit/4c44194c2aa30cb7ff16aae08d31225f297563dc))
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
+### Documentation improvements
+
+- Updated method documentation ([commit 4c44194](https://github.com/googleapis/google-cloud-dotnet/commit/4c44194c2aa30cb7ff16aae08d31225f297563dc))
+
 ## Version 2.15.0, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2096,7 +2096,7 @@
       "protoPath": "google/privacy/dlp/v2",
       "productName": "Google Cloud Data Loss Prevention",
       "productUrl": "https://cloud.google.com/dlp/",
-      "version": "2.15.0",
+      "version": "2.16.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Data Loss Prevention API, which provides methods for detection of privacy-sensitive fragments in text, images, and Google Cloud Platform storage repositories.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add RPCs for deleting TableDataProfiles ([commit 4c44194](https://github.com/googleapis/google-cloud-dotnet/commit/4c44194c2aa30cb7ff16aae08d31225f297563dc))
- Add RPCs for enabling discovery of Cloud SQL ([commit 4c44194](https://github.com/googleapis/google-cloud-dotnet/commit/4c44194c2aa30cb7ff16aae08d31225f297563dc))
- Add field to InspectJobs num_rows_processed for BigQuery inspect jobs ([commit 4c44194](https://github.com/googleapis/google-cloud-dotnet/commit/4c44194c2aa30cb7ff16aae08d31225f297563dc))
- Add new countries for supported detectors ([commit 4c44194](https://github.com/googleapis/google-cloud-dotnet/commit/4c44194c2aa30cb7ff16aae08d31225f297563dc))
- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))

### Documentation improvements

- Updated method documentation ([commit 4c44194](https://github.com/googleapis/google-cloud-dotnet/commit/4c44194c2aa30cb7ff16aae08d31225f297563dc))
