### PR TITLE
Release Google.Cloud.Firestore.Admin.V1 version 3.9.0

### DIFF
--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.csproj
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.8.0</Version>
+    <Version>3.9.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Firestore Admin API.</Description>

--- a/apis/Google.Cloud.Firestore.Admin.V1/docs/history.md
+++ b/apis/Google.Cloud.Firestore.Admin.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 3.9.0, released 2024-05-08
+
+### New features
+
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
+### Documentation improvements
+
+- Allow 14 week backup retention for Firestore daily backups ([commit 484b7d9](https://github.com/googleapis/google-cloud-dotnet/commit/484b7d946753effa6c5faa8ebd1192f57846e624))
+- Correct BackupSchedule recurrence docs that mentioned specific time of day ([commit d41af41](https://github.com/googleapis/google-cloud-dotnet/commit/d41af41616ae720d5b96e640f9d0a50d83582f3e))
+
 ## Version 3.8.0, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2365,7 +2365,7 @@
       "listingDescription": "Firestore Administration (e.g. index management)",
       "productName": "Firestore Admin",
       "productUrl": "https://firebase.google.com",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Firestore Admin API.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))

### Documentation improvements

- Allow 14 week backup retention for Firestore daily backups ([commit 484b7d9](https://github.com/googleapis/google-cloud-dotnet/commit/484b7d946753effa6c5faa8ebd1192f57846e624))
- Correct BackupSchedule recurrence docs that mentioned specific time of day ([commit d41af41](https://github.com/googleapis/google-cloud-dotnet/commit/d41af41616ae720d5b96e640f9d0a50d83582f3e))
