### PR TITLE
Release Google.Cloud.Kms.V1 version 3.11.0

### DIFF
--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.csproj
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.10.0</Version>
+    <Version>3.11.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Key Management Service API, which manages encryption for your cloud services the same way you do on-premises. You can generate, use, rotate, and destroy AES256 encryption keys.</Description>

--- a/apis/Google.Cloud.Kms.V1/docs/history.md
+++ b/apis/Google.Cloud.Kms.V1/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 3.11.0, released 2024-05-08
+
+### New features
+
+- Add client library for KMS Autokey service, which enables automated KMS key provision and management ([commit 5ff96b3](https://github.com/googleapis/google-cloud-dotnet/commit/5ff96b3bb71b5732b4bc9d0a21f195440a7ac1d3))
+- Introduce Long-Running Operations (LRO) for KMS ([commit 3020530](https://github.com/googleapis/google-cloud-dotnet/commit/3020530fd4cac7f9c8185059b9e69091eb89afe6))
+- Support the ED25519 asymmetric signing algorithm ([commit 820f2ec](https://github.com/googleapis/google-cloud-dotnet/commit/820f2ec4dc8134c0a63434a93b930bb88e3788e1))
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
+### Documentation improvements
+
+- In google.cloud.kms.v1.PublicKey, pem field is always populated ([commit 790ddc8](https://github.com/googleapis/google-cloud-dotnet/commit/790ddc8e9191b3652679ab54e7cf8c5f74518002))
+
 ## Version 3.10.0, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2815,7 +2815,7 @@
       "protoPath": "google/cloud/kms/v1",
       "productName": "Google Cloud Key Management Service",
       "productUrl": "https://cloud.google.com/kms/",
-      "version": "3.10.0",
+      "version": "3.11.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Key Management Service API, which manages encryption for your cloud services the same way you do on-premises. You can generate, use, rotate, and destroy AES256 encryption keys.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Add client library for KMS Autokey service, which enables automated KMS key provision and management ([commit 5ff96b3](https://github.com/googleapis/google-cloud-dotnet/commit/5ff96b3bb71b5732b4bc9d0a21f195440a7ac1d3))
- Introduce Long-Running Operations (LRO) for KMS ([commit 3020530](https://github.com/googleapis/google-cloud-dotnet/commit/3020530fd4cac7f9c8185059b9e69091eb89afe6))
- Support the ED25519 asymmetric signing algorithm ([commit 820f2ec](https://github.com/googleapis/google-cloud-dotnet/commit/820f2ec4dc8134c0a63434a93b930bb88e3788e1))
- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))

### Documentation improvements

- In google.cloud.kms.v1.PublicKey, pem field is always populated ([commit 790ddc8](https://github.com/googleapis/google-cloud-dotnet/commit/790ddc8e9191b3652679ab54e7cf8c5f74518002))
