### PR TITLE
Release Google.Cloud.LifeSciences.V2Beta version 2.0.0-beta06

### DIFF
--- a/apis/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta.csproj
+++ b/apis/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta05</Version>
+    <Version>2.0.0-beta06</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Life Sciences API, which is a suite of services and tools for managing, processing, and transforming life sciences data.</Description>

--- a/apis/Google.Cloud.LifeSciences.V2Beta/docs/history.md
+++ b/apis/Google.Cloud.LifeSciences.V2Beta/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.0.0-beta06, released 2024-05-08
+
+### New features
+
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
 ## Version 2.0.0-beta05, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2876,7 +2876,7 @@
     },
     {
       "id": "Google.Cloud.LifeSciences.V2Beta",
-      "version": "2.0.0-beta05",
+      "version": "2.0.0-beta06",
       "type": "grpc",
       "productName": "Cloud Life Sciences",
       "productUrl": "https://cloud.google.com/life-sciences/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
