### PR TITLE
Release Google.Cloud.Parallelstore.V1Beta version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.csproj
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to manage the Parallelstore high performance, managed parallel file service.</Description>

--- a/apis/Google.Cloud.Parallelstore.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2024-05-08
+
+### New features
+
+- Add ImportData and ExportData RPCs ([commit aded486](https://github.com/googleapis/google-cloud-dotnet/commit/aded48685ab1ba8ad1fc117ed4f66ef7561356ec))
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
+### Documentation improvements
+
+- Fix typo in Instance.reserved_ip_range field doc ([commit aded486](https://github.com/googleapis/google-cloud-dotnet/commit/aded48685ab1ba8ad1fc117ed4f66ef7561356ec))
+
 ## Version 1.0.0-beta01, released 2024-04-18
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3610,7 +3610,7 @@
     },
     {
       "id": "Google.Cloud.Parallelstore.V1Beta",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Parallelstore",
       "productUrl": "http://cloud/parallelstore?hl=en",


### PR DESCRIPTION

Changes in this release:

### New features

- Add ImportData and ExportData RPCs ([commit aded486](https://github.com/googleapis/google-cloud-dotnet/commit/aded48685ab1ba8ad1fc117ed4f66ef7561356ec))
- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))

### Documentation improvements

- Fix typo in Instance.reserved_ip_range field doc ([commit aded486](https://github.com/googleapis/google-cloud-dotnet/commit/aded48685ab1ba8ad1fc117ed4f66ef7561356ec))
