### PR TITLE
Release Google.Cloud.PrivateCatalog.V1Beta1 version 2.0.0-beta05

### DIFF
--- a/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1.csproj
+++ b/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta04</Version>
+    <Version>2.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Private Catalog API, which enables Cloud users to discover private catalogs and products in their organizations.</Description>

--- a/apis/Google.Cloud.PrivateCatalog.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.PrivateCatalog.V1Beta1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.0.0-beta05, released 2024-05-08
+
+### New features
+
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
 ## Version 2.0.0-beta04, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3718,7 +3718,7 @@
     },
     {
       "id": "Google.Cloud.PrivateCatalog.V1Beta1",
-      "version": "2.0.0-beta04",
+      "version": "2.0.0-beta05",
       "type": "grpc",
       "productName": "Cloud Private Catalog",
       "productUrl": "https://cloud.google.com/private-catalog/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
