### PR TITLE
Release Google.Cloud.SecretManager.V1Beta2 version 1.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.csproj
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Secret Manager API (v1beta2).</Description>

--- a/apis/Google.Cloud.SecretManager.V1Beta2/docs/history.md
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2024-05-08
+
+### New features
+
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
 ## Version 1.0.0-beta02, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4095,7 +4095,7 @@
       "protoPath": "google/cloud/secretmanager/v1beta2",
       "productName": "Secret Manager",
       "productUrl": "https://cloud.google.com/secret-manager",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "description": "Recommended Google client library to access the Secret Manager API (v1beta2).",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
