### PR TITLE
Release Google.Cloud.SecurityCenterManagement.V1 version 1.0.0-beta04

### DIFF
--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.csproj
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Security Command Center Management API, a built-in security and risk management solution for Google Cloud.</Description>

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/docs/history.md
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta04, released 2024-05-08
+
+### New features
+
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
 ## Version 1.0.0-beta03, released 2024-03-26
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4300,7 +4300,7 @@
     },
     {
       "id": "Google.Cloud.SecurityCenterManagement.V1",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0-beta04",
       "type": "grpc",
       "productName": "Security Center Management",
       "productUrl": "https://cloud.google.com/security-command-center/docs/reference/security-center-management/rest",


### PR DESCRIPTION

Changes in this release:

### New features

- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
