### PR TITLE
Release Google.Cloud.Storage.Control.V2 version 1.0.0-beta04

### DIFF
--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.csproj
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Storage Control API (v2), providing control-plane functionality for Google Cloud Storage.</Description>

--- a/apis/Google.Cloud.Storage.Control.V2/docs/history.md
+++ b/apis/Google.Cloud.Storage.Control.V2/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 1.0.0-beta04, released 2024-05-08
+
+### Bug fixes
+
+- **BREAKING CHANGE** An existing resource pattern value `projects/{project}/buckets/{bucket}/managedFolders/{managedFolder=**}` to resource definition `storage.googleapis.com/ManagedFolder` is removed ([commit 160d32c](https://github.com/googleapis/google-cloud-dotnet/commit/160d32cd7ff78ae2aeeb9aa6383c8212b27d3b67))
+
+### New features
+
+- A new resource pattern value `projects/{project}/buckets/{bucket}/managedFolders/{managed_folder=**}` added to the resource definition `storage.googleapis.com/ManagedFolder` ([commit 160d32c](https://github.com/googleapis/google-cloud-dotnet/commit/160d32cd7ff78ae2aeeb9aa6383c8212b27d3b67))
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
 ## Version 1.0.0-beta03, released 2024-04-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4661,7 +4661,7 @@
     },
     {
       "id": "Google.Cloud.Storage.Control.V2",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0-beta04",
       "type": "grpc",
       "productName": "Cloud Storage",
       "productUrl": "https://cloud.google.com/storage/docs/overview",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** An existing resource pattern value `projects/{project}/buckets/{bucket}/managedFolders/{managedFolder=**}` to resource definition `storage.googleapis.com/ManagedFolder` is removed ([commit 160d32c](https://github.com/googleapis/google-cloud-dotnet/commit/160d32cd7ff78ae2aeeb9aa6383c8212b27d3b67))

### New features

- A new resource pattern value `projects/{project}/buckets/{bucket}/managedFolders/{managed_folder=**}` added to the resource definition `storage.googleapis.com/ManagedFolder` ([commit 160d32c](https://github.com/googleapis/google-cloud-dotnet/commit/160d32cd7ff78ae2aeeb9aa6383c8212b27d3b67))
- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
