### PR TITLE
Release Google.Cloud.TextToSpeech.V1Beta1 version 2.0.0-beta07

### DIFF
--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.csproj
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta06</Version>
+    <Version>2.0.0-beta07</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Text-to-Speech API v1beta1, synthesizes natural-sounding speech by applying powerful neural network models.</Description>

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.0.0-beta07, released 2024-05-08
+
+### New features
+
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
 ## Version 2.0.0-beta06, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4933,7 +4933,7 @@
     },
     {
       "id": "Google.Cloud.TextToSpeech.V1Beta1",
-      "version": "2.0.0-beta06",
+      "version": "2.0.0-beta07",
       "type": "grpc",
       "productName": "Google Cloud Text-to-Speech",
       "productUrl": "https://cloud.google.com/text-to-speech",


### PR DESCRIPTION

Changes in this release:

### New features

- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
