### PR TITLE
Release Google.Shopping.Type version 1.0.0-beta06

### DIFF
--- a/apis/Google.Shopping.Type/Google.Shopping.Type/Google.Shopping.Type.csproj
+++ b/apis/Google.Shopping.Type/Google.Shopping.Type/Google.Shopping.Type.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta05</Version>
+    <Version>1.0.0-beta06</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Version-agnostic types for Shopping APIs.</Description>

--- a/apis/Google.Shopping.Type/docs/history.md
+++ b/apis/Google.Shopping.Type/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.0.0-beta06, released 2024-05-08
+
+### New features
+
+- Add `Weight` to common types for Shopping APIs to be used for accounts bundle ([commit f73940b](https://github.com/googleapis/google-cloud-dotnet/commit/f73940b4eaa5619c460c77d24a018634039b95f0))
+
+### Documentation improvements
+
+- A comment for field `amount_micros` in message `.google.shopping.type.Price` is changed ([commit f73940b](https://github.com/googleapis/google-cloud-dotnet/commit/f73940b4eaa5619c460c77d24a018634039b95f0))
+
 ## Version 1.0.0-beta05, released 2024-03-28
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5845,7 +5845,7 @@
     },
     {
       "id": "Google.Shopping.Type",
-      "version": "1.0.0-beta05",
+      "version": "1.0.0-beta06",
       "type": "other",
       "description": "Version-agnostic types for Shopping APIs.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Add `Weight` to common types for Shopping APIs to be used for accounts bundle ([commit f73940b](https://github.com/googleapis/google-cloud-dotnet/commit/f73940b4eaa5619c460c77d24a018634039b95f0))

### Documentation improvements

- A comment for field `amount_micros` in message `.google.shopping.type.Price` is changed ([commit f73940b](https://github.com/googleapis/google-cloud-dotnet/commit/f73940b4eaa5619c460c77d24a018634039b95f0))
