### PR TITLE
Release Google.Cloud.ApiKeys.V2 version 1.4.0

### DIFF
--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.csproj
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the API Keys API (v2), which manages the API keys associated with developer projects.</Description>

--- a/apis/Google.Cloud.ApiKeys.V2/docs/history.md
+++ b/apis/Google.Cloud.ApiKeys.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.4.0, released 2024-05-13
+
+### New features
+
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
 ## Version 1.3.0, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -348,7 +348,7 @@
     },
     {
       "id": "Google.Cloud.ApiKeys.V2",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "type": "grpc",
       "productName": "API Keys",
       "productUrl": "https://cloud.google.com/api-keys/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
