### PR TITLE
Release Google.Cloud.Batch.V1Alpha version 1.0.0-alpha28

### DIFF
--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha27</Version>
+    <Version>1.0.0-alpha28</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1alpha), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 1.0.0-alpha28, released 2024-05-13
+
+### New features
+
+- Update description on allowed_locations in LocationPolicy field ([commit fb760fc](https://github.com/googleapis/google-cloud-dotnet/commit/fb760fc31a58b8adbd3b7a471147bf2f331e3d0f))
+- Add UpdateJob API to update the job spec, only task_count is supported now ([commit fb760fc](https://github.com/googleapis/google-cloud-dotnet/commit/fb760fc31a58b8adbd3b7a471147bf2f331e3d0f))
+
+### Documentation improvements
+
+- Updated comments ([commit fb760fc](https://github.com/googleapis/google-cloud-dotnet/commit/fb760fc31a58b8adbd3b7a471147bf2f331e3d0f))
+
 ## Version 1.0.0-alpha27, released 2024-05-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -711,7 +711,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1Alpha",
-      "version": "1.0.0-alpha27",
+      "version": "1.0.0-alpha28",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Update description on allowed_locations in LocationPolicy field ([commit fb760fc](https://github.com/googleapis/google-cloud-dotnet/commit/fb760fc31a58b8adbd3b7a471147bf2f331e3d0f))
- Add UpdateJob API to update the job spec, only task_count is supported now ([commit fb760fc](https://github.com/googleapis/google-cloud-dotnet/commit/fb760fc31a58b8adbd3b7a471147bf2f331e3d0f))

### Documentation improvements

- Updated comments ([commit fb760fc](https://github.com/googleapis/google-cloud-dotnet/commit/fb760fc31a58b8adbd3b7a471147bf2f331e3d0f))
