### PR TITLE
Release Google.Cloud.BeyondCorp.ClientGateways.V1 version 1.3.0

### DIFF
--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.csproj
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BeyondCorp Enterprise Client Gateways API.</Description>

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/docs/history.md
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.3.0, released 2024-05-13
+
+### New features
+
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
 ## Version 1.2.0, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -800,7 +800,7 @@
     },
     {
       "id": "Google.Cloud.BeyondCorp.ClientGateways.V1",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "type": "grpc",
       "productName": "BeyondCorp Client Gateways",
       "productUrl": "https://cloud.google.com/beyondcorp-enterprise",


### PR DESCRIPTION

Changes in this release:

### New features

- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
