### PR TITLE
Release Google.Cloud.Billing.Budgets.V1 version 2.6.0

### DIFF
--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.csproj
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Cloud Billing Budget API v1. This API stores Cloud Billing budgets, which define a budget plan and the rules to execute as spend is tracked against that plan.</Description>

--- a/apis/Google.Cloud.Billing.Budgets.V1/docs/history.md
+++ b/apis/Google.Cloud.Billing.Budgets.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.6.0, released 2024-05-13
+
+### New features
+
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
 ## Version 2.5.0, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1109,7 +1109,7 @@
     },
     {
       "id": "Google.Cloud.Billing.Budgets.V1",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "type": "grpc",
       "productName": "Cloud Billing Budget",
       "productUrl": "https://cloud.google.com/billing/docs/how-to/budget-api-overview",


### PR DESCRIPTION

Changes in this release:

### New features

- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
