### PR TITLE
Release Google.Cloud.BinaryAuthorization.V1 version 2.5.0

### DIFF
--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.csproj
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Binary Authorization API v1, providing policy control for images deployed to Kubernetes Engine clusters.</Description>

--- a/apis/Google.Cloud.BinaryAuthorization.V1/docs/history.md
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.5.0, released 2024-05-13
+
+### New features
+
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
 ## Version 2.4.0, released 2024-03-28
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1171,7 +1171,7 @@
     },
     {
       "id": "Google.Cloud.BinaryAuthorization.V1",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "type": "grpc",
       "productName": "Binary Authorization",
       "productUrl": "https://cloud.google.com/binary-authorization/docs/reference/rpc",


### PR DESCRIPTION

Changes in this release:

### New features

- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
