### PR TITLE
Release Google.Cloud.CertificateManager.V1 version 2.7.0

### DIFF
--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.csproj
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Certificate Manager API, which lets you acquire and manage TLS (SSL) certificates for use with Cloud Load Balancing</Description>

--- a/apis/Google.Cloud.CertificateManager.V1/docs/history.md
+++ b/apis/Google.Cloud.CertificateManager.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.7.0, released 2024-05-13
+
+### New features
+
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
 ## Version 2.6.0, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1219,7 +1219,7 @@
     },
     {
       "id": "Google.Cloud.CertificateManager.V1",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "type": "grpc",
       "productName": "Certificate Manager",
       "productUrl": "https://cloud.google.com/certificate-manager/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
