### PR TITLE
Release Google.Cloud.ConfidentialComputing.V1 version 1.5.0

### DIFF
--- a/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.csproj
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.4.0</Version>
+    <Version>1.5.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Confidential Computing API (v1)</Description>

--- a/apis/Google.Cloud.ConfidentialComputing.V1/docs/history.md
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.5.0, released 2024-05-13
+
+### New features
+
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
 ## Version 1.4.0, released 2024-03-27
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1446,7 +1446,7 @@
     },
     {
       "id": "Google.Cloud.ConfidentialComputing.V1",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "type": "grpc",
       "productName": "Confidential Computing",
       "productUrl": "https://cloud.google.com/confidential-computing",


### PR DESCRIPTION

Changes in this release:

### New features

- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
