### PR TITLE
Release Google.Cloud.GkeMultiCloud.V1 version 2.6.0

### DIFF
--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.csproj
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Anthos Multi-Cloud API, which provides a way to manage Kubernetes clusters that run on AWS and Azure infrastructure using the Anthos Multi-Cloud API. Combined with Connect, you can manage Kubernetes clusters on Google Cloud, AWS, and Azure from the Google Cloud Console.  When you create a cluster with Anthos Multi-Cloud, Google creates the resources needed and brings up a cluster on your behalf. You can deploy workloads with the Anthos Multi-Cloud API or the gcloud and kubectl command-line tools.</Description>

--- a/apis/Google.Cloud.GkeMultiCloud.V1/docs/history.md
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 2.6.0, released 2024-05-14
+
+### New features
+
+- Option to ignore_errors while deleting Azure clusters / nodepools ([commit 564312f](https://github.com/googleapis/google-cloud-dotnet/commit/564312fafe111033b4f45180097c60ac02f5ddf4))
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
 ## Version 2.5.0, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2626,7 +2626,7 @@
     },
     {
       "id": "Google.Cloud.GkeMultiCloud.V1",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "type": "grpc",
       "productName": "Anthos Multi-Cloud",
       "productUrl": "https://cloud.google.com/anthos/clusters/docs/multi-cloud",


### PR DESCRIPTION

Changes in this release:

### New features

- Option to ignore_errors while deleting Azure clusters / nodepools ([commit 564312f](https://github.com/googleapis/google-cloud-dotnet/commit/564312fafe111033b4f45180097c60ac02f5ddf4))
- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
