### PR TITLE
Release Google.Cloud.Iam.V1 version 3.3.0

### DIFF
--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.csproj
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.2.0</Version>
+    <Version>3.3.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>gRPC services for the Google Identity and Access Management API. This library is typically used as a dependency for other API client libraries.</Description>

--- a/apis/Google.Cloud.Iam.V1/docs/history.md
+++ b/apis/Google.Cloud.Iam.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.3.0, released 2024-05-14
+
+### New features
+
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
 ## Version 3.2.0, released 2024-03-25
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2700,7 +2700,7 @@
       "protoPath": "google/iam/v1",
       "productName": "Google Cloud Identity and Access Management (IAM)",
       "productUrl": "https://cloud.google.com/iam/",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "type": "grpc",
       "metadataType": "CORE",
       "description": "gRPC services for the Google Identity and Access Management API. This library is typically used as a dependency for other API client libraries.",


### PR DESCRIPTION

Changes in this release:

### New features

- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
