### PR TITLE
Release Google.Cloud.NetworkManagement.V1 version 2.10.0

### DIFF
--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.csproj
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.9.0</Version>
+    <Version>2.10.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Network Management API, which provides a collection of network performance monitoring and diagnostic capabilities.</Description>

--- a/apis/Google.Cloud.NetworkManagement.V1/docs/history.md
+++ b/apis/Google.Cloud.NetworkManagement.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.10.0, released 2024-05-14
+
+### New features
+
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
 ## Version 2.9.0, released 2024-03-28
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3289,7 +3289,7 @@
     },
     {
       "id": "Google.Cloud.NetworkManagement.V1",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "type": "grpc",
       "productName": "Network Management",
       "productUrl": "https://cloud.google.com/network-intelligence-center/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
