### PR TITLE
Release Google.Cloud.Retail.V2 version 2.9.0

### DIFF
--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.csproj
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.8.0</Version>
+    <Version>2.9.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Cloud Retail service enables customers to build end-to-end personalized recommendation systems without requiring a high level of expertise in machine learning, recommendation system, or Google Cloud.</Description>

--- a/apis/Google.Cloud.Retail.V2/docs/history.md
+++ b/apis/Google.Cloud.Retail.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.9.0, released 2024-05-14
+
+### New features
+
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
 ## Version 2.8.0, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3999,7 +3999,7 @@
     },
     {
       "id": "Google.Cloud.Retail.V2",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "type": "grpc",
       "productName": "Retail",
       "productUrl": "https://cloud.google.com/retail/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
