### PR TITLE
Release Google.Cloud.Security.PrivateCA.V1 version 3.8.0

### DIFF
--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.csproj
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.7.0</Version>
+    <Version>3.8.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Certificate Authority Service API version v1. The Certificate Authority Service API is a highly-available, scalable service that enables you to simplify and automate the management of private certificate authorities (CAs) while staying in control of your private keys.</Description>

--- a/apis/Google.Cloud.Security.PrivateCA.V1/docs/history.md
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.8.0, released 2024-05-14
+
+### New features
+
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
 ## Version 3.7.0, released 2024-04-19
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4163,7 +4163,7 @@
     },
     {
       "id": "Google.Cloud.Security.PrivateCA.V1",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "type": "grpc",
       "productName": "Certificate Authority",
       "productUrl": "https://cloud.google.com/certificate-authority-service/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
