### PR TITLE
Release Google.Cloud.Video.Transcoder.V1 version 2.9.0

### DIFF
--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.csproj
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.8.0</Version>
+    <Version>2.9.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Transcoder API version v1, which converts video files into formats suitable for consumer distribution.</Description>

--- a/apis/Google.Cloud.Video.Transcoder.V1/docs/history.md
+++ b/apis/Google.Cloud.Video.Transcoder.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.9.0, released 2024-05-14
+
+### New features
+
+- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+
 ## Version 2.8.0, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5126,7 +5126,7 @@
     },
     {
       "id": "Google.Cloud.Video.Transcoder.V1",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "type": "grpc",
       "productName": "Transcoder",
       "productUrl": "https://cloud.google.com/transcoder/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
