### PR TITLE
tools: Allow separation of local release branch creation and push

### DIFF
--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/BatchReleaseConfig.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/BatchReleaseConfig.cs
@@ -89,6 +89,12 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
         /// </summary>
         public string LastReleaseBefore { get; set; }
 
+        /// <summary>
+        /// When true, release branches are created but not pushed (so no PRs are created).
+        /// The "push-releases" command can be used to perform the push later.
+        /// </summary>
+        public bool DeferPush { get; set; }
+
         internal IEnumerable<IBatchCriterion> GetCriteria()
         {
             if (KnownCommits is object)

--- a/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/ReleaseProposal.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/BatchRelease/ReleaseProposal.cs
@@ -131,7 +131,11 @@ namespace Google.Cloud.Tools.ReleaseManager.BatchRelease
             new SetVersionCommand().InternalExecute(Id, NewVersion.ToString(), quiet: true);
             ModifiedHistoryFile.Save(HistoryFile.GetPathForPackage(Id));
             new CommitCommand().InternalExecute();
-            new PushCommand().InternalExecute();
+
+            if (!config.DeferPush)
+            {
+                new PushCommand().InternalExecute();
+            }
 
             // Go back to our current branch
             Commands.Checkout(repo, original);

--- a/tools/Google.Cloud.Tools.ReleaseManager/PushReleaseBranchesCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/PushReleaseBranchesCommand.cs
@@ -1,0 +1,48 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using LibGit2Sharp;
+using System;
+using System.Linq;
+using Repository = LibGit2Sharp.Repository;
+
+namespace Google.Cloud.Tools.ReleaseManager;
+
+public sealed class PushReleaseBranchesCommand : CommandBase
+{
+    public PushReleaseBranchesCommand()
+        : base("push-releases", "Push all branches with a name starting with 'release-'")
+    {
+    }
+
+    protected override int ExecuteImpl(string[] args)
+    {
+        var root = DirectoryLayout.DetermineRootDirectory();
+        using var repo = new Repository(root);
+
+        var originalBranch = repo.Head;
+        var releaseBranches = repo.Branches.Where(b => b.FriendlyName.StartsWith("release-")).ToList();
+
+        foreach (var branch in releaseBranches)
+        {
+            Console.WriteLine($"Releasing {branch.FriendlyName}");
+            Commands.Checkout(repo, branch);
+            new PushCommand().InternalExecute();
+        }
+
+        Commands.Checkout(repo, originalBranch);
+        return 0;
+    }
+}


### PR DESCRIPTION
The push part takes a while, and doesn't need to be interactive. Separating this from the branch creation should allow for a simpler release process.