### PR TITLE
Release Google.Cloud.NetApp.V1 version 1.3.0

### DIFF
--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.csproj
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud NetApp Volumes API, which is a fully-managed, cloud-based data storage service that provides advanced data management capabilities and highly scalable performance with global availability.</Description>
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.3.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.NetApp.V1/docs/history.md
+++ b/apis/Google.Cloud.NetApp.V1/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+## Version 1.3.0, released 2024-05-17
+
+### New features
+
+- Add a new Service Level FLEX ([commit 77da572](https://github.com/googleapis/google-cloud-dotnet/commit/77da5720c8820c47d6738502351ecc4edd76eb73))
+- Add Tiering Policy to Volume ([commit 77da572](https://github.com/googleapis/google-cloud-dotnet/commit/77da5720c8820c47d6738502351ecc4edd76eb73))
+- Add backup chain bytes to BackupConfig in Volume ([commit 77da572](https://github.com/googleapis/google-cloud-dotnet/commit/77da5720c8820c47d6738502351ecc4edd76eb73))
+- Add Location metadata support ([commit 77da572](https://github.com/googleapis/google-cloud-dotnet/commit/77da5720c8820c47d6738502351ecc4edd76eb73))
+
 ## Version 1.2.0, released 2024-05-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3221,7 +3221,7 @@
     },
     {
       "id": "Google.Cloud.NetApp.V1",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "type": "grpc",
       "productName": "NetApp",
       "productUrl": "https://cloud.google.com/netapp/volumes/docs/discover/overview",
@@ -3232,8 +3232,8 @@
         "availability"
       ],
       "dependencies": {
-        "Google.Cloud.Location": "2.2.0",
-        "Google.LongRunning": "3.2.0"
+        "Google.Cloud.Location": "2.3.0",
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/netapp/v1",


### PR DESCRIPTION

Changes in this release:

### New features

- Add a new Service Level FLEX ([commit 77da572](https://github.com/googleapis/google-cloud-dotnet/commit/77da5720c8820c47d6738502351ecc4edd76eb73))
- Add Tiering Policy to Volume ([commit 77da572](https://github.com/googleapis/google-cloud-dotnet/commit/77da5720c8820c47d6738502351ecc4edd76eb73))
- Add backup chain bytes to BackupConfig in Volume ([commit 77da572](https://github.com/googleapis/google-cloud-dotnet/commit/77da5720c8820c47d6738502351ecc4edd76eb73))
- Add Location metadata support ([commit 77da572](https://github.com/googleapis/google-cloud-dotnet/commit/77da5720c8820c47d6738502351ecc4edd76eb73))
