### PR TITLE
Release Google.Cloud.Parallelstore.V1Beta version 1.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.csproj
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to manage the Parallelstore high performance, managed parallel file service.</Description>
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.3.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Parallelstore.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/docs/history.md
@@ -1,5 +1,40 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2024-05-17
+
+### Bug fixes
+
+- **BREAKING CHANGE** An existing field `create_time` is removed from message `.google.cloud.parallelstore.v1beta.TransferOperationMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
+- **BREAKING CHANGE** An existing field `end_time` is removed from message `.google.cloud.parallelstore.v1beta.TransferOperationMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
+- **BREAKING CHANGE** An existing field `source` is removed from message `.google.cloud.parallelstore.v1beta.TransferOperationMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
+- **BREAKING CHANGE** An existing field `destination` is removed from message `.google.cloud.parallelstore.v1beta.TransferOperationMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
+
+### New features
+
+- A new field `create_time` is added to message `.google.cloud.parallelstore.v1beta.ImportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
+- A new field `end_time` is added to message `.google.cloud.parallelstore.v1beta.ImportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
+- A new field `target` is added to message `.google.cloud.parallelstore.v1beta.ImportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
+- A new field `verb` is added to message `.google.cloud.parallelstore.v1beta.ImportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
+- A new field `status_message` is added to message `.google.cloud.parallelstore.v1beta.ImportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
+- A new field `requested_cancellation` is added to message `.google.cloud.parallelstore.v1beta.ImportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
+- A new field `api_version` is added to message `.google.cloud.parallelstore.v1beta.ImportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
+- A new field `create_time` is added to message `.google.cloud.parallelstore.v1beta.ExportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
+- A new field `end_time` is added to message `.google.cloud.parallelstore.v1beta.ExportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
+- A new field `target` is added to message `.google.cloud.parallelstore.v1beta.ExportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
+- A new field `verb` is added to message `.google.cloud.parallelstore.v1beta.ExportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
+- A new field `status_message` is added to message `.google.cloud.parallelstore.v1beta.ExportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
+- A new field `requested_cancellation` is added to message `.google.cloud.parallelstore.v1beta.ExportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
+- A new field `api_version` is added to message `.google.cloud.parallelstore.v1beta.ExportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
+- A new field `source_parallelstore` is added to message `.google.cloud.parallelstore.v1beta.TransferOperationMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
+- A new field `source_gcs_bucket` is added to message `.google.cloud.parallelstore.v1beta.TransferOperationMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
+- A new field `destination_gcs_bucket` is added to message `.google.cloud.parallelstore.v1beta.TransferOperationMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
+- A new field `destination_parallelstore` is added to message `.google.cloud.parallelstore.v1beta.TransferOperationMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
+
+### Documentation improvements
+
+- A comment for field `counters` in message `.google.cloud.parallelstore.v1beta.TransferOperationMetadata` is changed ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
+- A comment for field `transfer_type` in message `.google.cloud.parallelstore.v1beta.TransferOperationMetadata` is changed ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
+
 ## Version 1.0.0-beta02, released 2024-05-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3610,7 +3610,7 @@
     },
     {
       "id": "Google.Cloud.Parallelstore.V1Beta",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "Parallelstore",
       "productUrl": "http://cloud/parallelstore?hl=en",
@@ -3619,8 +3619,8 @@
         "performance"
       ],
       "dependencies": {
-        "Google.Cloud.Location": "2.2.0",
-        "Google.LongRunning": "3.2.0"
+        "Google.Cloud.Location": "2.3.0",
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/parallelstore/v1beta",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** An existing field `create_time` is removed from message `.google.cloud.parallelstore.v1beta.TransferOperationMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
- **BREAKING CHANGE** An existing field `end_time` is removed from message `.google.cloud.parallelstore.v1beta.TransferOperationMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
- **BREAKING CHANGE** An existing field `source` is removed from message `.google.cloud.parallelstore.v1beta.TransferOperationMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
- **BREAKING CHANGE** An existing field `destination` is removed from message `.google.cloud.parallelstore.v1beta.TransferOperationMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))

### New features

- A new field `create_time` is added to message `.google.cloud.parallelstore.v1beta.ImportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
- A new field `end_time` is added to message `.google.cloud.parallelstore.v1beta.ImportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
- A new field `target` is added to message `.google.cloud.parallelstore.v1beta.ImportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
- A new field `verb` is added to message `.google.cloud.parallelstore.v1beta.ImportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
- A new field `status_message` is added to message `.google.cloud.parallelstore.v1beta.ImportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
- A new field `requested_cancellation` is added to message `.google.cloud.parallelstore.v1beta.ImportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
- A new field `api_version` is added to message `.google.cloud.parallelstore.v1beta.ImportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
- A new field `create_time` is added to message `.google.cloud.parallelstore.v1beta.ExportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
- A new field `end_time` is added to message `.google.cloud.parallelstore.v1beta.ExportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
- A new field `target` is added to message `.google.cloud.parallelstore.v1beta.ExportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
- A new field `verb` is added to message `.google.cloud.parallelstore.v1beta.ExportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
- A new field `status_message` is added to message `.google.cloud.parallelstore.v1beta.ExportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
- A new field `requested_cancellation` is added to message `.google.cloud.parallelstore.v1beta.ExportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
- A new field `api_version` is added to message `.google.cloud.parallelstore.v1beta.ExportDataMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
- A new field `source_parallelstore` is added to message `.google.cloud.parallelstore.v1beta.TransferOperationMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
- A new field `source_gcs_bucket` is added to message `.google.cloud.parallelstore.v1beta.TransferOperationMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
- A new field `destination_gcs_bucket` is added to message `.google.cloud.parallelstore.v1beta.TransferOperationMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
- A new field `destination_parallelstore` is added to message `.google.cloud.parallelstore.v1beta.TransferOperationMetadata` ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))

### Documentation improvements

- A comment for field `counters` in message `.google.cloud.parallelstore.v1beta.TransferOperationMetadata` is changed ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
- A comment for field `transfer_type` in message `.google.cloud.parallelstore.v1beta.TransferOperationMetadata` is changed ([commit a59f288](https://github.com/googleapis/google-cloud-dotnet/commit/a59f288c10ca3111a8bd7ce733aa68d726b32e0d))
