### PR TITLE
Release Google.Maps.Places.V1 version 1.0.0-beta07

### DIFF
--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1/Google.Maps.Places.V1.csproj
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1/Google.Maps.Places.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta06</Version>
+    <Version>1.0.0-beta07</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Places API, which allows developers to access a variety of search and retrieval endpoints for a Place.</Description>

--- a/apis/Google.Maps.Places.V1/docs/history.md
+++ b/apis/Google.Maps.Places.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 1.0.0-beta07, released 2024-05-20
+
+### New features
+
+- Add `generative_summary` and `area_summary` for place summaries ([commit 6ae2f61](https://github.com/googleapis/google-cloud-dotnet/commit/6ae2f614af154c7eb1299e6ab9ee242e37236cec))
+- Add `contextual_contents` field for contextual search results ([commit 6ae2f61](https://github.com/googleapis/google-cloud-dotnet/commit/6ae2f614af154c7eb1299e6ab9ee242e37236cec))
+
+### Documentation improvements
+
+- `included_primary_types` supports type collections `(regions)` and ([commit 6ae2f61](https://github.com/googleapis/google-cloud-dotnet/commit/6ae2f614af154c7eb1299e6ab9ee242e37236cec))
+
 ## Version 1.0.0-beta06, released 2024-05-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5648,7 +5648,7 @@
     },
     {
       "id": "Google.Maps.Places.V1",
-      "version": "1.0.0-beta06",
+      "version": "1.0.0-beta07",
       "type": "grpc",
       "productName": "Places API",
       "productUrl": "https://developers.google.com/maps/documentation/places/web-service/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add `generative_summary` and `area_summary` for place summaries ([commit 6ae2f61](https://github.com/googleapis/google-cloud-dotnet/commit/6ae2f614af154c7eb1299e6ab9ee242e37236cec))
- Add `contextual_contents` field for contextual search results ([commit 6ae2f61](https://github.com/googleapis/google-cloud-dotnet/commit/6ae2f614af154c7eb1299e6ab9ee242e37236cec))

### Documentation improvements

- `included_primary_types` supports type collections `(regions)` and ([commit 6ae2f61](https://github.com/googleapis/google-cloud-dotnet/commit/6ae2f614af154c7eb1299e6ab9ee242e37236cec))
