### PR TITLE
Release Google.Cloud.DataLabeling.V1Beta1 version 2.0.0-beta05

### DIFF
--- a/apis/Google.Cloud.DataLabeling.V1Beta1/Google.Cloud.DataLabeling.V1Beta1/Google.Cloud.DataLabeling.V1Beta1.csproj
+++ b/apis/Google.Cloud.DataLabeling.V1Beta1/Google.Cloud.DataLabeling.V1Beta1/Google.Cloud.DataLabeling.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta04</Version>
+    <Version>2.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud AI Data Labeling Service.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DataLabeling.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.DataLabeling.V1Beta1/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+## Version 2.0.0-beta05, released 2024-05-23
+
+This release is being used to publish a new front-page of
+documentation, to indicate package deprecation.
+
 ## Version 2.0.0-beta04, released 2024-05-08
 
 ### New features

--- a/apis/Google.Cloud.DataLabeling.V1Beta1/docs/index.md
+++ b/apis/Google.Cloud.DataLabeling.V1Beta1/docs/index.md
@@ -2,14 +2,10 @@
 
 {{description}}
 
-{{version}}
+The Data Labeling API is officially deprecated.
 
-{{installation}}
-
-{{auth}}
-
-## Getting started
-
-{{client-classes}}
-
-{{client-construction}}
+The Google.Cloud.DataLabeling.V1Beta package is delisted from NuGet,
+and the source code removed from the google-cloud-dotnet repository.
+Any projects that depend on the package will still be
+able to restore that dependency, but the package won't be shown in
+search results on [nuget.org](https://www.nuget.org/).

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1653,7 +1653,7 @@
     },
     {
       "id": "Google.Cloud.DataLabeling.V1Beta1",
-      "version": "2.0.0-beta04",
+      "version": "2.0.0-beta05",
       "type": "grpc",
       "productName": "Data Labeling",
       "productUrl": "https://cloud.google.com/ai-platform/data-labeling/docs",
@@ -1663,7 +1663,7 @@
         "labeling"
       ],
       "dependencies": {
-        "Google.LongRunning": "3.2.0"
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/datalabeling/v1beta1",


### PR DESCRIPTION

Changes in this release:

This release is being used to publish a new front-page of documentation, to indicate package deprecation.
