### PR TITLE
chore: Update docfx to 2.76.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "docfx": {
-      "version": "2.71.1",
+      "version": "2.76.0",
       "commands": [
         "docfx"
       ]


### PR DESCRIPTION
Tested by generating Spanner docs locally; there are some whitespace changes, but I haven't seen anything significant.

First part of b/337988290 - if this looks okay, we can roll it out to google-api-dotnet-client.