### PR TITLE
Release Google.Cloud.CloudControlsPartner.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.CloudControlsPartner.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.CloudControlsPartner.V1",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.CloudControlsPartner.V1/latest",
   "library_type": "GAPIC_AUTO",
   "language": "dotnet",

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.csproj
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Controls Partner API (v1) which provides insights about your customers and their Assured Workloads based on your Sovereign Controls by Partners offering.</Description>

--- a/apis/Google.Cloud.CloudControlsPartner.V1/docs/history.md
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2024-05-24
+
+No API surface changes; just dependency updates and promotion to GA.
+
 ## Version 1.0.0-beta02, released 2024-05-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1309,7 +1309,7 @@
     },
     {
       "id": "Google.Cloud.CloudControlsPartner.V1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Cloud Controls Partner",
       "productUrl": "https://cloud.google.com/sovereign-controls-by-partners/docs/sovereign-partners/reference/rest",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to GA.
