### PR TITLE
 chore: Downgrade docfx to 2.75.3 temporarily

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "docfx": {
-      "version": "2.76.0",
+      "version": "2.75.3",
       "commands": [
         "docfx"
       ]


### PR DESCRIPTION
There's a reported regression in docfx, which in turn seems to be because of a reported regression in Roslyn 4.9.2:

- https://github.com/dotnet/docfx/issues/9855
- https://github.com/dotnet/roslyn/issues/72558

Current recommendation from docfx is to downgrade to 2.75.3 until Roslyn releases a fix so docfx can release with the fixed Roslyn dependency.