### PR TITLE
Release Google.Maps.MapsPlatformDatasets.V1Alpha version 1.0.0-alpha05

### DIFF
--- a/PROCESSES.md
+++ b/PROCESSES.md
@@ -315,8 +315,8 @@ corresponding library is:
   manager `delist-package` command to delist all versions.
 - Create a PR to remove the API from the API catalog, delete the source
   code, and regenerate projects (which will update Renovate and the
-  README). See [this PR as an example]
-  (https://github.com/googleapis/google-cloud-dotnet/pull/13012).
+  README). See [this PR as an
+  example](https://github.com/googleapis/google-cloud-dotnet/pull/13012).
 
 ## Updating the .NET SDK
 

--- a/apis/Google.Maps.MapsPlatformDatasets.V1Alpha/Google.Maps.MapsPlatformDatasets.V1Alpha/Google.Maps.MapsPlatformDatasets.V1Alpha.csproj
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1Alpha/Google.Maps.MapsPlatformDatasets.V1Alpha/Google.Maps.MapsPlatformDatasets.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha04</Version>
+    <Version>1.0.0-alpha05</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Platform Datasets API (v1alpha).</Description>

--- a/apis/Google.Maps.MapsPlatformDatasets.V1Alpha/docs/history.md
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1Alpha/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+## Version 1.0.0-alpha05, released 2024-05-29
+
+This release is being used to publish a new front-page of
+documentation, to indicate package deprecation.
+
 ## Version 1.0.0-alpha04, released 2024-05-14
 
 ### New features

--- a/apis/Google.Maps.MapsPlatformDatasets.V1Alpha/docs/index.md
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1Alpha/docs/index.md
@@ -2,14 +2,14 @@
 
 {{description}}
 
-{{version}}
+The Maps Platform Datasets v1alpha API is officially deprecated,
+replaced by the v1 API.
 
-{{installation}}
+The Google.Maps.MapsPlatformDatasets.V1Alpha package is delisted from NuGet,
+and the source code removed from the google-cloud-dotnet repository.
+Any projects that depend on the package will still be
+able to restore that dependency, but the package won't be shown in
+search results on [nuget.org](https://www.nuget.org/).
 
-{{auth}}
-
-## Getting started
-
-{{client-classes}}
-
-{{client-construction}}
+Please update your code to use Google.Maps.MapsPlatformDatasets.V1
+instead.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5654,7 +5654,7 @@
     },
     {
       "id": "Google.Maps.MapsPlatformDatasets.V1Alpha",
-      "version": "1.0.0-alpha04",
+      "version": "1.0.0-alpha05",
       "type": "grpc",
       "productName": "Maps Platform Datasets",
       "productUrl": "https://developers.google.com/maps/documentation",


### PR DESCRIPTION

Changes in this release:

This release is being used to publish a new front-page of documentation, to indicate package deprecation.
