### PR TITLE
feat: Support detached sessions/transaction

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/PartitionedReadTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/PartitionedReadTests.cs
@@ -86,8 +86,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             using var connection = new SpannerConnection(_fixture.ConnectionString);
             await connection.OpenAsync();
 
-            using var transaction = await connection.BeginReadOnlyTransactionAsync();
-            transaction.DisposeBehavior = DisposeBehavior.Detach;
+            using var transaction = await connection.BeginDetachedReadOnlyTransactionAsync();
 
             using var cmd = commandFactory(connection);
             cmd.Transaction = transaction;

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TransactionTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TransactionTests.cs
@@ -92,8 +92,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             using var connection = new SpannerConnection(_fixture.ConnectionString);
             await connection.OpenAsync();
 
-            using var transaction = await connection.BeginTransactionAsync();
-            transaction.DisposeBehavior = DisposeBehavior.Detach;
+            using var transaction = await connection.BeginDetachedReadOnlyTransactionAsync();
 
             // We are testing (through the CommonTestsDiagnostics attribute) that there
             // are no active sessions or connections after we have disposed of both.

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TransactionTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/TransactionTests.cs
@@ -87,6 +87,50 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
         }
 
         [Fact]
+        public async Task Commit_ReturnsToPool()
+        {
+            using var connection = new SpannerConnection(_fixture.ConnectionString);
+            await connection.OpenAsync();
+
+            using var transaction = await connection.BeginTransactionAsync();
+            using var command = connection.CreateSelectCommand($"SELECT Int64Value FROM {_fixture.TableName} WHERE K=@k");
+            command.Parameters.Add("k", SpannerDbType.String, _key);
+            command.Transaction = transaction;
+
+            var value = await command.ExecuteScalarAsync();
+
+            transaction.Commit();
+
+            var poolStatistics = connection.GetSessionPoolSegmentStatistics();
+
+            // Because the session is eagerly returned to the pool after a commit, there shouldn't
+            // be any active sessions even before we dispose of the transaction explicitly.
+            Assert.Equal(0, poolStatistics.ActiveSessionCount);
+        }
+
+        [Fact]
+        public async Task Rollback_ReturnsToPool()
+        {
+            using var connection = new SpannerConnection(_fixture.ConnectionString);
+            await connection.OpenAsync();
+
+            using var transaction = await connection.BeginTransactionAsync();
+            using var command = connection.CreateSelectCommand($"SELECT Int64Value FROM {_fixture.TableName} WHERE K=@k");
+            command.Parameters.Add("k", SpannerDbType.String, _key);
+            command.Transaction = transaction;
+
+            var value = await command.ExecuteScalarAsync();
+
+            transaction.Rollback();
+
+            var poolStatistics = connection.GetSessionPoolSegmentStatistics();
+
+            // Because the session is eagerly returned to the pool after a rollback, there shouldn't
+            // be any active sessions even before we dispose of the transaction explicitly.
+            Assert.Equal(0, poolStatistics.ActiveSessionCount);
+        }
+
+        [Fact]
         public async Task DetachOnDisposeTransactionIsDetached()
         {
             using var connection = new SpannerConnection(_fixture.ConnectionString);

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerBatchCommandTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerBatchCommandTests.cs
@@ -442,6 +442,8 @@ namespace Google.Cloud.Spanner.Data.Tests
             public SpannerClient Client => throw new NotImplementedException();
             public IClock Clock => SystemClock.Instance;
             public SessionPoolOptions Options { get; } = new SessionPoolOptions();
+            public bool TracksSessions => throw new NotImplementedException();
+
             public void Release(PooledSession session, ByteString transactionId, bool deleteSession) =>  throw new NotImplementedException();
             public void Detach(PooledSession session) => throw new NotImplementedException();
 

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTests.cs
@@ -272,7 +272,7 @@ namespace Google.Cloud.Spanner.Data.Tests
                 .SetupStreamingRead();
 
             var connection = BuildSpannerConnection(spannerClientMock);
-            var transaction = await connection.BeginReadOnlyTransactionAsync();
+            var transaction = await connection.BeginDetachedReadOnlyTransactionAsync();
             var command = connection.CreateReadCommand("Foo", ReadOptions.FromColumns("Col1", "Col2").WithLimit(10), KeySet.All);
             command.Transaction = transaction;
             var partitions = await command.GetReaderPartitionsAsync(PartitionOptions.Default.WithPartitionSizeBytes(0).WithMaxPartitions(10));
@@ -1339,7 +1339,7 @@ namespace Google.Cloud.Spanner.Data.Tests
                 .SetupStreamingRead();
 
             var connection = BuildSpannerConnection(spannerClientMock);
-            var transaction = await connection.BeginReadOnlyTransactionAsync();
+            var transaction = await connection.BeginDetachedReadOnlyTransactionAsync();
             var command = connection.CreateReadCommand("Foo", ReadOptions.FromColumns("Col1", "Col2").WithLimit(10), KeySet.All);
             command.Transaction = transaction;
             var partitions = await command.GetReaderPartitionsAsync(PartitionOptions.Default.WithPartitionSizeBytes(0).WithMaxPartitions(10).WithDataBoostEnabled(dataBoostEnabled));

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/DirectedReadTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/DirectedReadTests.cs
@@ -442,6 +442,8 @@ public class DirectedReadTests
 
         public SessionPoolOptions Options => new SessionPoolOptions();
 
+        public bool TracksSessions => throw new NotImplementedException();
+
         public void Detach(PooledSession session) => throw new NotImplementedException();
         public Task<PooledSession> RefreshedOrNewAsync(PooledSession session, TransactionOptions transactionOptions, bool singleUseTransaction, CancellationToken cancellationToken) => throw new NotImplementedException();
         public void Release(PooledSession session, ByteString transactionToRollback, bool deleteSession) => throw new NotImplementedException();

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/PooledSessionTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/PooledSessionTests.cs
@@ -381,6 +381,7 @@ namespace Google.Cloud.Spanner.V1.Tests
             IClock SessionPool.ISessionPool.Clock => Clock;
             public FakeClock Clock => (FakeClock) Client.Settings.Clock;
             public Logger Logger { get; } = Logger.DefaultLogger;
+            public bool TracksSessions => true;
 
             public bool? ReleasedSessionDeleted { get; private set; }
             public ByteString RolledBackTransaction { get; private set; }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/RouteToLeaderTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/RouteToLeaderTests.cs
@@ -261,6 +261,8 @@ public class RouteToLeaderTests
 
         public SessionPoolOptions Options => new SessionPoolOptions();
 
+        public bool TracksSessions => throw new NotImplementedException();
+
         public void Detach(PooledSession session) => throw new NotImplementedException();
         public Task<PooledSession> RefreshedOrNewAsync(PooledSession session, TransactionOptions transactionOptions, bool singleUseTransaction, CancellationToken cancellationToken) => throw new NotImplementedException();
         public void Release(PooledSession session, ByteString transactionToRollback, bool deleteSession) => throw new NotImplementedException();

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/DisposeBehavior.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/DisposeBehavior.cs
@@ -12,29 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Threading;
-
 namespace Google.Cloud.Spanner.Data
 {
     /// <summary>
     /// Defines the behavior of <see cref="SpannerTransaction"/> when Dispose is called.
+    /// <see cref="SpannerTransaction.DisposeBehavior"/> for more information.
     /// </summary>
     public enum DisposeBehavior
     {
         /// <summary>
-        /// Releases transactional resources back to the global pool when <see cref="SpannerTransaction.Dispose"/> is called.
-        /// This option is not valid for shared transactions (see <see cref="SpannerCommand.GetReaderPartitionsAsync(PartitionOptions, CancellationToken)"/>).
+        /// For transactions with pooled resources, releases transactional resources back to the pool
+        /// when <see cref="SpannerTransaction.Dispose"/> is called.
+        /// Otherwise calling <see cref="SpannerTransaction.Dispose"/> has no effect on the transaction resources.
         /// </summary>
-        ReleaseToPool = 0,
+        Default = 0,
         /// <summary>
         /// Automatically closes resources when <see cref="SpannerTransaction.Dispose"/> is called.
         /// </summary>
         CloseResources = 1,
-        /// <summary>
-        /// Detaches from the transaction and leaves resources still allocated.  You must set
-        /// <see cref="SpannerTransaction.DisposeBehavior"/> to <see cref="CloseResources"/> on at least one
-        /// instance to ensure there are no resource leaks when doing parallel reads.
-        /// </summary>
-        Detach = 2
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/EphemeralTransaction.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/EphemeralTransaction.cs
@@ -185,7 +185,7 @@ namespace Google.Cloud.Spanner.Data
 
             async Task<ReliableStreamReader> Impl()
             {
-                PooledSession session = await _connection.AcquireSessionAsync(_singleUseTransactionOptions, singleUse: _singleUseTransactionOptions is not null, cancellationToken).ConfigureAwait(false);
+                PooledSession session = await _connection.AcquireSessionAsync(_singleUseTransactionOptions, singleUse: _singleUseTransactionOptions is not null, detached: false, cancellationToken).ConfigureAwait(false);
                 var callSettings = _connection.CreateCallSettings(
                     request.GetCallSettings,
                     cancellationToken);

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.ExecutableCommand.cs
@@ -168,8 +168,8 @@ namespace Google.Cloud.Spanner.Data
             {
                 ValidateConnectionAndCommandTextBuilder();
 
-                GaxPreconditions.CheckState(Transaction?.Mode == TransactionMode.ReadOnly,
-                    "GetReaderPartitions can only be executed within an explicitly created read-only transaction.");
+                GaxPreconditions.CheckState(Transaction?.Mode == TransactionMode.ReadOnly && Transaction?.IsDetached == true,
+                    "GetReaderPartitions can only be executed within an explicitly created detached read-only transaction.");
 
                 await Connection.EnsureIsOpenAsync(cancellationToken).ConfigureAwait(false);
                 var readOrQueryRequest = GetReadOrQueryRequest();

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PooledSession.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PooledSession.cs
@@ -142,8 +142,6 @@ namespace Google.Cloud.Spanner.V1
         private int _disposed;
         private int _committedOrRolledBack;
 
-        // TODO(atarafamas): When looking at detached transactions see if we can receive here the whole Transaction instead of
-        // its bits separately.
         private PooledSession(SessionPool.ISessionPool pool, SessionName sessionName, ByteString transactionId, TransactionOptions transactionOptions, bool singleUseTransaction, Timestamp readTimestamp, DateTime evictionTime, long refreshTicks)
         {
             _pool = pool;

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.ISessionPool.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.ISessionPool.cs
@@ -28,17 +28,10 @@ namespace Google.Cloud.Spanner.V1
         {
             SpannerClient Client { get; }
             IClock Clock { get; }
+            SessionPoolOptions Options { get; }
+            bool TracksSessions { get; }
             Task<PooledSession> RefreshedOrNewAsync(PooledSession session, TransactionOptions transactionOptions, bool singleUseTransaction, CancellationToken cancellationToken);
             void Release(PooledSession session, ByteString transactionToRollback, bool deleteSession);
-            /// <summary>
-            /// Detaches the given session from the pool, meaning the pool stops tracking this session as active,
-            /// but does nothing else, in particular it doesn't return the session to the pool or attempts to delete it.
-            /// </summary>
-            /// <param name="session">The pooled session to be detached. Currently unusued by all <see cref="ISessionPool"/>
-            /// implementations, but that's just an implementation detail: the <see cref="TargetedSessionPool"/> does not
-            /// keep track of active <see cref="PooledSession"/> instances themselves, but only through counters.</param>
-            void Detach(PooledSession session);
-            SessionPoolOptions Options { get; }
         }
     }
 }

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.SessionPoolBase.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.SessionPoolBase.cs
@@ -31,9 +31,10 @@ namespace Google.Cloud.Spanner.V1
             public IClock Clock => Parent._clock;
             public SessionPoolOptions Options => Parent.Options;
             protected SessionPool Parent { get; }
+            public abstract bool TracksSessions { get; }
+
             public abstract Task<PooledSession> RefreshedOrNewAsync(PooledSession session, TransactionOptions transactionOptions, bool singleUseTransaction, CancellationToken cancellationToken);
             public abstract void Release(PooledSession session, ByteString transactionToRollback, bool deleteSession);
-            public abstract void Detach(PooledSession session);
 
             protected SessionPoolBase(SessionPool parent) => Parent = parent;
         }

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.cs
@@ -151,7 +151,7 @@ namespace Google.Cloud.Spanner.V1
             _targetedPools.TryGetValue(SessionPoolSegmentKey.Create(databaseName), out var pool) ? pool.GetStatisticsSnapshot() : null;
 
         /// <summary>
-        /// Asynchronously acquires a session, potentially associated with a transaction.
+        /// Asynchronously acquires a session that will handle transaction creation as needed.
         /// This is equivalent to calling <see cref="AcquireSessionAsync(SessionPoolSegmentKey, TransactionOptions, CancellationToken)"/>
         /// passing a segment key with a null database role.
         /// </summary>
@@ -159,23 +159,25 @@ namespace Google.Cloud.Spanner.V1
         /// <param name="transactionOptions">The transaction options required for the session. After the operation completes,
         /// this value is no longer used, so modifications to the object will not affect the transaction. May be null.</param>
         /// <param name="cancellationToken">An optional token for canceling the call.</param>
-        /// <returns>The <see cref="PooledSession"/> representing the client, session and transaction.</returns>
+        /// <returns>The <see cref="PooledSession"/> representing the client, session and, eventually, the transaction.</returns>
         public Task<PooledSession> AcquireSessionAsync(DatabaseName databaseName, TransactionOptions transactionOptions, CancellationToken cancellationToken) =>
             AcquireSessionAsync(SessionPoolSegmentKey.Create(databaseName), transactionOptions, cancellationToken);
 
         /// <summary>
-        /// Asynchronously acquires a session using the given <see cref="SessionPoolSegmentKey"/>, potentially associated with a transaction.
+        /// Asynchronously acquires a session, using the given <see cref="SessionPoolSegmentKey"/>.
+        /// The session will handle transaction creation as needed.
         /// </summary>
         /// <param name="key">The <see cref="SessionPoolSegmentKey"/> to acquire the session.</param>
         /// <param name="transactionOptions">The transaction options required for the session. After the operation completes,
         /// this value is no longer used, so modifications to the object will not affect the transaction. May be null.</param>
         /// <param name="cancellationToken">An optional token for canceling the call.</param>
-        /// <returns>The <see cref="PooledSession"/> representing the client, session and transaction.</returns>
+        /// <returns>The <see cref="PooledSession"/> representing the client, session and, eventually, the transaction.</returns>
         public Task<PooledSession> AcquireSessionAsync(SessionPoolSegmentKey key, TransactionOptions transactionOptions, CancellationToken cancellationToken) =>
             AcquireSessionAsync(key, transactionOptions, singleUseTransaction: false, cancellationToken);
 
         /// <summary>
-        /// Asynchronously acquires a session using the given <see cref="SessionPoolSegmentKey"/>, potentially associated with a transaction.
+        /// Asynchronously acquires a session using the given <see cref="SessionPoolSegmentKey"/>.
+        /// The session will handle transaction creation as needed.
         /// </summary>
         /// <param name="key">The <see cref="SessionPoolSegmentKey"/> to acquire the session.</param>
         /// <param name="transactionOptions">The transaction options required for the session. After the operation completes,
@@ -183,7 +185,7 @@ namespace Google.Cloud.Spanner.V1
         /// <param name="singleUseTransaction">Whether the transaction used by this session is single use or not. May only be true if
         /// <paramref name="transactionOptions"/> is <see cref="TransactionOptions.ModeOneofCase.ReadOnly"/>.</param>
         /// <param name="cancellationToken">An optional token for canceling the call.</param>
-        /// <returns>The <see cref="PooledSession"/> representing the client, session and transaction.</returns>
+        /// <returns>The <see cref="PooledSession"/> representing the client, session and, eventually, the transaction.</returns>
         public Task<PooledSession> AcquireSessionAsync(SessionPoolSegmentKey key, TransactionOptions transactionOptions, bool singleUseTransaction, CancellationToken cancellationToken)
         {
             GaxPreconditions.CheckNotNull(key, nameof(key));

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SessionPool.cs
@@ -233,7 +233,6 @@ namespace Google.Cloud.Spanner.V1
             GaxPreconditions.CheckNotNull(transactionId, nameof(transactionId));
             return PooledSession.FromSessionName(_detachedSessionPool, sessionName).WithTransaction(transactionId, BuildTransactionOptions(), singleUseTransaction: false, readTimestamp);
 
-            // TODO: Maybe just consider the breaking change and directly receive TransactionOptions.
             TransactionOptions BuildTransactionOptions() => transactionMode switch
             {
                 ModeOneofCase.None => new TransactionOptions (),


### PR DESCRIPTION
@jskeet This is a draft so that we can discuss and agree on surface changes. I haven't changed existing tests or added new ones. A few things I'm uncertain about:

- Whether to surface detach as a paramater for transaction all the way up, or as a modifier or method names. (i.e. 
BeginTransaction(bool detached) vs. BeginDetachedTransaction).
- Whether swapping SpannerTransaction.Shared by SpannerTransaction.IsDetached warrants the breaking change, i.e. I think the change is for the better, but not certain if it is so much better.

As always one commit at a time (the first two are passing-by fixes).