### PR TITLE
Release Google.Cloud.BigQuery.V2 version 3.10.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.9.0</Version>
+    <Version>3.10.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.</Description>

--- a/apis/Google.Cloud.BigQuery.V2/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.10.0, released 2024-05-30
+
+### New features
+
+- Add a view option to GetTable ([commit 258e723](https://github.com/googleapis/google-cloud-dotnet/commit/258e723949d58454111e456feaae62836557672f))
+
 ## Version 3.9.0, released 2024-03-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1009,7 +1009,7 @@
       "id": "Google.Cloud.BigQuery.V2",
       "productName": "Google BigQuery",
       "productUrl": "https://cloud.google.com/bigquery/",
-      "version": "3.9.0",
+      "version": "3.10.0",
       "type": "rest",
       "description": "Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add a view option to GetTable ([commit 258e723](https://github.com/googleapis/google-cloud-dotnet/commit/258e723949d58454111e456feaae62836557672f))
