### PR TITLE
Release Google.Cloud.Tools.ReleaseProgressReporter version 0.4.1

### DIFF
--- a/tools/Google.Cloud.Tools.ReleaseProgressReporter/Google.Cloud.Tools.ReleaseProgressReporter.csproj
+++ b/tools/Google.Cloud.Tools.ReleaseProgressReporter/Google.Cloud.Tools.ReleaseProgressReporter.csproj
@@ -8,7 +8,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
-    <Version>0.4.0</Version>
+    <Version>0.4.1</Version>
     <Description>Tool used by Google .NET release processes. While there is nothing "secret" in this package, it is unlikely to be useful to other developers. It is only published as a matter of convenience for other Google .NET repositories.</Description>
     <ToolCommandName>release-progress-reporter</ToolCommandName>
   </PropertyGroup>


### PR DESCRIPTION
This attempts to match the head commit against two different commit SHAs in each PR (as they can vary based on exactly how the PR was merged). Also provides more diagnostics.