### PR TITLE
Release Google.Cloud.Datastore.V1 version 4.12.0

### DIFF
--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/Google.Cloud.Datastore.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/Google.Cloud.Datastore.V1.GeneratedSnippets.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.8.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
-    <PackageReference Include="Google.Cloud.Datastore.Admin.V1" Version="[2.3.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Datastore.Admin.V1" Version="[2.4.0, 3.0.0)" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
     <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.9.0, 4.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/Google.Cloud.Datastore.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/Google.Cloud.Datastore.V1.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.8.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
-    <PackageReference Include="Google.Cloud.Datastore.Admin.V1" Version="[2.3.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Datastore.Admin.V1" Version="[2.4.0, 3.0.0)" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
     <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.9.0, 4.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/Google.Cloud.Datastore.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/Google.Cloud.Datastore.V1.Snippets.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.8.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
-    <PackageReference Include="Google.Cloud.Datastore.Admin.V1" Version="[2.3.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Datastore.Admin.V1" Version="[2.4.0, 3.0.0)" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
     <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.9.0, 4.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/Google.Cloud.Datastore.V1.Tests.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/Google.Cloud.Datastore.V1.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Api.Gax.Grpc.Testing" Version="[4.8.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
-    <PackageReference Include="Google.Cloud.Datastore.Admin.V1" Version="[2.3.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Datastore.Admin.V1" Version="[2.4.0, 3.0.0)" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
     <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.9.0, 4.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.11.0</Version>
+    <Version>4.12.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>

--- a/apis/Google.Cloud.Datastore.V1/docs/history.md
+++ b/apis/Google.Cloud.Datastore.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 4.12.0, released 2024-05-30
+
+### New features
+
+- New PropertyMask field which allows partial commits, lookups, and query results ([commit d2d3c83](https://github.com/googleapis/google-cloud-dotnet/commit/d2d3c83729068ac7fa329b3cea1281519f16adec))
+
 ## Version 4.11.0, released 2024-05-13
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1769,7 +1769,7 @@
       "protoPath": "google/datastore/v1",
       "productName": "Google Cloud Datastore",
       "productUrl": "https://cloud.google.com/datastore/docs/concepts/overview",
-      "version": "4.11.0",
+      "version": "4.12.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.",
@@ -1777,12 +1777,12 @@
         "Datastore"
       ],
       "dependencies": {
-        "Google.LongRunning": "3.2.0",
+        "Google.LongRunning": "3.3.0",
         "System.Linq.Async": "6.0.1"
       },
       "testDependencies": {
         "Google.Api.Gax.Grpc.Testing": "default",
-        "Google.Cloud.Datastore.Admin.V1": "2.3.0",
+        "Google.Cloud.Datastore.Admin.V1": "2.4.0",
         "Google.Cloud.Firestore.Admin.V1": "3.9.0"
       },
       "shortName": "datastore",


### PR DESCRIPTION

Changes in this release:

### New features

- New PropertyMask field which allows partial commits, lookups, and query results ([commit d2d3c83](https://github.com/googleapis/google-cloud-dotnet/commit/d2d3c83729068ac7fa329b3cea1281519f16adec))
