### PR TITLE
chore: Fetch the full repo (not just a depth of 1) when cloning googleapis

### DIFF
--- a/generateapis.sh
+++ b/generateapis.sh
@@ -28,7 +28,7 @@ fetch_github_repos() {
   then
     git -C $GOOGLEAPIS pull -q
   else
-    git clone https://github.com/googleapis/googleapis $GOOGLEAPIS --depth 1
+    git clone https://github.com/googleapis/googleapis $GOOGLEAPIS
   fi
 }
 


### PR DESCRIPTION
Fixes b/340997472