### PR TITLE
Release Google.Cloud.Dlp.V2 version 4.9.0

### DIFF
--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.csproj
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.16.0</Version>
+    <Version>4.9.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Data Loss Prevention API, which provides methods for detection of privacy-sensitive fragments in text, images, and Google Cloud Platform storage repositories.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.3.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Dlp.V2/docs/history.md
+++ b/apis/Google.Cloud.Dlp.V2/docs/history.md
@@ -1,24 +1,26 @@
 # Version history
 
-## Version 2.16.0, released 2024-05-08
+## Version 4.9.0, released 2024-06-03
 
 ### New features
 
+- Add secrets discovery support ([commit ec67558](https://github.com/googleapis/google-cloud-dotnet/commit/ec675587050d36090ce23ac6b618d551d2a0074b))
 - Add RPCs for deleting TableDataProfiles ([commit 4c44194](https://github.com/googleapis/google-cloud-dotnet/commit/4c44194c2aa30cb7ff16aae08d31225f297563dc))
 - Add RPCs for enabling discovery of Cloud SQL ([commit 4c44194](https://github.com/googleapis/google-cloud-dotnet/commit/4c44194c2aa30cb7ff16aae08d31225f297563dc))
 - Add field to InspectJobs num_rows_processed for BigQuery inspect jobs ([commit 4c44194](https://github.com/googleapis/google-cloud-dotnet/commit/4c44194c2aa30cb7ff16aae08d31225f297563dc))
 - Add new countries for supported detectors ([commit 4c44194](https://github.com/googleapis/google-cloud-dotnet/commit/4c44194c2aa30cb7ff16aae08d31225f297563dc))
 - Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
+- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
 
 ### Documentation improvements
 
+- Updated method documentation ([commit ec67558](https://github.com/googleapis/google-cloud-dotnet/commit/ec675587050d36090ce23ac6b618d551d2a0074b))
 - Updated method documentation ([commit 4c44194](https://github.com/googleapis/google-cloud-dotnet/commit/4c44194c2aa30cb7ff16aae08d31225f297563dc))
 
-## Version 2.15.0, released 2024-03-26
+### Notes
 
-### New features
-
-- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))
+This includes changes that were accidentally released in 2.15.0 and
+2.16.0 (now delisted), after version 4.8.0.
 
 ## Version 4.8.0, released 2024-03-21
 

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2099,11 +2099,11 @@
       "protoPath": "google/privacy/dlp/v2",
       "productName": "Google Cloud Data Loss Prevention",
       "productUrl": "https://cloud.google.com/dlp/",
-      "version": "2.16.0",
+      "version": "4.9.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Data Loss Prevention API, which provides methods for detection of privacy-sensitive fragments in text, images, and Google Cloud Platform storage repositories.",
       "dependencies": {
-        "Google.Cloud.Location": "2.2.0"
+        "Google.Cloud.Location": "2.3.0"
       },
       "tags": [
         "DLP",


### PR DESCRIPTION

Changes in this release:

### New features

- Add secrets discovery support ([commit ec67558](https://github.com/googleapis/google-cloud-dotnet/commit/ec675587050d36090ce23ac6b618d551d2a0074b))
- Add RPCs for deleting TableDataProfiles ([commit 4c44194](https://github.com/googleapis/google-cloud-dotnet/commit/4c44194c2aa30cb7ff16aae08d31225f297563dc))
- Add RPCs for enabling discovery of Cloud SQL ([commit 4c44194](https://github.com/googleapis/google-cloud-dotnet/commit/4c44194c2aa30cb7ff16aae08d31225f297563dc))
- Add field to InspectJobs num_rows_processed for BigQuery inspect jobs ([commit 4c44194](https://github.com/googleapis/google-cloud-dotnet/commit/4c44194c2aa30cb7ff16aae08d31225f297563dc))
- Add new countries for supported detectors ([commit 4c44194](https://github.com/googleapis/google-cloud-dotnet/commit/4c44194c2aa30cb7ff16aae08d31225f297563dc))
- Add IServiceCollection extension methods for client registration where an IServiceProvider is required. ([commit 022fab2](https://github.com/googleapis/google-cloud-dotnet/commit/022fab203f28fb9c608972af7f8b83f571ae5694))
- Change netstandard2.1 target to netstandard2.0 ([commit 82bea85](https://github.com/googleapis/google-cloud-dotnet/commit/82bea850661975b9750ac30753528cc9d2e05240))

### Documentation improvements

- Updated method documentation ([commit ec67558](https://github.com/googleapis/google-cloud-dotnet/commit/ec675587050d36090ce23ac6b618d551d2a0074b))
- Updated method documentation ([commit 4c44194](https://github.com/googleapis/google-cloud-dotnet/commit/4c44194c2aa30cb7ff16aae08d31225f297563dc))

### Notes

This includes changes that were accidentally released in 2.15.0 and 2.16.0 (now delisted), after version 4.8.0.
