### PR TITLE
Release Google.Cloud.Batch.V1Alpha version 1.0.0-alpha29

### DIFF
--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha28</Version>
+    <Version>1.0.0-alpha29</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1alpha), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.3.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 1.0.0-alpha29, released 2024-06-04
+
+### New features
+
+- Add a install_ops_agent field to InstancePolicyOrTemplate for Ops Agent support ([commit 81aaa3d](https://github.com/googleapis/google-cloud-dotnet/commit/81aaa3dda894862048aae85a718e6cb4e3f2f061))
+
+### Documentation improvements
+
+- A comment for field `max_run_duration` in message `google.cloud.batch.v1alpha.TaskSpec` is changed ([commit 81aaa3d](https://github.com/googleapis/google-cloud-dotnet/commit/81aaa3dda894862048aae85a718e6cb4e3f2f061))
+- Refine doc for the update_mask field in message `google.cloud.batch.v1alpha.UpdateJobRequest` ([commit 81aaa3d](https://github.com/googleapis/google-cloud-dotnet/commit/81aaa3dda894862048aae85a718e6cb4e3f2f061))
+- Refine description for field `task_execution` ([commit f2e7e66](https://github.com/googleapis/google-cloud-dotnet/commit/f2e7e660cec9cbb940a894098f37b3f503c65f43))
+
 ## Version 1.0.0-alpha28, released 2024-05-13
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -712,7 +712,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1Alpha",
-      "version": "1.0.0-alpha28",
+      "version": "1.0.0-alpha29",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",
@@ -721,9 +721,9 @@
         "batch"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.2.0",
-        "Google.Cloud.Location": "2.2.0",
-        "Google.LongRunning": "3.2.0"
+        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Location": "2.3.0",
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/batch/v1alpha",


### PR DESCRIPTION

Changes in this release:

### New features

- Add a install_ops_agent field to InstancePolicyOrTemplate for Ops Agent support ([commit 81aaa3d](https://github.com/googleapis/google-cloud-dotnet/commit/81aaa3dda894862048aae85a718e6cb4e3f2f061))

### Documentation improvements

- A comment for field `max_run_duration` in message `google.cloud.batch.v1alpha.TaskSpec` is changed ([commit 81aaa3d](https://github.com/googleapis/google-cloud-dotnet/commit/81aaa3dda894862048aae85a718e6cb4e3f2f061))
- Refine doc for the update_mask field in message `google.cloud.batch.v1alpha.UpdateJobRequest` ([commit 81aaa3d](https://github.com/googleapis/google-cloud-dotnet/commit/81aaa3dda894862048aae85a718e6cb4e3f2f061))
- Refine description for field `task_execution` ([commit f2e7e66](https://github.com/googleapis/google-cloud-dotnet/commit/f2e7e660cec9cbb940a894098f37b3f503c65f43))
