### PR TITLE
Release Google.Cloud.DiscoveryEngine.V1Beta version 1.0.0-beta14

### DIFF
--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.csproj
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta13</Version>
+    <Version>1.0.0-beta14</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Discovery Engine API (v1beta). Discovery Engine powers high-quality content recommendations on your digital properties for Discovery for Media.</Description>
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.3.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/docs/history.md
@@ -1,5 +1,20 @@
 # Version history
 
+## Version 1.0.0-beta14, released 2024-06-04
+
+### New features
+
+- Add properties for nested resource name references ([commit 15eec4d](https://github.com/googleapis/google-cloud-dotnet/commit/15eec4dabb9fd3cf3b8f4b978d64b7ba435ca995))
+- Add control service APIs ([commit 50fe0e3](https://github.com/googleapis/google-cloud-dotnet/commit/50fe0e313e7fb11bb196f62128e5907b47bf711c))
+- Support writing user events for blended engines ([commit 50fe0e3](https://github.com/googleapis/google-cloud-dotnet/commit/50fe0e313e7fb11bb196f62128e5907b47bf711c))
+- Support cancelling import operations ([commit 50fe0e3](https://github.com/googleapis/google-cloud-dotnet/commit/50fe0e313e7fb11bb196f62128e5907b47bf711c))
+- Add custom model list API ([commit 50fe0e3](https://github.com/googleapis/google-cloud-dotnet/commit/50fe0e313e7fb11bb196f62128e5907b47bf711c))
+- Add provision project API ([commit 50fe0e3](https://github.com/googleapis/google-cloud-dotnet/commit/50fe0e313e7fb11bb196f62128e5907b47bf711c))
+
+### Documentation improvements
+
+- Keep the API doc up-to-date with recent changes ([commit 50fe0e3](https://github.com/googleapis/google-cloud-dotnet/commit/50fe0e313e7fb11bb196f62128e5907b47bf711c))
+
 ## Version 1.0.0-beta13, released 2024-05-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2073,7 +2073,7 @@
     },
     {
       "id": "Google.Cloud.DiscoveryEngine.V1Beta",
-      "version": "1.0.0-beta13",
+      "version": "1.0.0-beta14",
       "type": "grpc",
       "productName": "Discovery Engine",
       "productUrl": "https://cloud.google.com/discovery-engine/docs",
@@ -2083,8 +2083,8 @@
         "media"
       ],
       "dependencies": {
-        "Google.Cloud.Location": "2.2.0",
-        "Google.LongRunning": "3.2.0"
+        "Google.Cloud.Location": "2.3.0",
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/discoveryengine/v1beta",


### PR DESCRIPTION

Changes in this release:

### New features

- Add properties for nested resource name references ([commit 15eec4d](https://github.com/googleapis/google-cloud-dotnet/commit/15eec4dabb9fd3cf3b8f4b978d64b7ba435ca995))
- Add control service APIs ([commit 50fe0e3](https://github.com/googleapis/google-cloud-dotnet/commit/50fe0e313e7fb11bb196f62128e5907b47bf711c))
- Support writing user events for blended engines ([commit 50fe0e3](https://github.com/googleapis/google-cloud-dotnet/commit/50fe0e313e7fb11bb196f62128e5907b47bf711c))
- Support cancelling import operations ([commit 50fe0e3](https://github.com/googleapis/google-cloud-dotnet/commit/50fe0e313e7fb11bb196f62128e5907b47bf711c))
- Add custom model list API ([commit 50fe0e3](https://github.com/googleapis/google-cloud-dotnet/commit/50fe0e313e7fb11bb196f62128e5907b47bf711c))
- Add provision project API ([commit 50fe0e3](https://github.com/googleapis/google-cloud-dotnet/commit/50fe0e313e7fb11bb196f62128e5907b47bf711c))

### Documentation improvements

- Keep the API doc up-to-date with recent changes ([commit 50fe0e3](https://github.com/googleapis/google-cloud-dotnet/commit/50fe0e313e7fb11bb196f62128e5907b47bf711c))
