### PR TITLE
Release Google.Cloud.DocumentAI.V1 version 3.17.0

### DIFF
--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.16.0</Version>
+    <Version>3.17.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Document AI API (v1), which is a service to parse structured information from unstructured or semi-structured documents using state-of-the-art Google AI such as natural language, computer vision, translation, and AutoML.</Description>
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.3.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DocumentAI.V1/docs/history.md
+++ b/apis/Google.Cloud.DocumentAI.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 3.17.0, released 2024-06-04
+
+### New features
+
+- Add properties for nested resource name references ([commit 15eec4d](https://github.com/googleapis/google-cloud-dotnet/commit/15eec4dabb9fd3cf3b8f4b978d64b7ba435ca995))
+- Make Layout Parser generally available in V1 ([commit 25c96f8](https://github.com/googleapis/google-cloud-dotnet/commit/25c96f82e50204a67c9a6222c8dd9af5cb8059cb))
+- Make Layout Parser generally available in V1 ([commit 7359623](https://github.com/googleapis/google-cloud-dotnet/commit/735962332f058547aa816eea244e251591973243))
+
+### Documentation improvements
+
+- Clarify the unavailability of some features ([commit b14ce7d](https://github.com/googleapis/google-cloud-dotnet/commit/b14ce7d087969abb5e061692cd34be171439165f))
+
 ## Version 3.16.0, released 2024-05-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2120,7 +2120,7 @@
     },
     {
       "id": "Google.Cloud.DocumentAI.V1",
-      "version": "3.16.0",
+      "version": "3.17.0",
       "type": "grpc",
       "productName": "Cloud Document AI",
       "productUrl": "https://cloud.google.com/solutions/document-ai",
@@ -2134,8 +2134,8 @@
         "automl"
       ],
       "dependencies": {
-        "Google.Cloud.Location": "2.2.0",
-        "Google.LongRunning": "3.2.0"
+        "Google.Cloud.Location": "2.3.0",
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/documentai/v1",


### PR DESCRIPTION

Changes in this release:

### New features

- Add properties for nested resource name references ([commit 15eec4d](https://github.com/googleapis/google-cloud-dotnet/commit/15eec4dabb9fd3cf3b8f4b978d64b7ba435ca995))
- Make Layout Parser generally available in V1 ([commit 25c96f8](https://github.com/googleapis/google-cloud-dotnet/commit/25c96f82e50204a67c9a6222c8dd9af5cb8059cb))
- Make Layout Parser generally available in V1 ([commit 7359623](https://github.com/googleapis/google-cloud-dotnet/commit/735962332f058547aa816eea244e251591973243))

### Documentation improvements

- Clarify the unavailability of some features ([commit b14ce7d](https://github.com/googleapis/google-cloud-dotnet/commit/b14ce7d087969abb5e061692cd34be171439165f))
