### PR TITLE
Release Google.Cloud.GkeBackup.V1 version 2.6.0

### DIFF
--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.csproj
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Backup for GKE API, which is a managed Kubernetes workload backup and restore service for GKE clusters.</Description>
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.3.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.GkeBackup.V1/docs/history.md
+++ b/apis/Google.Cloud.GkeBackup.V1/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+## Version 2.6.0, released 2024-06-04
+
+### New features
+
+- Add fine-grained restore ([commit 34adaa4](https://github.com/googleapis/google-cloud-dotnet/commit/34adaa426a01647954131fe89a383ae1d00c5b17))
+- Add volume restore flexibility ([commit 34adaa4](https://github.com/googleapis/google-cloud-dotnet/commit/34adaa426a01647954131fe89a383ae1d00c5b17))
+- Add restore order ([commit 34adaa4](https://github.com/googleapis/google-cloud-dotnet/commit/34adaa426a01647954131fe89a383ae1d00c5b17))
+- Add strict-permissive mode ([commit 34adaa4](https://github.com/googleapis/google-cloud-dotnet/commit/34adaa426a01647954131fe89a383ae1d00c5b17))
+- Add gitops ([commit 34adaa4](https://github.com/googleapis/google-cloud-dotnet/commit/34adaa426a01647954131fe89a383ae1d00c5b17))
+
+### Documentation improvements
+
+- Update duration comment to include new validation from smart scheduling ([commit 34adaa4](https://github.com/googleapis/google-cloud-dotnet/commit/34adaa426a01647954131fe89a383ae1d00c5b17))
+
 ## Version 2.5.0, released 2024-05-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2535,7 +2535,7 @@
     },
     {
       "id": "Google.Cloud.GkeBackup.V1",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "type": "grpc",
       "productName": "Backup for GKE",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke",
@@ -2546,9 +2546,9 @@
         "backup"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.2.0",
-        "Google.Cloud.Location": "2.2.0",
-        "Google.LongRunning": "3.2.0"
+        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Location": "2.3.0",
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/gkebackup/v1",


### PR DESCRIPTION

Changes in this release:

### New features

- Add fine-grained restore ([commit 34adaa4](https://github.com/googleapis/google-cloud-dotnet/commit/34adaa426a01647954131fe89a383ae1d00c5b17))
- Add volume restore flexibility ([commit 34adaa4](https://github.com/googleapis/google-cloud-dotnet/commit/34adaa426a01647954131fe89a383ae1d00c5b17))
- Add restore order ([commit 34adaa4](https://github.com/googleapis/google-cloud-dotnet/commit/34adaa426a01647954131fe89a383ae1d00c5b17))
- Add strict-permissive mode ([commit 34adaa4](https://github.com/googleapis/google-cloud-dotnet/commit/34adaa426a01647954131fe89a383ae1d00c5b17))
- Add gitops ([commit 34adaa4](https://github.com/googleapis/google-cloud-dotnet/commit/34adaa426a01647954131fe89a383ae1d00c5b17))

### Documentation improvements

- Update duration comment to include new validation from smart scheduling ([commit 34adaa4](https://github.com/googleapis/google-cloud-dotnet/commit/34adaa426a01647954131fe89a383ae1d00c5b17))
