### PR TITLE
Release Google.Cloud.OsConfig.V1Alpha version 2.0.0-alpha06

### DIFF
--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.csproj
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha05</Version>
+    <Version>2.0.0-alpha06</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library for the Cloud OS Config API (v1 alpha). These are OS management tools that can be used for patch management, patch compliance, and configuration management on VM instances.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.OsConfig.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.0.0-alpha06, released 2024-06-04
+
+### New features
+
+- Add properties for nested resource name references ([commit 15eec4d](https://github.com/googleapis/google-cloud-dotnet/commit/15eec4dabb9fd3cf3b8f4b978d64b7ba435ca995))
+
 ## Version 2.0.0-alpha05, released 2024-05-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3547,7 +3547,7 @@
     },
     {
       "id": "Google.Cloud.OsConfig.V1Alpha",
-      "version": "2.0.0-alpha05",
+      "version": "2.0.0-alpha06",
       "type": "grpc",
       "productName": "Google Cloud OS Config",
       "productUrl": "https://cloud.google.com/compute/docs/osconfig/rest",
@@ -3560,7 +3560,7 @@
         "Configuration"
       ],
       "dependencies": {
-        "Google.LongRunning": "3.2.0"
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/osconfig/v1alpha",


### PR DESCRIPTION

Changes in this release:

### New features

- Add properties for nested resource name references ([commit 15eec4d](https://github.com/googleapis/google-cloud-dotnet/commit/15eec4dabb9fd3cf3b8f4b978d64b7ba435ca995))
