### PR TITLE
Release Google.Cloud.Video.Stitcher.V1 version 3.3.0

### DIFF
--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.csproj
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.2.0</Version>
+    <Version>3.3.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Video Stitcher API, which helps you generate dynamic content for delivery to client devices. </Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Video.Stitcher.V1/docs/history.md
+++ b/apis/Google.Cloud.Video.Stitcher.V1/docs/history.md
@@ -1,5 +1,20 @@
 # Version history
 
+## Version 3.3.0, released 2024-06-04
+
+### New features
+
+- Add apis for Create, Read, Update, Delete for VODConfigs ([commit cd0f56e](https://github.com/googleapis/google-cloud-dotnet/commit/cd0f56e7b7677feff24624233ba04446ed60674c))
+- Allowed usage for VODConfigs in VODSession ([commit cd0f56e](https://github.com/googleapis/google-cloud-dotnet/commit/cd0f56e7b7677feff24624233ba04446ed60674c))
+- Added token config for MediaCdnKey ([commit cd0f56e](https://github.com/googleapis/google-cloud-dotnet/commit/cd0f56e7b7677feff24624233ba04446ed60674c))
+- Added targetting parameter support to Livesession ([commit cd0f56e](https://github.com/googleapis/google-cloud-dotnet/commit/cd0f56e7b7677feff24624233ba04446ed60674c))
+- Added adtracking to Livesession ([commit cd0f56e](https://github.com/googleapis/google-cloud-dotnet/commit/cd0f56e7b7677feff24624233ba04446ed60674c))
+- Added fetchoptions with custom headers for Live and VODConfigs ([commit cd0f56e](https://github.com/googleapis/google-cloud-dotnet/commit/cd0f56e7b7677feff24624233ba04446ed60674c))
+
+### Documentation improvements
+
+- Added apis for Create, Read, Update, Delete For VODConfigs. Added vodConfig usage in VODSession. Added TokenConfig for MediaCdnKey. Added targeting_parameter and ad_tracking for Livesession. Added FetchOptions for Live and VOD configs. ([commit cd0f56e](https://github.com/googleapis/google-cloud-dotnet/commit/cd0f56e7b7677feff24624233ba04446ed60674c))
+
 ## Version 3.2.0, released 2024-05-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5178,7 +5178,7 @@
     },
     {
       "id": "Google.Cloud.Video.Stitcher.V1",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "type": "grpc",
       "productName": "Video Stitcher",
       "productUrl": "https://cloud.google.com/video-stitcher/docs",
@@ -5189,7 +5189,7 @@
         "content"
       ],
       "dependencies": {
-        "Google.LongRunning": "3.2.0"
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/video/stitcher/v1",


### PR DESCRIPTION

Changes in this release:

### New features

- Add apis for Create, Read, Update, Delete for VODConfigs ([commit cd0f56e](https://github.com/googleapis/google-cloud-dotnet/commit/cd0f56e7b7677feff24624233ba04446ed60674c))
- Allowed usage for VODConfigs in VODSession ([commit cd0f56e](https://github.com/googleapis/google-cloud-dotnet/commit/cd0f56e7b7677feff24624233ba04446ed60674c))
- Added token config for MediaCdnKey ([commit cd0f56e](https://github.com/googleapis/google-cloud-dotnet/commit/cd0f56e7b7677feff24624233ba04446ed60674c))
- Added targetting parameter support to Livesession ([commit cd0f56e](https://github.com/googleapis/google-cloud-dotnet/commit/cd0f56e7b7677feff24624233ba04446ed60674c))
- Added adtracking to Livesession ([commit cd0f56e](https://github.com/googleapis/google-cloud-dotnet/commit/cd0f56e7b7677feff24624233ba04446ed60674c))
- Added fetchoptions with custom headers for Live and VODConfigs ([commit cd0f56e](https://github.com/googleapis/google-cloud-dotnet/commit/cd0f56e7b7677feff24624233ba04446ed60674c))

### Documentation improvements

- Added apis for Create, Read, Update, Delete For VODConfigs. Added vodConfig usage in VODSession. Added TokenConfig for MediaCdnKey. Added targeting_parameter and ad_tracking for Livesession. Added FetchOptions for Live and VOD configs. ([commit cd0f56e](https://github.com/googleapis/google-cloud-dotnet/commit/cd0f56e7b7677feff24624233ba04446ed60674c))
