### PR TITLE
Release Google.Cloud.VmwareEngine.V1 version 1.5.0

### DIFF
--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.csproj
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.4.0</Version>
+    <Version>1.5.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google VMware Engine API, which lets you programmatically manage VMware environments.</Description>
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.3.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.VmwareEngine.V1/docs/history.md
+++ b/apis/Google.Cloud.VmwareEngine.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.5.0, released 2024-06-04
+
+### New features
+
+- Add properties for nested resource name references ([commit 15eec4d](https://github.com/googleapis/google-cloud-dotnet/commit/15eec4dabb9fd3cf3b8f4b978d64b7ba435ca995))
+
 ## Version 1.4.0, released 2024-05-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5265,7 +5265,7 @@
     },
     {
       "id": "Google.Cloud.VmwareEngine.V1",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "type": "grpc",
       "productName": "VMware Engine",
       "productUrl": "https://cloud.google.com/vmware-engine/docs",
@@ -5274,9 +5274,9 @@
         "vmware"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.2.0",
-        "Google.Cloud.Location": "2.2.0",
-        "Google.LongRunning": "3.2.0"
+        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Location": "2.3.0",
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/vmwareengine/v1",


### PR DESCRIPTION

Changes in this release:

### New features

- Add properties for nested resource name references ([commit 15eec4d](https://github.com/googleapis/google-cloud-dotnet/commit/15eec4dabb9fd3cf3b8f4b978d64b7ba435ca995))
