### PR TITLE
Release Google.Maps.FleetEngine.Delivery.V1 version 2.1.0

### DIFF
--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.csproj
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Fleet Engine Delivery API (v1), which enables access to Deliveries Solutions.</Description>

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/docs/history.md
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.1.0, released 2024-06-04
+
+### Documentation improvements
+
+- Remove comment about deleted SearchTasks method ([commit baba90c](https://github.com/googleapis/google-cloud-dotnet/commit/baba90cf3feb33c19c036e90ebc2066e9269add1))
+
 ## Version 2.0.0, released 2024-05-08
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5615,7 +5615,7 @@
     },
     {
       "id": "Google.Maps.FleetEngine.Delivery.V1",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "productName": "Last Mile Fleet Solution Delivery",
       "productUrl": "https://developers.google.com/maps/documentation/transportation-logistics/mobility",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Remove comment about deleted SearchTasks method ([commit baba90c](https://github.com/googleapis/google-cloud-dotnet/commit/baba90cf3feb33c19c036e90ebc2066e9269add1))
