### PR TITLE
Release Google.Shopping.Merchant.Reports.V1Beta version 1.0.0-beta03

### DIFF
--- a/apis/Google.Shopping.Merchant.Reports.V1Beta/Google.Shopping.Merchant.Reports.V1Beta/Google.Shopping.Merchant.Reports.V1Beta.csproj
+++ b/apis/Google.Shopping.Merchant.Reports.V1Beta/Google.Shopping.Merchant.Reports.V1Beta/Google.Shopping.Merchant.Reports.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Merchant Reports API (v1beta) which allows you to programmatically manage your Merchant Center accounts.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.Shopping.Type" Version="[1.0.0-beta05, 2.0.0)" />
+    <PackageReference Include="Google.Shopping.Type" Version="[1.0.0-beta06, 2.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Shopping.Merchant.Reports.V1Beta/docs/history.md
+++ b/apis/Google.Shopping.Merchant.Reports.V1Beta/docs/history.md
@@ -1,5 +1,21 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2024-06-04
+
+### New features
+
+- Add `non_product_performance_view` table to Reports sub-API ([commit d03e054](https://github.com/googleapis/google-cloud-dotnet/commit/d03e054359a122ff6a8a80471960ba588f44514d))
+- Add `effectiveness` field to `price_insights_product_view` table in Reports sub-API ([commit d03e054](https://github.com/googleapis/google-cloud-dotnet/commit/d03e054359a122ff6a8a80471960ba588f44514d))
+- A new enum `Effectiveness` is added ([commit a8a8d1e](https://github.com/googleapis/google-cloud-dotnet/commit/a8a8d1ed3650e4c4e6b7712a808fb490200c5e55))
+- A new field `effectiveness` is added to message `.google.shopping.merchant.reports.v1beta.PriceInsightsProductView` ([commit a8a8d1e](https://github.com/googleapis/google-cloud-dotnet/commit/a8a8d1ed3650e4c4e6b7712a808fb490200c5e55))
+
+### Documentation improvements
+
+- A comment for enum `AggregatedReportingContextStatus` is changed ([commit a8a8d1e](https://github.com/googleapis/google-cloud-dotnet/commit/a8a8d1ed3650e4c4e6b7712a808fb490200c5e55))
+- A comment for field `shipping_label` in message `.google.shopping.merchant.reports.v1beta.ProductView` is changed ([commit a8a8d1e](https://github.com/googleapis/google-cloud-dotnet/commit/a8a8d1ed3650e4c4e6b7712a808fb490200c5e55))
+- A comment for field `inventory_status` in message `.google.shopping.merchant.reports.v1beta.BestSellersProductClusterView` is changed ([commit a8a8d1e](https://github.com/googleapis/google-cloud-dotnet/commit/a8a8d1ed3650e4c4e6b7712a808fb490200c5e55))
+- A comment for field `brand_inventory_status` in message `.google.shopping.merchant.reports.v1beta.BestSellersProductClusterView` is changed ([commit a8a8d1e](https://github.com/googleapis/google-cloud-dotnet/commit/a8a8d1ed3650e4c4e6b7712a808fb490200c5e55))
+
 ## Version 1.0.0-beta02, released 2024-05-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5943,7 +5943,7 @@
     },
     {
       "id": "Google.Shopping.Merchant.Reports.V1Beta",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "Merchant",
       "productUrl": "https://developers.google.com/merchant/api",
@@ -5953,7 +5953,7 @@
         "reports"
       ],
       "dependencies": {
-        "Google.Shopping.Type": "1.0.0-beta05"
+        "Google.Shopping.Type": "1.0.0-beta06"
       },
       "generator": "micro",
       "protoPath": "google/shopping/merchant/reports/v1beta",


### PR DESCRIPTION

Changes in this release:

### New features

- Add `non_product_performance_view` table to Reports sub-API ([commit d03e054](https://github.com/googleapis/google-cloud-dotnet/commit/d03e054359a122ff6a8a80471960ba588f44514d))
- Add `effectiveness` field to `price_insights_product_view` table in Reports sub-API ([commit d03e054](https://github.com/googleapis/google-cloud-dotnet/commit/d03e054359a122ff6a8a80471960ba588f44514d))
- A new enum `Effectiveness` is added ([commit a8a8d1e](https://github.com/googleapis/google-cloud-dotnet/commit/a8a8d1ed3650e4c4e6b7712a808fb490200c5e55))
- A new field `effectiveness` is added to message `.google.shopping.merchant.reports.v1beta.PriceInsightsProductView` ([commit a8a8d1e](https://github.com/googleapis/google-cloud-dotnet/commit/a8a8d1ed3650e4c4e6b7712a808fb490200c5e55))

### Documentation improvements

- A comment for enum `AggregatedReportingContextStatus` is changed ([commit a8a8d1e](https://github.com/googleapis/google-cloud-dotnet/commit/a8a8d1ed3650e4c4e6b7712a808fb490200c5e55))
- A comment for field `shipping_label` in message `.google.shopping.merchant.reports.v1beta.ProductView` is changed ([commit a8a8d1e](https://github.com/googleapis/google-cloud-dotnet/commit/a8a8d1ed3650e4c4e6b7712a808fb490200c5e55))
- A comment for field `inventory_status` in message `.google.shopping.merchant.reports.v1beta.BestSellersProductClusterView` is changed ([commit a8a8d1e](https://github.com/googleapis/google-cloud-dotnet/commit/a8a8d1ed3650e4c4e6b7712a808fb490200c5e55))
- A comment for field `brand_inventory_status` in message `.google.shopping.merchant.reports.v1beta.BestSellersProductClusterView` is changed ([commit a8a8d1e](https://github.com/googleapis/google-cloud-dotnet/commit/a8a8d1ed3650e4c4e6b7712a808fb490200c5e55))
