### PR TITLE
Release Google.Cloud.Redis.Cluster.V1 version 1.3.0

### DIFF
--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.csproj
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library for the Redis Cluster API (v1), which creates and manages Redis instances on the Google Cloud Platform.</Description>
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.3.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Redis.Cluster.V1/docs/history.md
+++ b/apis/Google.Cloud.Redis.Cluster.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 1.3.0, released 2024-06-10
+
+### New features
+
+- [Memorystore for Redis Cluster] Add support for different node types ([commit 536acb5](https://github.com/googleapis/google-cloud-dotnet/commit/536acb56ba7e3f849aedba247d604707fcf841db))
+- [Memorystore for Redis Cluster] Add persistence support ([commit 536acb5](https://github.com/googleapis/google-cloud-dotnet/commit/536acb56ba7e3f849aedba247d604707fcf841db))
+- [Memorystore for Redis Cluster] Get details of certificate authority from redis cluster ([commit 536acb5](https://github.com/googleapis/google-cloud-dotnet/commit/536acb56ba7e3f849aedba247d604707fcf841db))
+
+### Documentation improvements
+
+- [Memorystore for Redis Cluster] size_gb field shows the size of the cluster rounded up to the next integer, precise_size_gb field will show the exact size of the cluster ([commit 536acb5](https://github.com/googleapis/google-cloud-dotnet/commit/536acb56ba7e3f849aedba247d604707fcf841db))
+
 ## Version 1.2.0, released 2024-05-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3941,7 +3941,7 @@
     },
     {
       "id": "Google.Cloud.Redis.Cluster.V1",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "type": "grpc",
       "productName": "Google Cloud Memorystore for Redis (cluster management)",
       "productUrl": "https://cloud.google.com/memorystore/docs/redis",
@@ -3952,8 +3952,8 @@
         "Cluster"
       ],
       "dependencies": {
-        "Google.Cloud.Location": "2.2.0",
-        "Google.LongRunning": "3.2.0"
+        "Google.Cloud.Location": "2.3.0",
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/redis/cluster/v1",


### PR DESCRIPTION

Changes in this release:

### New features

- [Memorystore for Redis Cluster] Add support for different node types ([commit 536acb5](https://github.com/googleapis/google-cloud-dotnet/commit/536acb56ba7e3f849aedba247d604707fcf841db))
- [Memorystore for Redis Cluster] Add persistence support ([commit 536acb5](https://github.com/googleapis/google-cloud-dotnet/commit/536acb56ba7e3f849aedba247d604707fcf841db))
- [Memorystore for Redis Cluster] Get details of certificate authority from redis cluster ([commit 536acb5](https://github.com/googleapis/google-cloud-dotnet/commit/536acb56ba7e3f849aedba247d604707fcf841db))

### Documentation improvements

- [Memorystore for Redis Cluster] size_gb field shows the size of the cluster rounded up to the next integer, precise_size_gb field will show the exact size of the cluster ([commit 536acb5](https://github.com/googleapis/google-cloud-dotnet/commit/536acb56ba7e3f849aedba247d604707fcf841db))
