### PR TITLE
chore: Update Microsoft.CodeAnalysis dependencies in Bigtable

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/Google.Cloud.Bigtable.V2.GenerateClient.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/Google.Cloud.Bigtable.V2.GenerateClient.csproj
@@ -15,8 +15,8 @@
       - or https://github.com/dotnet/roslyn/issues/71784 is fixed.
       - See b/328172159 as an example of the failure.
       -->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.10.0" />
 
     <!--
       - For some reason, the above packages introduce a dependency somewhere on version 3.0.3


### PR DESCRIPTION
#13156 and #13157 shoulc autoclose after this one is merged.