### PR TITLE
Release Google.Cloud.Storage.Control.V2 version 1.0.1

### DIFF
--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.csproj
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Storage Control API (v2), providing control-plane functionality for Google Cloud Storage.</Description>

--- a/apis/Google.Cloud.Storage.Control.V2/docs/history.md
+++ b/apis/Google.Cloud.Storage.Control.V2/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+## Version 1.0.1, released 2024-06-20
+
+No API surface changes; this release is purely to publish
+documentation which did not happen in the 1.0.0 release.
+
 ## Version 1.0.0, released 2024-06-18
 
 No API surface changes; just dependency updates and promotion to GA.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4762,7 +4762,7 @@
     },
     {
       "id": "Google.Cloud.Storage.Control.V2",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "type": "grpc",
       "productName": "Cloud Storage",
       "productUrl": "https://cloud.google.com/storage/docs/overview",
@@ -4775,7 +4775,9 @@
         "gcs"
       ],
       "dependencies": {
-        "Google.LongRunning": "3.3.0"
+        "Google.LongRunning": "3.3.0",
+        "Google.Api.Gax.Grpc": "4.8.0",
+        "Grpc.Core": "2.46.6"
       },
       "generator": "micro",
       "protoPath": "google/storage/control/v2",


### PR DESCRIPTION

Changes in this release:

No API surface changes; this release is purely to publish documentation which did not happen in the 1.0.0 release.
