### PR TITLE
Release Google.Cloud.BackupDR.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.csproj
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Backup and DR service, which is a powerful, centralized, cloud-first backup and disaster recovery solution for cloud-based and hybrid workloads.</Description>

--- a/apis/Google.Cloud.BackupDR.V1/docs/history.md
+++ b/apis/Google.Cloud.BackupDR.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 1.1.0, released 2024-06-24
+
+### New features
+
+- A new field `satisfies_pzs` is added ([commit 401cd38](https://github.com/googleapis/google-cloud-dotnet/commit/401cd38b79392a8e702bdd7718e99d69e26b5a8f))
+- A new field `satisfies_pzi` is added ([commit 401cd38](https://github.com/googleapis/google-cloud-dotnet/commit/401cd38b79392a8e702bdd7718e99d69e26b5a8f))
+- Updated documentation URI ([commit 401cd38](https://github.com/googleapis/google-cloud-dotnet/commit/401cd38b79392a8e702bdd7718e99d69e26b5a8f))
 ## Version 1.0.0, released 2024-05-24
 
 No API surface changes; just dependency updates and promotion to GA.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -641,7 +641,7 @@
     },
     {
       "id": "Google.Cloud.BackupDR.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Backup and DR Service",
       "productUrl": "https://cloud.google.com/backup-disaster-recovery/docs/concepts/backup-dr",


### PR DESCRIPTION

Changes in this release:

### New features

- A new field `satisfies_pzs` is added ([commit 401cd38](https://github.com/googleapis/google-cloud-dotnet/commit/401cd38b79392a8e702bdd7718e99d69e26b5a8f))
- A new field `satisfies_pzi` is added ([commit 401cd38](https://github.com/googleapis/google-cloud-dotnet/commit/401cd38b79392a8e702bdd7718e99d69e26b5a8f))
- Updated documentation URI ([commit 401cd38](https://github.com/googleapis/google-cloud-dotnet/commit/401cd38b79392a8e702bdd7718e99d69e26b5a8f))
