### PR TITLE
Release Google.Cloud.Container.V1 version 3.29.0

### DIFF
--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.28.0</Version>
+    <Version>3.29.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.</Description>

--- a/apis/Google.Cloud.Container.V1/docs/history.md
+++ b/apis/Google.Cloud.Container.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.29.0, released 2024-06-24
+
+### New features
+
+- Enable REST transport for google/container/v1 ([commit 198c8c6](https://github.com/googleapis/google-cloud-dotnet/commit/198c8c65d3b7142ddacf671789521c37f62dd721))
+
 ## Version 3.28.0, released 2024-06-10
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1572,7 +1572,7 @@
       "protoPath": "google/container/v1",
       "productName": "Google Kubernetes Engine",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/reference/rest/",
-      "version": "3.28.0",
+      "version": "3.29.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.",
       "dependencies": {},


### PR DESCRIPTION

Changes in this release:

### New features

- Enable REST transport for google/container/v1 ([commit 198c8c6](https://github.com/googleapis/google-cloud-dotnet/commit/198c8c65d3b7142ddacf671789521c37f62dd721))
