### PR TITLE
Release Google.Cloud.Dataplex.V1 version 3.2.0

### DIFF
--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.csproj
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataplex API, which is used to manage the lifecycle of data lakes.</Description>

--- a/apis/Google.Cloud.Dataplex.V1/docs/history.md
+++ b/apis/Google.Cloud.Dataplex.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 3.2.0, released 2024-06-24
+
+### New features
+
+- Exposing EntrySource.location field that contains location of a resource in the source system ([commit 4ce6d1e](https://github.com/googleapis/google-cloud-dotnet/commit/4ce6d1e6a9841ba9b1ffe7be7935d01f98e69b1e))
+
+### Documentation improvements
+
+- Scrub descriptions for GenerateDataQualityRules ([commit 4ce6d1e](https://github.com/googleapis/google-cloud-dotnet/commit/4ce6d1e6a9841ba9b1ffe7be7935d01f98e69b1e))
+- Clarify DataQualityRule.sql_assertion descriptions ([commit 5c4607f](https://github.com/googleapis/google-cloud-dotnet/commit/5c4607f3690d4b65941a6dcd8cf341f4243d8662))
+- Fix links to RuleType proto references ([commit 5c4607f](https://github.com/googleapis/google-cloud-dotnet/commit/5c4607f3690d4b65941a6dcd8cf341f4243d8662))
+
 ## Version 3.1.0, released 2024-06-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1699,7 +1699,7 @@
     },
     {
       "id": "Google.Cloud.Dataplex.V1",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "type": "grpc",
       "productName": "Cloud Dataplex",
       "productUrl": "https://cloud.google.com/dataplex/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Exposing EntrySource.location field that contains location of a resource in the source system ([commit 4ce6d1e](https://github.com/googleapis/google-cloud-dotnet/commit/4ce6d1e6a9841ba9b1ffe7be7935d01f98e69b1e))

### Documentation improvements

- Scrub descriptions for GenerateDataQualityRules ([commit 4ce6d1e](https://github.com/googleapis/google-cloud-dotnet/commit/4ce6d1e6a9841ba9b1ffe7be7935d01f98e69b1e))
- Clarify DataQualityRule.sql_assertion descriptions ([commit 5c4607f](https://github.com/googleapis/google-cloud-dotnet/commit/5c4607f3690d4b65941a6dcd8cf341f4243d8662))
- Fix links to RuleType proto references ([commit 5c4607f](https://github.com/googleapis/google-cloud-dotnet/commit/5c4607f3690d4b65941a6dcd8cf341f4243d8662))
