### PR TITLE
Release Google.Cloud.Firestore.Admin.V1 version 3.10.0

### DIFF
--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.csproj
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.9.0</Version>
+    <Version>3.10.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Firestore Admin API.</Description>
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.3.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Firestore.Admin.V1/docs/history.md
+++ b/apis/Google.Cloud.Firestore.Admin.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.10.0, released 2024-06-24
+
+### New features
+
+- Add bulk delete api ([commit 75848dd](https://github.com/googleapis/google-cloud-dotnet/commit/75848dd15ccd47ad3ca9d03d771b75b2d06a8816))
+
+### Documentation improvements
+
+- Update field api description ([commit 75848dd](https://github.com/googleapis/google-cloud-dotnet/commit/75848dd15ccd47ad3ca9d03d771b75b2d06a8816))
+
 ## Version 3.9.0, released 2024-05-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2371,7 +2371,7 @@
       "listingDescription": "Firestore Administration (e.g. index management)",
       "productName": "Firestore Admin",
       "productUrl": "https://firebase.google.com",
-      "version": "3.9.0",
+      "version": "3.10.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Firestore Admin API.",
       "tags": [
@@ -2380,8 +2380,8 @@
         "admin"
       ],
       "dependencies": {
-        "Google.Cloud.Location": "2.2.0",
-        "Google.LongRunning": "3.2.0"
+        "Google.Cloud.Location": "2.3.0",
+        "Google.LongRunning": "3.3.0"
       },
       "shortName": "firestore",
       "serviceConfigFile": "firestore_v1.yaml",


### PR DESCRIPTION

Changes in this release:

### New features

- Add bulk delete api ([commit 75848dd](https://github.com/googleapis/google-cloud-dotnet/commit/75848dd15ccd47ad3ca9d03d771b75b2d06a8816))

### Documentation improvements

- Update field api description ([commit 75848dd](https://github.com/googleapis/google-cloud-dotnet/commit/75848dd15ccd47ad3ca9d03d771b75b2d06a8816))
