### PR TITLE
Release Google.Cloud.Monitoring.V3 version 3.11.0

### DIFF
--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.10.0</Version>
+    <Version>3.11.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Monitoring API, which manages your Google Cloud Monitoring data and configurations.</Description>

--- a/apis/Google.Cloud.Monitoring.V3/docs/history.md
+++ b/apis/Google.Cloud.Monitoring.V3/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.11.0, released 2024-06-24
+
+### New features
+
+- Add support to add links in AlertPolicy ([commit 3513b82](https://github.com/googleapis/google-cloud-dotnet/commit/3513b829e9f69a503494975f9e86e4568db66dad))
+
 ## Version 3.10.0, released 2024-06-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3234,7 +3234,7 @@
       "protoPath": "google/monitoring/v3",
       "productName": "Google Cloud Monitoring",
       "productUrl": "https://cloud.google.com/monitoring/api/v3/",
-      "version": "3.10.0",
+      "version": "3.11.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Monitoring API, which manages your Google Cloud Monitoring data and configurations.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Add support to add links in AlertPolicy ([commit 3513b82](https://github.com/googleapis/google-cloud-dotnet/commit/3513b829e9f69a503494975f9e86e4568db66dad))
