### PR TITLE
Release Google.Cloud.PubSub.V1 version 3.15.0

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.14.0</Version>
+    <Version>3.15.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.</Description>

--- a/apis/Google.Cloud.PubSub.V1/docs/history.md
+++ b/apis/Google.Cloud.PubSub.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.15.0, released 2024-06-24
+
+### New features
+
+- Add use_topic_schema for Cloud Storage Subscriptions ([commit d557116](https://github.com/googleapis/google-cloud-dotnet/commit/d557116c5844dc4fdd4da4637d7713b325d7dfe7))
+
 ## Version 3.14.0, released 2024-05-31
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3843,7 +3843,7 @@
       "protoPath": "google/pubsub/v1",
       "productName": "Cloud Pub/Sub",
       "productUrl": "https://cloud.google.com/pubsub/",
-      "version": "3.14.0",
+      "version": "3.15.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",


### PR DESCRIPTION

Changes in this release:

### New features

- Add use_topic_schema for Cloud Storage Subscriptions ([commit d557116](https://github.com/googleapis/google-cloud-dotnet/commit/d557116c5844dc4fdd4da4637d7713b325d7dfe7))
