### PR TITLE
Release Google.Cloud.SecurityCenterManagement.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.csproj
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Security Command Center Management API, a built-in security and risk management solution for Google Cloud.</Description>

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/docs/history.md
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 1.1.0, released 2024-06-24
+
+### New features
+
+- Add `TOXIC_COMBINATION` to `FindingClass` enum ([commit 67f599e](https://github.com/googleapis/google-cloud-dotnet/commit/67f599eecc849a94b692b42648410ac685d7c88b))
+- Add `show_eligible_modules_only` field to `GetSecurityCenterServiceRequest` message ([commit 67f599e](https://github.com/googleapis/google-cloud-dotnet/commit/67f599eecc849a94b692b42648410ac685d7c88b))
+- Add an INGEST_ONLY EnablementState ([commit 2e6ed33](https://github.com/googleapis/google-cloud-dotnet/commit/2e6ed3391be2710d674d3606a473ccd5d8058947))
+
+### Documentation improvements
+
+- Minor docs formatting in `UpdateSecurityCenterServiceRequest.validate_only` ([commit ee64d62](https://github.com/googleapis/google-cloud-dotnet/commit/ee64d62302a7d363b15dd105d56bb839b4e746fc))
+
 ## Version 1.0.0, released 2024-05-24
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4401,7 +4401,7 @@
     },
     {
       "id": "Google.Cloud.SecurityCenterManagement.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Security Center Management",
       "productUrl": "https://cloud.google.com/security-command-center/docs/reference/security-center-management/rest",


### PR DESCRIPTION

Changes in this release:

### New features

- Add `TOXIC_COMBINATION` to `FindingClass` enum ([commit 67f599e](https://github.com/googleapis/google-cloud-dotnet/commit/67f599eecc849a94b692b42648410ac685d7c88b))
- Add `show_eligible_modules_only` field to `GetSecurityCenterServiceRequest` message ([commit 67f599e](https://github.com/googleapis/google-cloud-dotnet/commit/67f599eecc849a94b692b42648410ac685d7c88b))
- Add an INGEST_ONLY EnablementState ([commit 2e6ed33](https://github.com/googleapis/google-cloud-dotnet/commit/2e6ed3391be2710d674d3606a473ccd5d8058947))

### Documentation improvements

- Minor docs formatting in `UpdateSecurityCenterServiceRequest.validate_only` ([commit ee64d62](https://github.com/googleapis/google-cloud-dotnet/commit/ee64d62302a7d363b15dd105d56bb839b4e746fc))
