### PR TITLE
Release Firestore libraries version 3.8.0

### DIFF
--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.7.0</Version>
+    <Version>3.8.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Low-level Google client library to access the Firestore API. Users are recommended to use the Google.Cloud.Firestore package instead.</Description>
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.3.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Firestore.V1/docs/history.md
+++ b/apis/Google.Cloud.Firestore.V1/docs/history.md
@@ -4,6 +4,10 @@ This package is primarily a dependency of Google.Cloud.Firestore. See the
 [Google.Cloud.Firestore version history](https://googleapis.dev/dotnet/Google.Cloud.Firestore/latest/history.html)
 for more details.
 
+## Version 3.8.0, released 2024-06-24
+
+No API surface changes; just dependency updates.
+
 ## Version 3.7.0, released 2024-05-03
 
 ### New features

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/Google.Cloud.Firestore.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/Google.Cloud.Firestore.IntegrationTests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Google.Api.Gax.Testing" Version="[4.8.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Firestore\Google.Cloud.Firestore.csproj" />
-    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.8.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.9.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core.Testing" Version="[2.46.6, 3.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/Google.Cloud.Firestore.Snippets.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/Google.Cloud.Firestore.Snippets.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Google.Api.Gax.Testing" Version="[4.8.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Firestore\Google.Cloud.Firestore.csproj" />
-    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.8.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.9.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core.Testing" Version="[2.46.6, 3.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Google.Cloud.Firestore.Tests.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Google.Cloud.Firestore.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Google.Api.Gax.Testing" Version="[4.8.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Firestore\Google.Cloud.Firestore.csproj" />
-    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.8.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.9.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core.Testing" Version="[2.46.6, 3.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.7.0</Version>
+    <Version>3.8.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Firestore API.</Description>

--- a/apis/Google.Cloud.Firestore/docs/history.md
+++ b/apis/Google.Cloud.Firestore/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.8.0, released 2024-06-24
+
+### New features
+
+- Add dependency injection support for FirestoreDb ([commit 1a7e44b](https://github.com/googleapis/google-cloud-dotnet/commit/1a7e44bc3c0f0638977191bb48a4e993a75ece03))
+
+### Documentation improvements
+
+- Fix documentation for FirestoreDocumentUpdateTimestampAttribute ([commit 836de44](https://github.com/googleapis/google-cloud-dotnet/commit/836de44bedbcd0fc3b652b293b6aa1ab48e07e39))
+
 ## Version 3.7.0, released 2024-05-03
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2394,7 +2394,7 @@
       "productName": "Firestore",
       "productUrl": "https://firebase.google.com/docs/firestore/",
       "listingDescription": "Firestore high-level library",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "type": "other",
       "metadataType": "GAPIC_MANUAL",
       "description": "Recommended Google client library to access the Firestore API.",
@@ -2411,7 +2411,7 @@
       "testDependencies": {
         "Google.Api.Gax.Grpc.Testing": "default",
         "Google.Api.Gax.Testing": "default",
-        "Google.Cloud.Firestore.Admin.V1": "3.8.0",
+        "Google.Cloud.Firestore.Admin.V1": "3.9.0",
         "Grpc.Core.Testing": "2.46.6",
         "System.ValueTuple": "4.5.0",
         "Xunit.Combinatorial": "1.6.24"
@@ -2425,7 +2425,7 @@
       "productName": "Firestore",
       "productUrl": "https://firebase.google.com",
       "listingDescription": "Firestore low-level API access",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "type": "grpc",
       "description": "Low-level Google client library to access the Firestore API. Users are recommended to use the Google.Cloud.Firestore package instead.",
       "tags": [
@@ -2434,8 +2434,8 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc": "default",
-        "Google.Cloud.Location": "2.2.0",
-        "Google.LongRunning": "3.2.0",
+        "Google.Cloud.Location": "2.3.0",
+        "Google.LongRunning": "3.3.0",
         "Grpc.Core": "2.46.6"
       },
       "shortName": "firestore",


### PR DESCRIPTION

Changes in Google.Cloud.Firestore version 3.8.0:

### New features

- Add dependency injection support for FirestoreDb ([commit 1a7e44b](https://github.com/googleapis/google-cloud-dotnet/commit/1a7e44bc3c0f0638977191bb48a4e993a75ece03))

### Documentation improvements

- Fix documentation for FirestoreDocumentUpdateTimestampAttribute ([commit 836de44](https://github.com/googleapis/google-cloud-dotnet/commit/836de44bedbcd0fc3b652b293b6aa1ab48e07e39))

Changes in Google.Cloud.Firestore.V1 version 3.8.0:

No API surface changes; just dependency updates.

Packages in this release:
- Release Google.Cloud.Firestore version 3.8.0
- Release Google.Cloud.Firestore.V1 version 3.8.0
