### PR TITLE
Release Google.Cloud.Batch.V1 version 2.11.0

### DIFF
--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.10.0</Version>
+    <Version>2.11.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.3.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Batch.V1/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1/docs/history.md
@@ -1,5 +1,21 @@
 # Version history
 
+## Version 2.11.0, released 2024-07-01
+
+### New features
+
+- Add a install_ops_agent field to InstancePolicyOrTemplate for Ops Agent support ([commit d8e69ab](https://github.com/googleapis/google-cloud-dotnet/commit/d8e69ab0b8dfe4d31a10f2ffbd197da1c7f4cee5))
+
+### Documentation improvements
+
+- Add instructions on how to configure cross-project pubsub publisher ([commit d8e69ab](https://github.com/googleapis/google-cloud-dotnet/commit/d8e69ab0b8dfe4d31a10f2ffbd197da1c7f4cee5))
+- Document default disk type: pd-standard for non boot disk, pd-balanced for boot disk ([commit d8e69ab](https://github.com/googleapis/google-cloud-dotnet/commit/d8e69ab0b8dfe4d31a10f2ffbd197da1c7f4cee5))
+- Update list of volume.mount_options field ([commit d8e69ab](https://github.com/googleapis/google-cloud-dotnet/commit/d8e69ab0b8dfe4d31a10f2ffbd197da1c7f4cee5))
+- Update GCS description of volume.mount_options field ([commit d8e69ab](https://github.com/googleapis/google-cloud-dotnet/commit/d8e69ab0b8dfe4d31a10f2ffbd197da1c7f4cee5))
+- Update links in the description of volume.mount_options field ([commit d8e69ab](https://github.com/googleapis/google-cloud-dotnet/commit/d8e69ab0b8dfe4d31a10f2ffbd197da1c7f4cee5))
+- Documentation improvements ([commit 5d53acd](https://github.com/googleapis/google-cloud-dotnet/commit/5d53acd9466eb6fccc74f0d195bb0b5c23c4c6f9))
+- Refine description for field `task_execution` ([commit 7115e29](https://github.com/googleapis/google-cloud-dotnet/commit/7115e2973ebcad9290fbb5748f12ac4f5c50eb11))
+
 ## Version 2.10.0, released 2024-05-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -689,7 +689,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",
@@ -698,9 +698,9 @@
         "batch"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.2.0",
-        "Google.Cloud.Location": "2.2.0",
-        "Google.LongRunning": "3.2.0"
+        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Location": "2.3.0",
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/batch/v1",


### PR DESCRIPTION

Changes in this release:

### New features

- Add a install_ops_agent field to InstancePolicyOrTemplate for Ops Agent support ([commit d8e69ab](https://github.com/googleapis/google-cloud-dotnet/commit/d8e69ab0b8dfe4d31a10f2ffbd197da1c7f4cee5))

### Documentation improvements

- Add instructions on how to configure cross-project pubsub publisher ([commit d8e69ab](https://github.com/googleapis/google-cloud-dotnet/commit/d8e69ab0b8dfe4d31a10f2ffbd197da1c7f4cee5))
- Document default disk type: pd-standard for non boot disk, pd-balanced for boot disk ([commit d8e69ab](https://github.com/googleapis/google-cloud-dotnet/commit/d8e69ab0b8dfe4d31a10f2ffbd197da1c7f4cee5))
- Update list of volume.mount_options field ([commit d8e69ab](https://github.com/googleapis/google-cloud-dotnet/commit/d8e69ab0b8dfe4d31a10f2ffbd197da1c7f4cee5))
- Update GCS description of volume.mount_options field ([commit d8e69ab](https://github.com/googleapis/google-cloud-dotnet/commit/d8e69ab0b8dfe4d31a10f2ffbd197da1c7f4cee5))
- Update links in the description of volume.mount_options field ([commit d8e69ab](https://github.com/googleapis/google-cloud-dotnet/commit/d8e69ab0b8dfe4d31a10f2ffbd197da1c7f4cee5))
- Documentation improvements ([commit 5d53acd](https://github.com/googleapis/google-cloud-dotnet/commit/5d53acd9466eb6fccc74f0d195bb0b5c23c4c6f9))
- Refine description for field `task_execution` ([commit 7115e29](https://github.com/googleapis/google-cloud-dotnet/commit/7115e2973ebcad9290fbb5748f12ac4f5c50eb11))
