### PR TITLE
Release Google.Cloud.BigQuery.AnalyticsHub.V1 version 1.7.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.6.0</Version>
+    <Version>1.7.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Analytics Hub, which allows users to exchange data and analytics assets securely and efficiently.</Description>

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 1.7.0, released 2024-07-08
+
+### New features
+
+- Support public directory self service for Listings/Exchanges ([commit b8e1836](https://github.com/googleapis/google-cloud-dotnet/commit/b8e1836f97c7a27540e7e7bd79658c87609ac71a))
+- Support Direct Table Access Toggle (Egress GA) ([commit b8e1836](https://github.com/googleapis/google-cloud-dotnet/commit/b8e1836f97c7a27540e7e7bd79658c87609ac71a))
+
+### Documentation improvements
+
+- A comment for message `Listing` is changed ([commit b8e1836](https://github.com/googleapis/google-cloud-dotnet/commit/b8e1836f97c7a27540e7e7bd79658c87609ac71a))
+- A comment for message `DataExchange` is changed ([commit b8e1836](https://github.com/googleapis/google-cloud-dotnet/commit/b8e1836f97c7a27540e7e7bd79658c87609ac71a))
+
 ## Version 1.6.0, released 2024-06-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -823,7 +823,7 @@
     },
     {
       "id": "Google.Cloud.BigQuery.AnalyticsHub.V1",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "type": "grpc",
       "productName": "Analytics Hub",
       "productUrl": "https://cloud.google.com/analytics-hub",


### PR DESCRIPTION

Changes in this release:

### New features

- Support public directory self service for Listings/Exchanges ([commit b8e1836](https://github.com/googleapis/google-cloud-dotnet/commit/b8e1836f97c7a27540e7e7bd79658c87609ac71a))
- Support Direct Table Access Toggle (Egress GA) ([commit b8e1836](https://github.com/googleapis/google-cloud-dotnet/commit/b8e1836f97c7a27540e7e7bd79658c87609ac71a))

### Documentation improvements

- A comment for message `Listing` is changed ([commit b8e1836](https://github.com/googleapis/google-cloud-dotnet/commit/b8e1836f97c7a27540e7e7bd79658c87609ac71a))
- A comment for message `DataExchange` is changed ([commit b8e1836](https://github.com/googleapis/google-cloud-dotnet/commit/b8e1836f97c7a27540e7e7bd79658c87609ac71a))
