### PR TITLE
Release Google.Cloud.Dataproc.V1 version 5.12.0

### DIFF
--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.11.0</Version>
+    <Version>5.12.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataproc API, which manages Hadoop-based clusters and jobs on Google Cloud Platform.</Description>
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Dataproc.V1/docs/history.md
+++ b/apis/Google.Cloud.Dataproc.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 5.12.0, released 2024-07-08
+
+### New features
+
+- Add the cohort and auto tuning configuration to the batch's RuntimeConfig ([commit b5e041d](https://github.com/googleapis/google-cloud-dotnet/commit/b5e041d1f859a5d14601e4f37c1f4b7b8bf0fa15))
+
 ## Version 5.11.0, released 2024-05-13
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1727,7 +1727,7 @@
       "protoPath": "google/cloud/dataproc/v1",
       "productName": "Google Cloud Dataproc",
       "productUrl": "https://cloud.google.com/dataproc/docs/concepts/overview",
-      "version": "5.11.0",
+      "version": "5.12.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Dataproc API, which manages Hadoop-based clusters and jobs on Google Cloud Platform.",
       "tags": [
@@ -1735,8 +1735,8 @@
         "Hadoop"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.2.0",
-        "Google.LongRunning": "3.2.0"
+        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.LongRunning": "3.3.0"
       },
       "shortName": "dataproc",
       "serviceConfigFile": "dataproc_v1.yaml",


### PR DESCRIPTION

Changes in this release:

### New features

- Add the cohort and auto tuning configuration to the batch's RuntimeConfig ([commit b5e041d](https://github.com/googleapis/google-cloud-dotnet/commit/b5e041d1f859a5d14601e4f37c1f4b7b8bf0fa15))
