### PR TITLE
Release Google.Cloud.DiscoveryEngine.V1 version 1.3.0

### DIFF
--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.csproj
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Discovery Engine API (v1). Discovery Engine powers high-quality content recommendations on your digital properties for Discovery for Media.</Description>

--- a/apis/Google.Cloud.DiscoveryEngine.V1/docs/history.md
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 1.3.0, released 2024-07-08
+
+### New features
+
+- Add Chunk resource in the search response ([commit f45a47f](https://github.com/googleapis/google-cloud-dotnet/commit/f45a47fdbd58cbff8349ba7f0d9975bee8cf55a2))
+- Add NO_RELEVANT_CONTENT to Answer API ([commit f45a47f](https://github.com/googleapis/google-cloud-dotnet/commit/f45a47fdbd58cbff8349ba7f0d9975bee8cf55a2))
+- Support AlloyDB Connector ([commit f45a47f](https://github.com/googleapis/google-cloud-dotnet/commit/f45a47fdbd58cbff8349ba7f0d9975bee8cf55a2))
+
+### Documentation improvements
+
+- Keep the API doc up-to-date with recent changes ([commit f45a47f](https://github.com/googleapis/google-cloud-dotnet/commit/f45a47fdbd58cbff8349ba7f0d9975bee8cf55a2))
+
 ## Version 1.2.0, released 2024-06-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2052,7 +2052,7 @@
     },
     {
       "id": "Google.Cloud.DiscoveryEngine.V1",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "type": "grpc",
       "productName": "Discovery Engine",
       "productUrl": "https://cloud.google.com/discovery-engine/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add Chunk resource in the search response ([commit f45a47f](https://github.com/googleapis/google-cloud-dotnet/commit/f45a47fdbd58cbff8349ba7f0d9975bee8cf55a2))
- Add NO_RELEVANT_CONTENT to Answer API ([commit f45a47f](https://github.com/googleapis/google-cloud-dotnet/commit/f45a47fdbd58cbff8349ba7f0d9975bee8cf55a2))
- Support AlloyDB Connector ([commit f45a47f](https://github.com/googleapis/google-cloud-dotnet/commit/f45a47fdbd58cbff8349ba7f0d9975bee8cf55a2))

### Documentation improvements

- Keep the API doc up-to-date with recent changes ([commit f45a47f](https://github.com/googleapis/google-cloud-dotnet/commit/f45a47fdbd58cbff8349ba7f0d9975bee8cf55a2))
