### PR TITLE
Release Google.Cloud.Parallelstore.V1Beta version 1.0.0-beta04

### DIFF
--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.csproj
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to manage the Parallelstore high performance, managed parallel file service.</Description>

--- a/apis/Google.Cloud.Parallelstore.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 1.0.0-beta04, released 2024-07-08
+
+### New features
+
+- Add iam.googleapis.com/ServiceAccount resource definition ([commit 30a556d](https://github.com/googleapis/google-cloud-dotnet/commit/30a556d14d92f990dde82de69600515cf0ce18d8))
+- Adding Import/Export BYOSA to the export Data request ([commit 30a556d](https://github.com/googleapis/google-cloud-dotnet/commit/30a556d14d92f990dde82de69600515cf0ce18d8))
+- Adding Import/Export BYOSA to the import Data request ([commit 30a556d](https://github.com/googleapis/google-cloud-dotnet/commit/30a556d14d92f990dde82de69600515cf0ce18d8))
+
 ## Version 1.0.0-beta03, released 2024-05-17
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3687,7 +3687,7 @@
     },
     {
       "id": "Google.Cloud.Parallelstore.V1Beta",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0-beta04",
       "type": "grpc",
       "productName": "Parallelstore",
       "productUrl": "http://cloud/parallelstore?hl=en",


### PR DESCRIPTION

Changes in this release:

### New features

- Add iam.googleapis.com/ServiceAccount resource definition ([commit 30a556d](https://github.com/googleapis/google-cloud-dotnet/commit/30a556d14d92f990dde82de69600515cf0ce18d8))
- Adding Import/Export BYOSA to the export Data request ([commit 30a556d](https://github.com/googleapis/google-cloud-dotnet/commit/30a556d14d92f990dde82de69600515cf0ce18d8))
- Adding Import/Export BYOSA to the import Data request ([commit 30a556d](https://github.com/googleapis/google-cloud-dotnet/commit/30a556d14d92f990dde82de69600515cf0ce18d8))
