### PR TITLE
Release Google.Cloud.SecurityCenter.V2 version 1.0.0-beta04

### DIFF
--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.csproj
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Security Command Center API (v2), which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.</Description>
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.SecurityCenter.V2/docs/history.md
+++ b/apis/Google.Cloud.SecurityCenter.V2/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 1.0.0-beta04, released 2024-07-08
+
+### New features
+
+- Added cloud provider field to list findings response ([commit 7c4de98](https://github.com/googleapis/google-cloud-dotnet/commit/7c4de983db64fe1cf73a409656566a6c68714bb2))
+- Added http configuration rule to ResourceValueConfig and ValuedResource API methods ([commit 7c4de98](https://github.com/googleapis/google-cloud-dotnet/commit/7c4de983db64fe1cf73a409656566a6c68714bb2))
+- Added toxic combination field to finding ([commit 7c4de98](https://github.com/googleapis/google-cloud-dotnet/commit/7c4de983db64fe1cf73a409656566a6c68714bb2))
+- Add toxic_combination and group_memberships fields to finding ([commit fb4213a](https://github.com/googleapis/google-cloud-dotnet/commit/fb4213aecfa69d90b36d862189785131abe8d1c2))
+
+### Documentation improvements
+
+- Updated comments for ResourceValueConfig ([commit 7c4de98](https://github.com/googleapis/google-cloud-dotnet/commit/7c4de983db64fe1cf73a409656566a6c68714bb2))
+
 ## Version 1.0.0-beta03, released 2024-05-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4401,7 +4401,7 @@
     },
     {
       "id": "Google.Cloud.SecurityCenter.V2",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0-beta04",
       "type": "grpc",
       "productName": "Security Command Center",
       "productUrl": "https://cloud.google.com/security-command-center/docs/reference/rest",
@@ -4411,8 +4411,8 @@
         "data risk"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.2.0",
-        "Google.LongRunning": "3.2.0"
+        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/securitycenter/v2",


### PR DESCRIPTION

Changes in this release:

### New features

- Added cloud provider field to list findings response ([commit 7c4de98](https://github.com/googleapis/google-cloud-dotnet/commit/7c4de983db64fe1cf73a409656566a6c68714bb2))
- Added http configuration rule to ResourceValueConfig and ValuedResource API methods ([commit 7c4de98](https://github.com/googleapis/google-cloud-dotnet/commit/7c4de983db64fe1cf73a409656566a6c68714bb2))
- Added toxic combination field to finding ([commit 7c4de98](https://github.com/googleapis/google-cloud-dotnet/commit/7c4de983db64fe1cf73a409656566a6c68714bb2))
- Add toxic_combination and group_memberships fields to finding ([commit fb4213a](https://github.com/googleapis/google-cloud-dotnet/commit/fb4213aecfa69d90b36d862189785131abe8d1c2))

### Documentation improvements

- Updated comments for ResourceValueConfig ([commit 7c4de98](https://github.com/googleapis/google-cloud-dotnet/commit/7c4de983db64fe1cf73a409656566a6c68714bb2))
