### PR TITLE
Release Google.Cloud.BigQuery.Migration.V2 version 1.5.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.4.0</Version>
+    <Version>1.5.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Migration service, exposing apis for migration jobs operations, and agent management.</Description>

--- a/apis/Google.Cloud.BigQuery.Migration.V2/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 1.5.0, released 2024-07-22
+
+### New features
+
+- Update MS API stubs with Unified API ([commit a645ee7](https://github.com/googleapis/google-cloud-dotnet/commit/a645ee7f96307cf71de1fdac850acb35d83e8ef8))
+
+### Documentation improvements
+
+- A comment for field `name` in message `.google.cloud.bigquery.migration.v2.MigrationWorkflow` is changed to include 'Identifier' ([commit a645ee7](https://github.com/googleapis/google-cloud-dotnet/commit/a645ee7f96307cf71de1fdac850acb35d83e8ef8))
+- A comment for field `translation_config_details` in message `.google.cloud.bigquery.migration.v2.MigrationTask` is changed ([commit a645ee7](https://github.com/googleapis/google-cloud-dotnet/commit/a645ee7f96307cf71de1fdac850acb35d83e8ef8))
+- A comment for field `type` in message `.google.cloud.bigquery.migration.v2.MigrationTask` is changed to include new supported types ([commit a645ee7](https://github.com/googleapis/google-cloud-dotnet/commit/a645ee7f96307cf71de1fdac850acb35d83e8ef8))
+
 ## Version 1.4.0, released 2024-05-13
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -970,7 +970,7 @@
     },
     {
       "id": "Google.Cloud.BigQuery.Migration.V2",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "type": "grpc",
       "productName": "BigQuery Migration",
       "productUrl": "https://cloud.google.com/bigquery/docs/migration-intro",


### PR DESCRIPTION

Changes in this release:

### New features

- Update MS API stubs with Unified API ([commit a645ee7](https://github.com/googleapis/google-cloud-dotnet/commit/a645ee7f96307cf71de1fdac850acb35d83e8ef8))

### Documentation improvements

- A comment for field `name` in message `.google.cloud.bigquery.migration.v2.MigrationWorkflow` is changed to include 'Identifier' ([commit a645ee7](https://github.com/googleapis/google-cloud-dotnet/commit/a645ee7f96307cf71de1fdac850acb35d83e8ef8))
- A comment for field `translation_config_details` in message `.google.cloud.bigquery.migration.v2.MigrationTask` is changed ([commit a645ee7](https://github.com/googleapis/google-cloud-dotnet/commit/a645ee7f96307cf71de1fdac850acb35d83e8ef8))
- A comment for field `type` in message `.google.cloud.bigquery.migration.v2.MigrationTask` is changed to include new supported types ([commit a645ee7](https://github.com/googleapis/google-cloud-dotnet/commit/a645ee7f96307cf71de1fdac850acb35d83e8ef8))
