### PR TITLE
Release Google.Cloud.Bigtable.Admin.V2 version 3.18.0

### DIFF
--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.17.0</Version>
+    <Version>3.18.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Bigtable Instance and Table Admin APIs.</Description>

--- a/apis/Google.Cloud.Bigtable.Admin.V2/docs/history.md
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 3.18.0, released 2024-07-22
+
+### New features
+
+- Add min, max, hll aggregators and more types ([commit 7874fc6](https://github.com/googleapis/google-cloud-dotnet/commit/7874fc6abca3df5a590a33bf4d2a7ce40cb35537))
+- Update Go Datastore import path ([commit 83fa86a](https://github.com/googleapis/google-cloud-dotnet/commit/83fa86a145d211f5670a14e875d30b4fa2207b74))
+- Update Go Bigtable import path ([commit 83fa86a](https://github.com/googleapis/google-cloud-dotnet/commit/83fa86a145d211f5670a14e875d30b4fa2207b74))
+
+### Documentation improvements
+
+- Corrected various type documentation ([commit 7874fc6](https://github.com/googleapis/google-cloud-dotnet/commit/7874fc6abca3df5a590a33bf4d2a7ce40cb35537))
+
 ## Version 3.17.0, released 2024-06-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1049,7 +1049,7 @@
       "protoPath": "google/bigtable/admin/v2",
       "productName": "Google Cloud Bigtable Administration",
       "productUrl": "https://cloud.google.com/bigtable/",
-      "version": "3.17.0",
+      "version": "3.18.0",
       "commonResourcesConfig": "apis/Google.Cloud.Bigtable.Common.V2/CommonResourcesConfig.json",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Bigtable Instance and Table Admin APIs.",


### PR DESCRIPTION

Changes in this release:

### New features

- Add min, max, hll aggregators and more types ([commit 7874fc6](https://github.com/googleapis/google-cloud-dotnet/commit/7874fc6abca3df5a590a33bf4d2a7ce40cb35537))
- Update Go Datastore import path ([commit 83fa86a](https://github.com/googleapis/google-cloud-dotnet/commit/83fa86a145d211f5670a14e875d30b4fa2207b74))
- Update Go Bigtable import path ([commit 83fa86a](https://github.com/googleapis/google-cloud-dotnet/commit/83fa86a145d211f5670a14e875d30b4fa2207b74))

### Documentation improvements

- Corrected various type documentation ([commit 7874fc6](https://github.com/googleapis/google-cloud-dotnet/commit/7874fc6abca3df5a590a33bf4d2a7ce40cb35537))
