### PR TITLE
Release Google.Cloud.ConfidentialComputing.V1 version 1.6.0

### DIFF
--- a/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.csproj
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.5.0</Version>
+    <Version>1.6.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Confidential Computing API (v1)</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.3.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ConfidentialComputing.V1/docs/history.md
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.6.0, released 2024-07-22
+
+### New features
+
+- Add a new field `tee_attestation` to `VerifyAttestationRequest` message proto for SEV SNP and TDX attestations ([commit b087c55](https://github.com/googleapis/google-cloud-dotnet/commit/b087c557e634a648a2ecfdf9340309334697f8de))
+
 ## Version 1.5.0, released 2024-05-13
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1447,7 +1447,7 @@
     },
     {
       "id": "Google.Cloud.ConfidentialComputing.V1",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "type": "grpc",
       "productName": "Confidential Computing",
       "productUrl": "https://cloud.google.com/confidential-computing",
@@ -1459,7 +1459,7 @@
         "privacy"
       ],
       "dependencies": {
-        "Google.Cloud.Location": "2.2.0"
+        "Google.Cloud.Location": "2.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/confidentialcomputing/v1",


### PR DESCRIPTION

Changes in this release:

### New features

- Add a new field `tee_attestation` to `VerifyAttestationRequest` message proto for SEV SNP and TDX attestations ([commit b087c55](https://github.com/googleapis/google-cloud-dotnet/commit/b087c557e634a648a2ecfdf9340309334697f8de))
