### PR TITLE
Release Google.Cloud.Container.V1 version 3.30.0

### DIFF
--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.29.0</Version>
+    <Version>3.30.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.</Description>

--- a/apis/Google.Cloud.Container.V1/docs/history.md
+++ b/apis/Google.Cloud.Container.V1/docs/history.md
@@ -1,5 +1,20 @@
 # Version history
 
+## Version 3.30.0, released 2024-07-22
+
+### Bug fixes
+
+- Deprecate "EXPERIMENTAL" option for Gateway API (this value has never been supported) ([commit 5b1d67c](https://github.com/googleapis/google-cloud-dotnet/commit/5b1d67c6816af885dbfe25073209c070e1667db1))
+
+### New features
+
+- Support for Ray Clusters ([commit 6f0ee61](https://github.com/googleapis/google-cloud-dotnet/commit/6f0ee612c091c819c8313fc1b7ac2724fd416885))
+- Add DCGM enum in monitoring config ([commit 5b1d67c](https://github.com/googleapis/google-cloud-dotnet/commit/5b1d67c6816af885dbfe25073209c070e1667db1))
+
+### Documentation improvements
+
+- Trivial updates ([commit 6f0ee61](https://github.com/googleapis/google-cloud-dotnet/commit/6f0ee612c091c819c8313fc1b7ac2724fd416885))
+
 ## Version 3.29.0, released 2024-06-24
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1572,7 +1572,7 @@
       "protoPath": "google/container/v1",
       "productName": "Google Kubernetes Engine",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/reference/rest/",
-      "version": "3.29.0",
+      "version": "3.30.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.",
       "dependencies": {},


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Deprecate "EXPERIMENTAL" option for Gateway API (this value has never been supported) ([commit 5b1d67c](https://github.com/googleapis/google-cloud-dotnet/commit/5b1d67c6816af885dbfe25073209c070e1667db1))

### New features

- Support for Ray Clusters ([commit 6f0ee61](https://github.com/googleapis/google-cloud-dotnet/commit/6f0ee612c091c819c8313fc1b7ac2724fd416885))
- Add DCGM enum in monitoring config ([commit 5b1d67c](https://github.com/googleapis/google-cloud-dotnet/commit/5b1d67c6816af885dbfe25073209c070e1667db1))

### Documentation improvements

- Trivial updates ([commit 6f0ee61](https://github.com/googleapis/google-cloud-dotnet/commit/6f0ee612c091c819c8313fc1b7ac2724fd416885))
