### PR TITLE
Release Google.Cloud.Deploy.V1 version 2.19.0

### DIFF
--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.18.0</Version>
+    <Version>2.19.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Deploy API, which automates delivery of your applications to a series of target environments in a defined sequence.</Description>

--- a/apis/Google.Cloud.Deploy.V1/docs/history.md
+++ b/apis/Google.Cloud.Deploy.V1/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 2.19.0, released 2024-07-22
+
+### New features
+
+- Added support for new custom target type and deploy policy platform logs ([commit 50b0fe6](https://github.com/googleapis/google-cloud-dotnet/commit/50b0fe6c19d49962cea3f0bea359ee40d4575281))
+- Added support for deploy policies ([commit dd03c4a](https://github.com/googleapis/google-cloud-dotnet/commit/dd03c4ae63b9339d53b7815707e25731a0dce83f))
+- Added support for configuring a proxy_url to a Kubernetes server ([commit dd03c4a](https://github.com/googleapis/google-cloud-dotnet/commit/dd03c4ae63b9339d53b7815707e25731a0dce83f))
+
+### Documentation improvements
+
+- Small Cloud Deploy API documentation updates ([commit 50b0fe6](https://github.com/googleapis/google-cloud-dotnet/commit/50b0fe6c19d49962cea3f0bea359ee40d4575281))
+- Small corrections to Cloud Deploy API documentation ([commit dd03c4a](https://github.com/googleapis/google-cloud-dotnet/commit/dd03c4ae63b9339d53b7815707e25731a0dce83f))
+
 ## Version 2.18.0, released 2024-06-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1841,7 +1841,7 @@
     },
     {
       "id": "Google.Cloud.Deploy.V1",
-      "version": "2.18.0",
+      "version": "2.19.0",
       "type": "grpc",
       "productName": "Google Cloud Deploy",
       "productUrl": "https://cloud.google.com/deploy/",


### PR DESCRIPTION

Changes in this release:

### New features

- Added support for new custom target type and deploy policy platform logs ([commit 50b0fe6](https://github.com/googleapis/google-cloud-dotnet/commit/50b0fe6c19d49962cea3f0bea359ee40d4575281))
- Added support for deploy policies ([commit dd03c4a](https://github.com/googleapis/google-cloud-dotnet/commit/dd03c4ae63b9339d53b7815707e25731a0dce83f))
- Added support for configuring a proxy_url to a Kubernetes server ([commit dd03c4a](https://github.com/googleapis/google-cloud-dotnet/commit/dd03c4ae63b9339d53b7815707e25731a0dce83f))

### Documentation improvements

- Small Cloud Deploy API documentation updates ([commit 50b0fe6](https://github.com/googleapis/google-cloud-dotnet/commit/50b0fe6c19d49962cea3f0bea359ee40d4575281))
- Small corrections to Cloud Deploy API documentation ([commit dd03c4a](https://github.com/googleapis/google-cloud-dotnet/commit/dd03c4ae63b9339d53b7815707e25731a0dce83f))
