### PR TITLE
Release Google.Cloud.Run.V2 version 2.9.0

### DIFF
--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.8.0</Version>
+    <Version>2.9.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Run Admin API (v2)</Description>
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.3.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Run.V2/docs/history.md
+++ b/apis/Google.Cloud.Run.V2/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 2.9.0, released 2024-07-22
+
+### New features
+
+- Support update_mask in Cloud Run UpdateService ([commit bb34cc0](https://github.com/googleapis/google-cloud-dotnet/commit/bb34cc0531c91e8f2468ad6833da92fcff735936))
+- Add Job start_execution_token and run_execution_token to execute jobs immediately on creation ([commit bb34cc0](https://github.com/googleapis/google-cloud-dotnet/commit/bb34cc0531c91e8f2468ad6833da92fcff735936))
+- Add Job ExecutionReference.completion_status to show status of the most recent execution ([commit bb34cc0](https://github.com/googleapis/google-cloud-dotnet/commit/bb34cc0531c91e8f2468ad6833da92fcff735936))
+
+### Documentation improvements
+
+- Clarify optional fields in Cloud Run requests ([commit bb34cc0](https://github.com/googleapis/google-cloud-dotnet/commit/bb34cc0531c91e8f2468ad6833da92fcff735936))
+
 ## Version 2.8.0, released 2024-05-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4122,7 +4122,7 @@
     },
     {
       "id": "Google.Cloud.Run.V2",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "type": "grpc",
       "productName": "Cloud Run Admin",
       "productUrl": "https://cloud.google.com/run/docs",
@@ -4132,9 +4132,9 @@
         "admin"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.2.0",
-        "Google.Cloud.Location": "2.2.0",
-        "Google.LongRunning": "3.2.0"
+        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Location": "2.3.0",
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/run/v2",


### PR DESCRIPTION

Changes in this release:

### New features

- Support update_mask in Cloud Run UpdateService ([commit bb34cc0](https://github.com/googleapis/google-cloud-dotnet/commit/bb34cc0531c91e8f2468ad6833da92fcff735936))
- Add Job start_execution_token and run_execution_token to execute jobs immediately on creation ([commit bb34cc0](https://github.com/googleapis/google-cloud-dotnet/commit/bb34cc0531c91e8f2468ad6833da92fcff735936))
- Add Job ExecutionReference.completion_status to show status of the most recent execution ([commit bb34cc0](https://github.com/googleapis/google-cloud-dotnet/commit/bb34cc0531c91e8f2468ad6833da92fcff735936))

### Documentation improvements

- Clarify optional fields in Cloud Run requests ([commit bb34cc0](https://github.com/googleapis/google-cloud-dotnet/commit/bb34cc0531c91e8f2468ad6833da92fcff735936))
