### PR TITLE
Release Google.Cloud.SecurityCenter.V1 version 3.23.0

### DIFF
--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.csproj
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.22.0</Version>
+    <Version>3.23.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Security Command Center API (v1), which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.</Description>

--- a/apis/Google.Cloud.SecurityCenter.V1/docs/history.md
+++ b/apis/Google.Cloud.SecurityCenter.V1/docs/history.md
@@ -1,5 +1,20 @@
 # Version history
 
+## Version 3.23.0, released 2024-07-22
+
+### New features
+
+- Added cloud provider field to list findings response ([commit d546ea7](https://github.com/googleapis/google-cloud-dotnet/commit/d546ea7efd769ac3ec7bb330854d6634b5f89fe0))
+- Added ResourceValueConfig protos and API methods ([commit d546ea7](https://github.com/googleapis/google-cloud-dotnet/commit/d546ea7efd769ac3ec7bb330854d6634b5f89fe0))
+- Added etd custom module protos and API methods ([commit d546ea7](https://github.com/googleapis/google-cloud-dotnet/commit/d546ea7efd769ac3ec7bb330854d6634b5f89fe0))
+- Added toxic combination field to finding ([commit d546ea7](https://github.com/googleapis/google-cloud-dotnet/commit/d546ea7efd769ac3ec7bb330854d6634b5f89fe0))
+- Added attack path API methods ([commit d546ea7](https://github.com/googleapis/google-cloud-dotnet/commit/d546ea7efd769ac3ec7bb330854d6634b5f89fe0))
+
+### Documentation improvements
+
+- Update toxic combinations comments ([commit d546ea7](https://github.com/googleapis/google-cloud-dotnet/commit/d546ea7efd769ac3ec7bb330854d6634b5f89fe0))
+- Update examples in comments to use backticks ([commit d546ea7](https://github.com/googleapis/google-cloud-dotnet/commit/d546ea7efd769ac3ec7bb330854d6634b5f89fe0))
+
 ## Version 3.22.0, released 2024-07-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4358,7 +4358,7 @@
       "protoPath": "google/cloud/securitycenter/v1",
       "productName": "Google Cloud Security Command Center",
       "productUrl": "https://cloud.google.com/security-command-center/",
-      "version": "3.22.0",
+      "version": "3.23.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Security Command Center API (v1), which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Added cloud provider field to list findings response ([commit d546ea7](https://github.com/googleapis/google-cloud-dotnet/commit/d546ea7efd769ac3ec7bb330854d6634b5f89fe0))
- Added ResourceValueConfig protos and API methods ([commit d546ea7](https://github.com/googleapis/google-cloud-dotnet/commit/d546ea7efd769ac3ec7bb330854d6634b5f89fe0))
- Added etd custom module protos and API methods ([commit d546ea7](https://github.com/googleapis/google-cloud-dotnet/commit/d546ea7efd769ac3ec7bb330854d6634b5f89fe0))
- Added toxic combination field to finding ([commit d546ea7](https://github.com/googleapis/google-cloud-dotnet/commit/d546ea7efd769ac3ec7bb330854d6634b5f89fe0))
- Added attack path API methods ([commit d546ea7](https://github.com/googleapis/google-cloud-dotnet/commit/d546ea7efd769ac3ec7bb330854d6634b5f89fe0))

### Documentation improvements

- Update toxic combinations comments ([commit d546ea7](https://github.com/googleapis/google-cloud-dotnet/commit/d546ea7efd769ac3ec7bb330854d6634b5f89fe0))
- Update examples in comments to use backticks ([commit d546ea7](https://github.com/googleapis/google-cloud-dotnet/commit/d546ea7efd769ac3ec7bb330854d6634b5f89fe0))
