### PR TITLE
Release Google.Cloud.Storage.Control.V2 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.csproj
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Storage Control API (v2), providing control-plane functionality for Google Cloud Storage.</Description>

--- a/apis/Google.Cloud.Storage.Control.V2/docs/history.md
+++ b/apis/Google.Cloud.Storage.Control.V2/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+## Version 1.1.0, released 2024-07-22
+
+### Documentation improvements
+
+- Remove allowlist note from Folders RPCs ([commit a2afefb](https://github.com/googleapis/google-cloud-dotnet/commit/a2afefb2bb16c0b0d5382cd6e2eae4ff81867ee7))
 ## Version 1.0.1, released 2024-06-20
 
 No API surface changes; this release is purely to publish

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4784,7 +4784,7 @@
     },
     {
       "id": "Google.Cloud.Storage.Control.V2",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Cloud Storage",
       "productUrl": "https://cloud.google.com/storage/docs/overview",
@@ -4797,8 +4797,8 @@
         "gcs"
       ],
       "dependencies": {
-        "Google.LongRunning": "3.3.0",
         "Google.Api.Gax.Grpc": "4.8.0",
+        "Google.LongRunning": "3.3.0",
         "Grpc.Core": "2.46.6"
       },
       "generator": "micro",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Remove allowlist note from Folders RPCs ([commit a2afefb](https://github.com/googleapis/google-cloud-dotnet/commit/a2afefb2bb16c0b0d5382cd6e2eae4ff81867ee7))
