### PR TITLE
Release Google.Cloud.Video.LiveStream.V1 version 1.8.0

### DIFF
--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.csproj
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.7.0</Version>
+    <Version>1.8.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Live Stream API, which transcodes mezzanine live signals into direct-to-consumer streaming formats.</Description>

--- a/apis/Google.Cloud.Video.LiveStream.V1/docs/history.md
+++ b/apis/Google.Cloud.Video.LiveStream.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 1.8.0, released 2024-07-22
+
+### New features
+
+- Added RetentionConfig for enabling retention of output media segments ([commit 3f438f2](https://github.com/googleapis/google-cloud-dotnet/commit/3f438f2fd6076c94464ac874e17f88e891887487))
+- Added Clip resource for performing clip cutting jobs ([commit 3f438f2](https://github.com/googleapis/google-cloud-dotnet/commit/3f438f2fd6076c94464ac874e17f88e891887487))
+- Added StaticOverlay for embedding images the whole duration of the live stream ([commit 3f438f2](https://github.com/googleapis/google-cloud-dotnet/commit/3f438f2fd6076c94464ac874e17f88e891887487))
+
+### Documentation improvements
+
+- Clarify the format of key/id fields ([commit 3f438f2](https://github.com/googleapis/google-cloud-dotnet/commit/3f438f2fd6076c94464ac874e17f88e891887487))
+
 ## Version 1.7.0, released 2024-06-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5205,7 +5205,7 @@
     },
     {
       "id": "Google.Cloud.Video.LiveStream.V1",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "type": "grpc",
       "productName": "Live Stream",
       "productUrl": "https://cloud.google.com/livestream/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Added RetentionConfig for enabling retention of output media segments ([commit 3f438f2](https://github.com/googleapis/google-cloud-dotnet/commit/3f438f2fd6076c94464ac874e17f88e891887487))
- Added Clip resource for performing clip cutting jobs ([commit 3f438f2](https://github.com/googleapis/google-cloud-dotnet/commit/3f438f2fd6076c94464ac874e17f88e891887487))
- Added StaticOverlay for embedding images the whole duration of the live stream ([commit 3f438f2](https://github.com/googleapis/google-cloud-dotnet/commit/3f438f2fd6076c94464ac874e17f88e891887487))

### Documentation improvements

- Clarify the format of key/id fields ([commit 3f438f2](https://github.com/googleapis/google-cloud-dotnet/commit/3f438f2fd6076c94464ac874e17f88e891887487))
