### PR TITLE
Release Google.Cloud.VmwareEngine.V1 version 1.6.0

### DIFF
--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.csproj
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.5.0</Version>
+    <Version>1.6.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google VMware Engine API, which lets you programmatically manage VMware environments.</Description>

--- a/apis/Google.Cloud.VmwareEngine.V1/docs/history.md
+++ b/apis/Google.Cloud.VmwareEngine.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.6.0, released 2024-07-22
+
+### New features
+
+- Adding autoscaling settings ([commit 7384b74](https://github.com/googleapis/google-cloud-dotnet/commit/7384b7494aed8c08d34a03aa7cb85a88a6230f9f))
+
 ## Version 1.5.0, released 2024-06-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5316,7 +5316,7 @@
     },
     {
       "id": "Google.Cloud.VmwareEngine.V1",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "type": "grpc",
       "productName": "VMware Engine",
       "productUrl": "https://cloud.google.com/vmware-engine/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Adding autoscaling settings ([commit 7384b74](https://github.com/googleapis/google-cloud-dotnet/commit/7384b7494aed8c08d34a03aa7cb85a88a6230f9f))
