### PR TITLE
Release Google.Maps.MapsPlatformDatasets.V1 version 1.0.0-beta06

### DIFF
--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.csproj
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta05</Version>
+    <Version>1.0.0-beta06</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Platform Datasets API (v1).</Description>

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/docs/history.md
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta06, released 2024-07-22
+
+### New features
+
+- Added a new API FetchDatasetErrors ([commit edc58db](https://github.com/googleapis/google-cloud-dotnet/commit/edc58dbd29e45a0f4e6fa53d4043dff8418d90df))
+
 ## Version 1.0.0-beta05, released 2024-06-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5711,7 +5711,7 @@
     },
     {
       "id": "Google.Maps.MapsPlatformDatasets.V1",
-      "version": "1.0.0-beta05",
+      "version": "1.0.0-beta06",
       "type": "grpc",
       "productName": "Maps Platform Datasets",
       "productUrl": "https://developers.google.com/maps/documentation",


### PR DESCRIPTION

Changes in this release:

### New features

- Added a new API FetchDatasetErrors ([commit edc58db](https://github.com/googleapis/google-cloud-dotnet/commit/edc58dbd29e45a0f4e6fa53d4043dff8418d90df))
