### PR TITLE
Release Google.Cloud.Dialogflow.Cx.V3 version 2.20.0

### DIFF
--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.19.0</Version>
+    <Version>2.20.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Builds conversational interfaces (for example, chatbots, and voice-powered apps and devices).</Description>

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/docs/history.md
@@ -1,5 +1,23 @@
 # Version history
 
+## Version 2.20.0, released 2024-07-29
+
+### New features
+
+- Exposed DataStoreConnectionSignals ([commit 4a52f53](https://github.com/googleapis/google-cloud-dotnet/commit/4a52f533537949ab4f66b4c13e63194f0c48693d))
+- Added support for lock flow ([commit 4a52f53](https://github.com/googleapis/google-cloud-dotnet/commit/4a52f533537949ab4f66b4c13e63194f0c48693d))
+- Added support for multi language settings in flow ([commit 4a52f53](https://github.com/googleapis/google-cloud-dotnet/commit/4a52f533537949ab4f66b4c13e63194f0c48693d))
+- Added support for service directory in tools ([commit 4a52f53](https://github.com/googleapis/google-cloud-dotnet/commit/4a52f533537949ab4f66b4c13e63194f0c48693d))
+- Added support for oauth and service agent auth for webhook. ([commit 4a52f53](https://github.com/googleapis/google-cloud-dotnet/commit/4a52f533537949ab4f66b4c13e63194f0c48693d))
+- Expose store tts option in security settings ([commit 4a52f53](https://github.com/googleapis/google-cloud-dotnet/commit/4a52f533537949ab4f66b4c13e63194f0c48693d))
+- Expose PersonalizationSettings & SpeechSettings in v3 API. ([commit 4a52f53](https://github.com/googleapis/google-cloud-dotnet/commit/4a52f533537949ab4f66b4c13e63194f0c48693d))
+
+### Documentation improvements
+
+- Clarified wording around enable_stackdriver_logging & enable_interaction_logging ([commit 4a52f53](https://github.com/googleapis/google-cloud-dotnet/commit/4a52f533537949ab4f66b4c13e63194f0c48693d))
+- Clarified wording around start point of test config. ([commit 4a52f53](https://github.com/googleapis/google-cloud-dotnet/commit/4a52f533537949ab4f66b4c13e63194f0c48693d))
+- Clarified wording around audio redaction ([commit 4a52f53](https://github.com/googleapis/google-cloud-dotnet/commit/4a52f533537949ab4f66b4c13e63194f0c48693d))
+
 ## Version 2.19.0, released 2024-06-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1982,7 +1982,7 @@
     },
     {
       "id": "Google.Cloud.Dialogflow.Cx.V3",
-      "version": "2.19.0",
+      "version": "2.20.0",
       "type": "grpc",
       "productName": "Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow/cx/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Exposed DataStoreConnectionSignals ([commit 4a52f53](https://github.com/googleapis/google-cloud-dotnet/commit/4a52f533537949ab4f66b4c13e63194f0c48693d))
- Added support for lock flow ([commit 4a52f53](https://github.com/googleapis/google-cloud-dotnet/commit/4a52f533537949ab4f66b4c13e63194f0c48693d))
- Added support for multi language settings in flow ([commit 4a52f53](https://github.com/googleapis/google-cloud-dotnet/commit/4a52f533537949ab4f66b4c13e63194f0c48693d))
- Added support for service directory in tools ([commit 4a52f53](https://github.com/googleapis/google-cloud-dotnet/commit/4a52f533537949ab4f66b4c13e63194f0c48693d))
- Added support for oauth and service agent auth for webhook. ([commit 4a52f53](https://github.com/googleapis/google-cloud-dotnet/commit/4a52f533537949ab4f66b4c13e63194f0c48693d))
- Expose store tts option in security settings ([commit 4a52f53](https://github.com/googleapis/google-cloud-dotnet/commit/4a52f533537949ab4f66b4c13e63194f0c48693d))
- Expose PersonalizationSettings & SpeechSettings in v3 API. ([commit 4a52f53](https://github.com/googleapis/google-cloud-dotnet/commit/4a52f533537949ab4f66b4c13e63194f0c48693d))

### Documentation improvements

- Clarified wording around enable_stackdriver_logging & enable_interaction_logging ([commit 4a52f53](https://github.com/googleapis/google-cloud-dotnet/commit/4a52f533537949ab4f66b4c13e63194f0c48693d))
- Clarified wording around start point of test config. ([commit 4a52f53](https://github.com/googleapis/google-cloud-dotnet/commit/4a52f533537949ab4f66b4c13e63194f0c48693d))
- Clarified wording around audio redaction ([commit 4a52f53](https://github.com/googleapis/google-cloud-dotnet/commit/4a52f533537949ab4f66b4c13e63194f0c48693d))
