### PR TITLE
Release Google.Cloud.Deploy.V1 version 3.0.0

### DIFF
--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.19.0</Version>
+    <Version>3.0.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Deploy API, which automates delivery of your applications to a series of target environments in a defined sequence.</Description>

--- a/apis/Google.Cloud.Deploy.V1/docs/history.md
+++ b/apis/Google.Cloud.Deploy.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 3.0.0, released 2024-07-30
+
+### Bug fixes
+
+- **BREAKING CHANGE** Remove an API that was mistakenly made public ([commit bac7850](https://github.com/googleapis/google-cloud-dotnet/commit/bac78507ef14cfd9ec7bb0c79b2e2c4dd1d628b2))
+- **BREAKING CHANGE** Make changes to an API that is disabled on the server, but whose client libraries were prematurely published ([commit 18300d9](https://github.com/googleapis/google-cloud-dotnet/commit/18300d937ff8c51e9351077798945307e1dbf0be))
+
+### New features
+
+- Add support for different Pod selector labels when doing canaries ([commit 18300d9](https://github.com/googleapis/google-cloud-dotnet/commit/18300d937ff8c51e9351077798945307e1dbf0be))
+
 ## Version 2.19.0, released 2024-07-22
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1841,7 +1841,7 @@
     },
     {
       "id": "Google.Cloud.Deploy.V1",
-      "version": "2.19.0",
+      "version": "3.0.0",
       "type": "grpc",
       "productName": "Google Cloud Deploy",
       "productUrl": "https://cloud.google.com/deploy/",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Remove an API that was mistakenly made public ([commit bac7850](https://github.com/googleapis/google-cloud-dotnet/commit/bac78507ef14cfd9ec7bb0c79b2e2c4dd1d628b2))
- **BREAKING CHANGE** Make changes to an API that is disabled on the server, but whose client libraries were prematurely published ([commit 18300d9](https://github.com/googleapis/google-cloud-dotnet/commit/18300d937ff8c51e9351077798945307e1dbf0be))

### New features

- Add support for different Pod selector labels when doing canaries ([commit 18300d9](https://github.com/googleapis/google-cloud-dotnet/commit/18300d937ff8c51e9351077798945307e1dbf0be))
