### PR TITLE
Release Google.Cloud.GkeConnect.Gateway.V1Beta1 version 2.0.0-beta05

### DIFF
--- a/apis/Google.Cloud.GkeConnect.Gateway.V1Beta1/Google.Cloud.GkeConnect.Gateway.V1Beta1/Google.Cloud.GkeConnect.Gateway.V1Beta1.csproj
+++ b/apis/Google.Cloud.GkeConnect.Gateway.V1Beta1/Google.Cloud.GkeConnect.Gateway.V1Beta1/Google.Cloud.GkeConnect.Gateway.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta04</Version>
+    <Version>2.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the GKE Connect Gateway API, which allows connectivity from external parties to connected Kubernetes clusters.</Description>

--- a/apis/Google.Cloud.GkeConnect.Gateway.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.GkeConnect.Gateway.V1Beta1/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+## Version 2.0.0-beta05, released 2024-07-31
+
+This release is being used to publish a new front-page of
+documentation, to indicate package deprecation.
+
 ## Version 2.0.0-beta04, released 2024-05-14
 
 ### New features

--- a/apis/Google.Cloud.GkeConnect.Gateway.V1Beta1/docs/index.md
+++ b/apis/Google.Cloud.GkeConnect.Gateway.V1Beta1/docs/index.md
@@ -2,14 +2,13 @@
 
 {{description}}
 
-{{version}}
+The libraries for the [GKE Connect Gateway
+API](https://cloud.google.com/kubernetes-engine/enterprise/multicluster-management/gateway/using)
+are now deprecated. Customers should use the Kubernetes client
+library instead.
 
-{{installation}}
-
-{{auth}}
-
-## Getting started
-
-{{client-classes}}
-
-{{client-construction}}
+The Google.Cloud.GkeConnect.Gateway.V1Beta1 package is delisted from NuGet,
+and the source code removed from the google-cloud-dotnet repository.
+Any projects that depend on the package will still be
+able to restore that dependency, but the package won't be shown in
+search results on [nuget.org](https://www.nuget.org/).

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2585,7 +2585,7 @@
     },
     {
       "id": "Google.Cloud.GkeConnect.Gateway.V1Beta1",
-      "version": "2.0.0-beta04",
+      "version": "2.0.0-beta05",
       "type": "grpc",
       "productName": "Connect Gateway",
       "productUrl": "https://cloud.google.com/anthos/multicluster-management/gateway/",


### PR DESCRIPTION

Changes in this release:

This release is being used to publish a new front-page of documentation, to indicate package deprecation.
