### PR TITLE
docs: Fix snippet label

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/SpannerConnectionSnippets.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Snippets/SpannerConnectionSnippets.cs
@@ -70,7 +70,7 @@ namespace Google.Cloud.Spanner.Data.Snippets
                 .ConnectionString;
 
             // Sample: CreateDatabaseAsync
-            // Additional: CreateDdlCommand
+            // Additional: CreateDdlCommand(*,*)
             using (SpannerConnection connection = new SpannerConnection(connectionString))
             {
                 SpannerCommand createDbCmd = connection.CreateDdlCommand($"CREATE DATABASE {databaseName}");


### PR DESCRIPTION
This is currently breaking documentation generation because we added a new `CreateDdlCommand` overload in #13189