### PR TITLE
Release Google.Analytics.Admin.V1Alpha version 2.0.0-alpha20

### DIFF
--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha19</Version>
+    <Version>2.0.0-alpha20</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Admin API (v1alpha)</Description>

--- a/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
+++ b/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
@@ -1,5 +1,30 @@
 # Version history
 
+## Version 2.0.0-alpha20, released 2024-08-05
+
+### Bug fixes
+
+- **BREAKING CHANGE** Rename custom method `CreateSubpropertyRequest` to `ProvisionSubpropertyRequest` ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))
+
+### New features
+
+- Add `GetKeyEvent`, `CreateKeyEvent`, `ListKeyEvents`, `UpdateKeyEvent`, and `DeleteKeyEvent` methods ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))
+- Mark `GetConversionEvent`, `CreateConversionEvent`, `ListConversionEvents`, `UpdateConversionEvent`, and `DeleteConversionEvent` methods as deprecated ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))
+- Add the `create_time` field to the `Audience` resource ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))
+- Add the `primary` field to the `ChannelGroup` resource ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))
+- Add `CreateBigQueryLink`, `UpdateBigQueryLink`, and `DeleteBigQueryLink` methods ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))
+- Add the `dataset_location` field to the `BigQueryLink` resource ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))
+- Add the `BIGQUERY_LINK` option to the `ChangeHistoryResourceType` enum ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))
+- Add the `gmp_organization` field to the `Account` resource ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))
+- Add `GetEventEditRule`, `CreateEventEditRule`, `ListEventEditRules`, `UpdateEventEditRule`, `DeleteEventEditRule`, and `ReorderEventEditRules` methods to the Admin API v1 alpha ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))
+
+### Documentation improvements
+
+- Add deprecation comment to `GetConversionEvent`, `CreateConversionEvent`, `ListConversionEvents`, `UpdateConversionEvent`, and `DeleteConversionEvent` methods ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))
+- Improve comment formatting of the `parent` field in `CreateFirebaseLinkRequest` and `ListFirebaseLinksRequest` ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))
+- Improve comment formatting of the `name` field in `DeleteFirebaseLinkRequest`, `GetGlobalSiteTagRequest`, and `GetDataSharingSettingsRequest` ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))
+- Improve comment formatting of `account` and `property` fields in `SearchChangeHistoryEventsRequest` ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))
+
 ## Version 2.0.0-alpha19, released 2024-05-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2,7 +2,7 @@
   "apis": [
     {
       "id": "Google.Analytics.Admin.V1Alpha",
-      "version": "2.0.0-alpha19",
+      "version": "2.0.0-alpha20",
       "type": "grpc",
       "productName": "Analytics Admin",
       "productUrl": "https://developers.google.com/analytics",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Rename custom method `CreateSubpropertyRequest` to `ProvisionSubpropertyRequest` ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))

### New features

- Add `GetKeyEvent`, `CreateKeyEvent`, `ListKeyEvents`, `UpdateKeyEvent`, and `DeleteKeyEvent` methods ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))
- Mark `GetConversionEvent`, `CreateConversionEvent`, `ListConversionEvents`, `UpdateConversionEvent`, and `DeleteConversionEvent` methods as deprecated ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))
- Add the `create_time` field to the `Audience` resource ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))
- Add the `primary` field to the `ChannelGroup` resource ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))
- Add `CreateBigQueryLink`, `UpdateBigQueryLink`, and `DeleteBigQueryLink` methods ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))
- Add the `dataset_location` field to the `BigQueryLink` resource ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))
- Add the `BIGQUERY_LINK` option to the `ChangeHistoryResourceType` enum ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))
- Add the `gmp_organization` field to the `Account` resource ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))
- Add `GetEventEditRule`, `CreateEventEditRule`, `ListEventEditRules`, `UpdateEventEditRule`, `DeleteEventEditRule`, and `ReorderEventEditRules` methods to the Admin API v1 alpha ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))

### Documentation improvements

- Add deprecation comment to `GetConversionEvent`, `CreateConversionEvent`, `ListConversionEvents`, `UpdateConversionEvent`, and `DeleteConversionEvent` methods ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))
- Improve comment formatting of the `parent` field in `CreateFirebaseLinkRequest` and `ListFirebaseLinksRequest` ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))
- Improve comment formatting of the `name` field in `DeleteFirebaseLinkRequest`, `GetGlobalSiteTagRequest`, and `GetDataSharingSettingsRequest` ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))
- Improve comment formatting of `account` and `property` fields in `SearchChangeHistoryEventsRequest` ([commit 998db44](https://github.com/googleapis/google-cloud-dotnet/commit/998db446b4a48cc8addaf19c30d54bebf8950b3d))
