### PR TITLE
Release Google.Analytics.Data.V1Beta version 2.0.0-beta08

### DIFF
--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.csproj
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta07</Version>
+    <Version>2.0.0-beta08</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Data API (v1beta)</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Analytics.Data.V1Beta/docs/history.md
+++ b/apis/Google.Analytics.Data.V1Beta/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 2.0.0-beta08, released 2024-08-05
+
+### New features
+
+- Add the `comparisons` field to the `Metadata` resource ([commit 06b5f26](https://github.com/googleapis/google-cloud-dotnet/commit/06b5f26b32e4914cd8aea9dfc9d000c638c5d0c9))
+- Add the `comparisons` field to the `RunReportRequest`, `RunPivotReportRequest` resources ([commit 06b5f26](https://github.com/googleapis/google-cloud-dotnet/commit/06b5f26b32e4914cd8aea9dfc9d000c638c5d0c9))
+- Add the `Comparison` type ([commit 06b5f26](https://github.com/googleapis/google-cloud-dotnet/commit/06b5f26b32e4914cd8aea9dfc9d000c638c5d0c9))
+- Add the `ComparisonMetadata` type ([commit 06b5f26](https://github.com/googleapis/google-cloud-dotnet/commit/06b5f26b32e4914cd8aea9dfc9d000c638c5d0c9))
+
+### Documentation improvements
+
+- A comment for field `custom_definition` in message `DimensionMetadata` is changed ([commit 06b5f26](https://github.com/googleapis/google-cloud-dotnet/commit/06b5f26b32e4914cd8aea9dfc9d000c638c5d0c9))
+
 ## Version 2.0.0-beta07, released 2024-05-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -40,7 +40,7 @@
     },
     {
       "id": "Google.Analytics.Data.V1Beta",
-      "version": "2.0.0-beta07",
+      "version": "2.0.0-beta08",
       "type": "grpc",
       "productName": "Google Analytics Data",
       "productUrl": "https://developers.google.com/analytics",
@@ -49,7 +49,7 @@
         "analytics"
       ],
       "dependencies": {
-        "Google.LongRunning": "3.2.0"
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/analytics/data/v1beta",


### PR DESCRIPTION

Changes in this release:

### New features

- Add the `comparisons` field to the `Metadata` resource ([commit 06b5f26](https://github.com/googleapis/google-cloud-dotnet/commit/06b5f26b32e4914cd8aea9dfc9d000c638c5d0c9))
- Add the `comparisons` field to the `RunReportRequest`, `RunPivotReportRequest` resources ([commit 06b5f26](https://github.com/googleapis/google-cloud-dotnet/commit/06b5f26b32e4914cd8aea9dfc9d000c638c5d0c9))
- Add the `Comparison` type ([commit 06b5f26](https://github.com/googleapis/google-cloud-dotnet/commit/06b5f26b32e4914cd8aea9dfc9d000c638c5d0c9))
- Add the `ComparisonMetadata` type ([commit 06b5f26](https://github.com/googleapis/google-cloud-dotnet/commit/06b5f26b32e4914cd8aea9dfc9d000c638c5d0c9))

### Documentation improvements

- A comment for field `custom_definition` in message `DimensionMetadata` is changed ([commit 06b5f26](https://github.com/googleapis/google-cloud-dotnet/commit/06b5f26b32e4914cd8aea9dfc9d000c638c5d0c9))
