### PR TITLE
Release Google.Cloud.Bigtable.Admin.V2 version 3.19.0

### DIFF
--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.18.0</Version>
+    <Version>3.19.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Bigtable Instance and Table Admin APIs.</Description>

--- a/apis/Google.Cloud.Bigtable.Admin.V2/docs/history.md
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.19.0, released 2024-08-05
+
+### New features
+
+- Add fields and the BackupType proto for Hot Backups ([commit d3cf2d8](https://github.com/googleapis/google-cloud-dotnet/commit/d3cf2d81c0db1160f450cb023ff91a7fb680cbc8))
+
+### Documentation improvements
+
+- Clarify comments and fix typos ([commit d3cf2d8](https://github.com/googleapis/google-cloud-dotnet/commit/d3cf2d81c0db1160f450cb023ff91a7fb680cbc8))
+
 ## Version 3.18.0, released 2024-07-22
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1049,7 +1049,7 @@
       "protoPath": "google/bigtable/admin/v2",
       "productName": "Google Cloud Bigtable Administration",
       "productUrl": "https://cloud.google.com/bigtable/",
-      "version": "3.18.0",
+      "version": "3.19.0",
       "commonResourcesConfig": "apis/Google.Cloud.Bigtable.Common.V2/CommonResourcesConfig.json",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Bigtable Instance and Table Admin APIs.",


### PR DESCRIPTION

Changes in this release:

### New features

- Add fields and the BackupType proto for Hot Backups ([commit d3cf2d8](https://github.com/googleapis/google-cloud-dotnet/commit/d3cf2d81c0db1160f450cb023ff91a7fb680cbc8))

### Documentation improvements

- Clarify comments and fix typos ([commit d3cf2d8](https://github.com/googleapis/google-cloud-dotnet/commit/d3cf2d81c0db1160f450cb023ff91a7fb680cbc8))
