### PR TITLE
Release Google.Cloud.Dialogflow.V2 version 4.21.0

### DIFF
--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.20.0</Version>
+    <Version>4.21.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Dialogflow API (v2).</Description>

--- a/apis/Google.Cloud.Dialogflow.V2/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.V2/docs/history.md
@@ -1,5 +1,36 @@
 # Version history
 
+## Version 4.21.0, released 2024-08-05
+
+### Bug fixes
+
+- Changed field behavior for an existing field `parent` in message `.google.cloud.dialogflow.v2.SearchKnowledgeRequest` ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
+- Changed field behavior for an existing field `session_id` in message `.google.cloud.dialogflow.v2.SearchKnowledgeRequest` ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
+
+### New features
+
+- Add Proactive Generative Knowledge Assist endpoints and types ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
+- Add Generator related services and types ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
+- Add GenerateStatelessSuggestion related endpoints and types ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
+
+### Documentation improvements
+
+- A comment for field `name` in message `.google.cloud.dialogflow.v2.Conversation` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
+- A comment for field `conversation_stage` in message `.google.cloud.dialogflow.v2.Conversation` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
+- A comment for field `filter` in message `.google.cloud.dialogflow.v2.ListConversationsRequest` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
+- A comment for field `latest_message` in message `.google.cloud.dialogflow.v2.SuggestConversationSummaryRequest` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
+- A comment for field `context_size` in message `.google.cloud.dialogflow.v2.SuggestConversationSummaryRequest` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
+- A comment for field `assist_query_params` in message `.google.cloud.dialogflow.v2.SuggestConversationSummaryRequest` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
+- A comment for field `latest_message` in message `.google.cloud.dialogflow.v2.GenerateStatelessSummaryRequest` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
+- A comment for field `max_context_size` in message `.google.cloud.dialogflow.v2.GenerateStatelessSummaryRequest` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
+- A comment for field `parent` in message `.google.cloud.dialogflow.v2.SearchKnowledgeRequest` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
+- A comment for field `session_id` in message `.google.cloud.dialogflow.v2.SearchKnowledgeRequest` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
+- A comment for field `conversation` in message `.google.cloud.dialogflow.v2.SearchKnowledgeRequest` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
+- A comment for field `latest_message` in message `.google.cloud.dialogflow.v2.SearchKnowledgeRequest` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
+- A comment for message `HumanAgentHandoffConfig` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
+- A comment for field `live_person_config` in message `.google.cloud.dialogflow.v2.HumanAgentHandoffConfig` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
+- A comment for field `audio` in message `.google.cloud.dialogflow.v2.AudioInput` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
+
 ## Version 4.20.0, released 2024-06-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2010,7 +2010,7 @@
       "protoPath": "google/cloud/dialogflow/v2",
       "productName": "Google Cloud Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow-enterprise/",
-      "version": "4.20.0",
+      "version": "4.21.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Dialogflow API (v2).",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Changed field behavior for an existing field `parent` in message `.google.cloud.dialogflow.v2.SearchKnowledgeRequest` ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
- Changed field behavior for an existing field `session_id` in message `.google.cloud.dialogflow.v2.SearchKnowledgeRequest` ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))

### New features

- Add Proactive Generative Knowledge Assist endpoints and types ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
- Add Generator related services and types ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
- Add GenerateStatelessSuggestion related endpoints and types ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))

### Documentation improvements

- A comment for field `name` in message `.google.cloud.dialogflow.v2.Conversation` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
- A comment for field `conversation_stage` in message `.google.cloud.dialogflow.v2.Conversation` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
- A comment for field `filter` in message `.google.cloud.dialogflow.v2.ListConversationsRequest` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
- A comment for field `latest_message` in message `.google.cloud.dialogflow.v2.SuggestConversationSummaryRequest` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
- A comment for field `context_size` in message `.google.cloud.dialogflow.v2.SuggestConversationSummaryRequest` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
- A comment for field `assist_query_params` in message `.google.cloud.dialogflow.v2.SuggestConversationSummaryRequest` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
- A comment for field `latest_message` in message `.google.cloud.dialogflow.v2.GenerateStatelessSummaryRequest` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
- A comment for field `max_context_size` in message `.google.cloud.dialogflow.v2.GenerateStatelessSummaryRequest` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
- A comment for field `parent` in message `.google.cloud.dialogflow.v2.SearchKnowledgeRequest` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
- A comment for field `session_id` in message `.google.cloud.dialogflow.v2.SearchKnowledgeRequest` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
- A comment for field `conversation` in message `.google.cloud.dialogflow.v2.SearchKnowledgeRequest` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
- A comment for field `latest_message` in message `.google.cloud.dialogflow.v2.SearchKnowledgeRequest` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
- A comment for message `HumanAgentHandoffConfig` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
- A comment for field `live_person_config` in message `.google.cloud.dialogflow.v2.HumanAgentHandoffConfig` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
- A comment for field `audio` in message `.google.cloud.dialogflow.v2.AudioInput` is changed ([commit b56beb4](https://github.com/googleapis/google-cloud-dotnet/commit/b56beb4b533d546023e44cec994d1ec3cd93b953))
