### PR TITLE
Release Google.Cloud.Dialogflow.V2Beta1 version 1.0.0-beta18

### DIFF
--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta17</Version>
+    <Version>1.0.0-beta18</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Dialogflow API (v2beta1).</Description>

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/docs/history.md
@@ -1,5 +1,37 @@
 # Version history
 
+## Version 1.0.0-beta18, released 2024-08-05
+
+### Bug fixes
+
+- An existing method_signature `parent` is fixed for method `BatchCreateMessages` in service `Conversations` ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
+- Changed field behavior for an existing field `parent` in message `.google.cloud.dialogflow.v2beta1.SearchKnowledgeRequest` ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
+- Changed field behavior for an existing field `session_id` in message `.google.cloud.dialogflow.v2beta1.SearchKnowledgeRequest` ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
+
+### New features
+
+- Add Proactive Generative Knowledge Assist endpoints and types ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
+- Add Generator related services and types ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
+- Add GenerateStatelessSuggestion related endpoints and types ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
+
+### Documentation improvements
+
+- A comment for field `name` in message `.google.cloud.dialogflow.v2beta1.Conversation` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
+- A comment for field `conversation_stage` in message `.google.cloud.dialogflow.v2beta1.Conversation` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
+- A comment for field `filter` in message `.google.cloud.dialogflow.v2beta1.ListConversationsRequest` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
+- A comment for field `latest_message` in message `.google.cloud.dialogflow.v2beta1.SuggestConversationSummaryRequest` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
+- A comment for field `context_size` in message `.google.cloud.dialogflow.v2beta1.SuggestConversationSummaryRequest` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
+- A comment for field `assist_query_params` in message `.google.cloud.dialogflow.v2beta1.SuggestConversationSummaryRequest` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
+- A comment for field `latest_message` in message `.google.cloud.dialogflow.v2beta1.GenerateStatelessSummaryRequest` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
+- A comment for field `max_context_size` in message `.google.cloud.dialogflow.v2beta1.GenerateStatelessSummaryRequest` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
+- A comment for field `parent` in message `.google.cloud.dialogflow.v2beta1.SearchKnowledgeRequest` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
+- A comment for field `session_id` in message `.google.cloud.dialogflow.v2beta1.SearchKnowledgeRequest` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
+- A comment for field `conversation` in message `.google.cloud.dialogflow.v2beta1.SearchKnowledgeRequest` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
+- A comment for field `latest_message` in message `.google.cloud.dialogflow.v2beta1.SearchKnowledgeRequest` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
+- A comment for message `HumanAgentHandoffConfig` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
+- A comment for field `live_person_config` in message `.google.cloud.dialogflow.v2beta1.HumanAgentHandoffConfig` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
+- A comment for field `audio` in message `.google.cloud.dialogflow.v2beta1.AudioInput` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
+
 ## Version 1.0.0-beta17, released 2024-06-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2032,7 +2032,7 @@
     },
     {
       "id": "Google.Cloud.Dialogflow.V2Beta1",
-      "version": "1.0.0-beta17",
+      "version": "1.0.0-beta18",
       "type": "grpc",
       "productName": "Google Cloud Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow-enterprise/",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- An existing method_signature `parent` is fixed for method `BatchCreateMessages` in service `Conversations` ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
- Changed field behavior for an existing field `parent` in message `.google.cloud.dialogflow.v2beta1.SearchKnowledgeRequest` ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
- Changed field behavior for an existing field `session_id` in message `.google.cloud.dialogflow.v2beta1.SearchKnowledgeRequest` ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))

### New features

- Add Proactive Generative Knowledge Assist endpoints and types ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
- Add Generator related services and types ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
- Add GenerateStatelessSuggestion related endpoints and types ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))

### Documentation improvements

- A comment for field `name` in message `.google.cloud.dialogflow.v2beta1.Conversation` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
- A comment for field `conversation_stage` in message `.google.cloud.dialogflow.v2beta1.Conversation` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
- A comment for field `filter` in message `.google.cloud.dialogflow.v2beta1.ListConversationsRequest` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
- A comment for field `latest_message` in message `.google.cloud.dialogflow.v2beta1.SuggestConversationSummaryRequest` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
- A comment for field `context_size` in message `.google.cloud.dialogflow.v2beta1.SuggestConversationSummaryRequest` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
- A comment for field `assist_query_params` in message `.google.cloud.dialogflow.v2beta1.SuggestConversationSummaryRequest` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
- A comment for field `latest_message` in message `.google.cloud.dialogflow.v2beta1.GenerateStatelessSummaryRequest` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
- A comment for field `max_context_size` in message `.google.cloud.dialogflow.v2beta1.GenerateStatelessSummaryRequest` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
- A comment for field `parent` in message `.google.cloud.dialogflow.v2beta1.SearchKnowledgeRequest` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
- A comment for field `session_id` in message `.google.cloud.dialogflow.v2beta1.SearchKnowledgeRequest` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
- A comment for field `conversation` in message `.google.cloud.dialogflow.v2beta1.SearchKnowledgeRequest` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
- A comment for field `latest_message` in message `.google.cloud.dialogflow.v2beta1.SearchKnowledgeRequest` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
- A comment for message `HumanAgentHandoffConfig` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
- A comment for field `live_person_config` in message `.google.cloud.dialogflow.v2beta1.HumanAgentHandoffConfig` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
- A comment for field `audio` in message `.google.cloud.dialogflow.v2beta1.AudioInput` is changed ([commit 33eca8a](https://github.com/googleapis/google-cloud-dotnet/commit/33eca8af540108582435bd8cf0e2ec5230ab3430))
