### PR TITLE
Release Google.Cloud.Dlp.V2 version 4.11.0

### DIFF
--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.csproj
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.10.0</Version>
+    <Version>4.11.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Data Loss Prevention API, which provides methods for detection of privacy-sensitive fragments in text, images, and Google Cloud Platform storage repositories.</Description>

--- a/apis/Google.Cloud.Dlp.V2/docs/history.md
+++ b/apis/Google.Cloud.Dlp.V2/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 4.11.0, released 2024-08-05
+
+### New features
+
+- Org-level connection bindings ([commit 2268fa6](https://github.com/googleapis/google-cloud-dotnet/commit/2268fa61a7f338d380c9371defd3547d4df6d55c))
+- GRPC config for get, list, and delete FileStoreDataProfiles ([commit 2268fa6](https://github.com/googleapis/google-cloud-dotnet/commit/2268fa61a7f338d380c9371defd3547d4df6d55c))
+- Add refresh frequency for data profiling ([commit 2268fa6](https://github.com/googleapis/google-cloud-dotnet/commit/2268fa61a7f338d380c9371defd3547d4df6d55c))
+
+### Documentation improvements
+
+- Replace HTML tags with CommonMark notation ([commit 9eb36ce](https://github.com/googleapis/google-cloud-dotnet/commit/9eb36ce1f7e1a41f873983424d20af053c472c28))
+- Small improvements ([commit 2268fa6](https://github.com/googleapis/google-cloud-dotnet/commit/2268fa61a7f338d380c9371defd3547d4df6d55c))
+
 ## Version 4.10.0, released 2024-07-22
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2102,7 +2102,7 @@
       "protoPath": "google/privacy/dlp/v2",
       "productName": "Google Cloud Data Loss Prevention",
       "productUrl": "https://cloud.google.com/dlp/",
-      "version": "4.10.0",
+      "version": "4.11.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Data Loss Prevention API, which provides methods for detection of privacy-sensitive fragments in text, images, and Google Cloud Platform storage repositories.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Org-level connection bindings ([commit 2268fa6](https://github.com/googleapis/google-cloud-dotnet/commit/2268fa61a7f338d380c9371defd3547d4df6d55c))
- GRPC config for get, list, and delete FileStoreDataProfiles ([commit 2268fa6](https://github.com/googleapis/google-cloud-dotnet/commit/2268fa61a7f338d380c9371defd3547d4df6d55c))
- Add refresh frequency for data profiling ([commit 2268fa6](https://github.com/googleapis/google-cloud-dotnet/commit/2268fa61a7f338d380c9371defd3547d4df6d55c))

### Documentation improvements

- Replace HTML tags with CommonMark notation ([commit 9eb36ce](https://github.com/googleapis/google-cloud-dotnet/commit/9eb36ce1f7e1a41f873983424d20af053c472c28))
- Small improvements ([commit 2268fa6](https://github.com/googleapis/google-cloud-dotnet/commit/2268fa61a7f338d380c9371defd3547d4df6d55c))
