### PR TITLE
Release Google.Cloud.DocumentAI.V1 version 3.18.0

### DIFF
--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.17.0</Version>
+    <Version>3.18.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Document AI API (v1), which is a service to parse structured information from unstructured or semi-structured documents using state-of-the-art Google AI such as natural language, computer vision, translation, and AutoML.</Description>

--- a/apis/Google.Cloud.DocumentAI.V1/docs/history.md
+++ b/apis/Google.Cloud.DocumentAI.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 3.18.0, released 2024-08-05
+
+### New features
+
+- A new field `imageless_mode` is added to message `.google.cloud.documentai.v1.ProcessRequest` ([commit 8bb3707](https://github.com/googleapis/google-cloud-dotnet/commit/8bb3707919368cf60a6ec33d596ecdc865d13f78))
+- A new field `gen_ai_model_info` is added to message `.google.cloud.documentai.v1.ProcessorVersion` ([commit 8bb3707](https://github.com/googleapis/google-cloud-dotnet/commit/8bb3707919368cf60a6ec33d596ecdc865d13f78))
+
+### Documentation improvements
+
+- Update the comment to add a note about `documentai.processors.create` permission ([commit 885982c](https://github.com/googleapis/google-cloud-dotnet/commit/885982cc55f380091fd5c6d01ff00cb47e02d937))
+
 ## Version 3.17.0, released 2024-06-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2122,7 +2122,7 @@
     },
     {
       "id": "Google.Cloud.DocumentAI.V1",
-      "version": "3.17.0",
+      "version": "3.18.0",
       "type": "grpc",
       "productName": "Cloud Document AI",
       "productUrl": "https://cloud.google.com/solutions/document-ai",


### PR DESCRIPTION

Changes in this release:

### New features

- A new field `imageless_mode` is added to message `.google.cloud.documentai.v1.ProcessRequest` ([commit 8bb3707](https://github.com/googleapis/google-cloud-dotnet/commit/8bb3707919368cf60a6ec33d596ecdc865d13f78))
- A new field `gen_ai_model_info` is added to message `.google.cloud.documentai.v1.ProcessorVersion` ([commit 8bb3707](https://github.com/googleapis/google-cloud-dotnet/commit/8bb3707919368cf60a6ec33d596ecdc865d13f78))

### Documentation improvements

- Update the comment to add a note about `documentai.processors.create` permission ([commit 885982c](https://github.com/googleapis/google-cloud-dotnet/commit/885982cc55f380091fd5c6d01ff00cb47e02d937))
