### PR TITLE
Release Google.Cloud.DocumentAI.V1Beta3 version 2.0.0-beta21

### DIFF
--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta20</Version>
+    <Version>2.0.0-beta21</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Document AI API (v1beta3), which is a service to parse structured information from unstructured or semi-structured documents using state-of-the-art Google AI such as natural language, computer vision, translation, and AutoML.</Description>

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/docs/history.md
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.0.0-beta21, released 2024-08-05
+
+### New features
+
+- A new field `imageless_mode` is added to message `.google.cloud.documentai.v1.ProcessRequest` ([commit ca07e67](https://github.com/googleapis/google-cloud-dotnet/commit/ca07e67a242098a759491a65324dc8d45397144e))
+
+### Documentation improvements
+
+- Keep the API doc up-to-date with recent changes ([commit ca07e67](https://github.com/googleapis/google-cloud-dotnet/commit/ca07e67a242098a759491a65324dc8d45397144e))
+
 ## Version 2.0.0-beta20, released 2024-06-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2149,7 +2149,7 @@
     },
     {
       "id": "Google.Cloud.DocumentAI.V1Beta3",
-      "version": "2.0.0-beta20",
+      "version": "2.0.0-beta21",
       "type": "grpc",
       "productName": "Cloud Document AI",
       "productUrl": "https://cloud.google.com/solutions/document-ai",


### PR DESCRIPTION

Changes in this release:

### New features

- A new field `imageless_mode` is added to message `.google.cloud.documentai.v1.ProcessRequest` ([commit ca07e67](https://github.com/googleapis/google-cloud-dotnet/commit/ca07e67a242098a759491a65324dc8d45397144e))

### Documentation improvements

- Keep the API doc up-to-date with recent changes ([commit ca07e67](https://github.com/googleapis/google-cloud-dotnet/commit/ca07e67a242098a759491a65324dc8d45397144e))
