### PR TITLE
Release Google.Cloud.Parallelstore.V1Beta version 1.0.0-beta05

### DIFF
--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.csproj
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta04</Version>
+    <Version>1.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to manage the Parallelstore high performance, managed parallel file service.</Description>

--- a/apis/Google.Cloud.Parallelstore.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta05, released 2024-08-05
+
+### New features
+
+- Add file_stripe_level and directory_stripe_level fields to Instance ([commit 1c3d418](https://github.com/googleapis/google-cloud-dotnet/commit/1c3d4184644c42787fe2bff86b8ae395d3562142))
+
 ## Version 1.0.0-beta04, released 2024-07-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3665,7 +3665,7 @@
     },
     {
       "id": "Google.Cloud.Parallelstore.V1Beta",
-      "version": "1.0.0-beta04",
+      "version": "1.0.0-beta05",
       "type": "grpc",
       "productName": "Parallelstore",
       "productUrl": "http://cloud/parallelstore?hl=en",


### PR DESCRIPTION

Changes in this release:

### New features

- Add file_stripe_level and directory_stripe_level fields to Instance ([commit 1c3d418](https://github.com/googleapis/google-cloud-dotnet/commit/1c3d4184644c42787fe2bff86b8ae395d3562142))
