### PR TITLE
Release Google.Cloud.Batch.V1Alpha version 1.0.0-alpha30

### DIFF
--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha29</Version>
+    <Version>1.0.0-alpha30</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1alpha), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
@@ -1,5 +1,23 @@
 # Version history
 
+## Version 1.0.0-alpha30, released 2024-08-13
+
+### New features
+
+- Add block_project_ssh_keys field to the v1alpha job API to block project level ssh keys access to Batch created VMs ([commit 3a1b85f](https://github.com/googleapis/google-cloud-dotnet/commit/3a1b85f77544b42ef731e07c7f1d382daf84469b))
+- Remove visibility restriction of cancel job api, allow in v1alpha ([commit 3a1b85f](https://github.com/googleapis/google-cloud-dotnet/commit/3a1b85f77544b42ef731e07c7f1d382daf84469b))
+- Update Go Datastore import path ([commit 3a1b85f](https://github.com/googleapis/google-cloud-dotnet/commit/3a1b85f77544b42ef731e07c7f1d382daf84469b))
+- Update Go Bigtable import path ([commit 3a1b85f](https://github.com/googleapis/google-cloud-dotnet/commit/3a1b85f77544b42ef731e07c7f1d382daf84469b))
+
+### Documentation improvements
+
+- Refine usage scope for field `task_execution` and `task_state` in `status_events` ([commit 3a1b85f](https://github.com/googleapis/google-cloud-dotnet/commit/3a1b85f77544b42ef731e07c7f1d382daf84469b))
+- Add instructions on how to configure cross-project pubsub publisher ([commit 5e272cf](https://github.com/googleapis/google-cloud-dotnet/commit/5e272cfb0d5d740cd383e1a3d64988f02f647a09))
+- Document default disk type: pd-standard for non boot disk, pd-balanced for boot disk ([commit 5e272cf](https://github.com/googleapis/google-cloud-dotnet/commit/5e272cfb0d5d740cd383e1a3d64988f02f647a09))
+- Update list of volume.mount_options field ([commit 5e272cf](https://github.com/googleapis/google-cloud-dotnet/commit/5e272cfb0d5d740cd383e1a3d64988f02f647a09))
+- Update GCS description of volume.mount_options field ([commit 5e272cf](https://github.com/googleapis/google-cloud-dotnet/commit/5e272cfb0d5d740cd383e1a3d64988f02f647a09))
+- Update links in the description of volume.mount_options field ([commit 5e272cf](https://github.com/googleapis/google-cloud-dotnet/commit/5e272cfb0d5d740cd383e1a3d64988f02f647a09))
+
 ## Version 1.0.0-alpha29, released 2024-06-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -738,7 +738,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1Alpha",
-      "version": "1.0.0-alpha29",
+      "version": "1.0.0-alpha30",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add block_project_ssh_keys field to the v1alpha job API to block project level ssh keys access to Batch created VMs ([commit 3a1b85f](https://github.com/googleapis/google-cloud-dotnet/commit/3a1b85f77544b42ef731e07c7f1d382daf84469b))
- Remove visibility restriction of cancel job api, allow in v1alpha ([commit 3a1b85f](https://github.com/googleapis/google-cloud-dotnet/commit/3a1b85f77544b42ef731e07c7f1d382daf84469b))
- Update Go Datastore import path ([commit 3a1b85f](https://github.com/googleapis/google-cloud-dotnet/commit/3a1b85f77544b42ef731e07c7f1d382daf84469b))
- Update Go Bigtable import path ([commit 3a1b85f](https://github.com/googleapis/google-cloud-dotnet/commit/3a1b85f77544b42ef731e07c7f1d382daf84469b))

### Documentation improvements

- Refine usage scope for field `task_execution` and `task_state` in `status_events` ([commit 3a1b85f](https://github.com/googleapis/google-cloud-dotnet/commit/3a1b85f77544b42ef731e07c7f1d382daf84469b))
- Add instructions on how to configure cross-project pubsub publisher ([commit 5e272cf](https://github.com/googleapis/google-cloud-dotnet/commit/5e272cfb0d5d740cd383e1a3d64988f02f647a09))
- Document default disk type: pd-standard for non boot disk, pd-balanced for boot disk ([commit 5e272cf](https://github.com/googleapis/google-cloud-dotnet/commit/5e272cfb0d5d740cd383e1a3d64988f02f647a09))
- Update list of volume.mount_options field ([commit 5e272cf](https://github.com/googleapis/google-cloud-dotnet/commit/5e272cfb0d5d740cd383e1a3d64988f02f647a09))
- Update GCS description of volume.mount_options field ([commit 5e272cf](https://github.com/googleapis/google-cloud-dotnet/commit/5e272cfb0d5d740cd383e1a3d64988f02f647a09))
- Update links in the description of volume.mount_options field ([commit 5e272cf](https://github.com/googleapis/google-cloud-dotnet/commit/5e272cfb0d5d740cd383e1a3d64988f02f647a09))
