### PR TITLE
Release Google.Cloud.Datastore.V1 version 4.13.0

### DIFF
--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/Google.Cloud.Datastore.V1.GeneratedSnippets.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/Google.Cloud.Datastore.V1.GeneratedSnippets.csproj
@@ -11,7 +11,7 @@
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <PackageReference Include="Google.Cloud.Datastore.Admin.V1" Version="[2.4.0, 3.0.0)" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
-    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.9.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.10.0, 4.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
     <PackageReference Include="System.Linq.Async" Version="$(SystemLinqAsyncVersion)" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/Google.Cloud.Datastore.V1.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/Google.Cloud.Datastore.V1.IntegrationTests.csproj
@@ -11,7 +11,7 @@
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <PackageReference Include="Google.Cloud.Datastore.Admin.V1" Version="[2.4.0, 3.0.0)" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
-    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.9.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.10.0, 4.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
     <PackageReference Include="System.Linq.Async" Version="$(SystemLinqAsyncVersion)" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/Google.Cloud.Datastore.V1.Snippets.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/Google.Cloud.Datastore.V1.Snippets.csproj
@@ -11,7 +11,7 @@
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <PackageReference Include="Google.Cloud.Datastore.Admin.V1" Version="[2.4.0, 3.0.0)" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
-    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.9.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.10.0, 4.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
     <PackageReference Include="System.Linq.Async" Version="$(SystemLinqAsyncVersion)" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/Google.Cloud.Datastore.V1.Tests.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/Google.Cloud.Datastore.V1.Tests.csproj
@@ -11,7 +11,7 @@
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <PackageReference Include="Google.Cloud.Datastore.Admin.V1" Version="[2.4.0, 3.0.0)" />
     <ProjectReference Include="..\Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj" />
-    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.9.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" Version="[3.10.0, 4.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
     <PackageReference Include="System.Linq.Async" Version="$(SystemLinqAsyncVersion)" />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.12.0</Version>
+    <Version>4.13.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.</Description>

--- a/apis/Google.Cloud.Datastore.V1/docs/history.md
+++ b/apis/Google.Cloud.Datastore.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 4.13.0, released 2024-08-13
+
+### New features
+
+- Update Go Datastore import path ([commit eb3a95f](https://github.com/googleapis/google-cloud-dotnet/commit/eb3a95f79d6af2ca0b183f6d63ea2a60fdca279c))
+- Update Go Bigtable import path ([commit eb3a95f](https://github.com/googleapis/google-cloud-dotnet/commit/eb3a95f79d6af2ca0b183f6d63ea2a60fdca279c))
+
 ## Version 4.12.0, released 2024-05-30
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1797,7 +1797,7 @@
       "protoPath": "google/datastore/v1",
       "productName": "Google Cloud Datastore",
       "productUrl": "https://cloud.google.com/datastore/docs/concepts/overview",
-      "version": "4.12.0",
+      "version": "4.13.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Datastore API, which accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.",
@@ -1811,7 +1811,7 @@
       "testDependencies": {
         "Google.Api.Gax.Grpc.Testing": "default",
         "Google.Cloud.Datastore.Admin.V1": "2.4.0",
-        "Google.Cloud.Firestore.Admin.V1": "3.9.0"
+        "Google.Cloud.Firestore.Admin.V1": "3.10.0"
       },
       "shortName": "datastore",
       "serviceConfigFile": "datastore_v1.yaml",


### PR DESCRIPTION

Changes in this release:

### New features

- Update Go Datastore import path ([commit eb3a95f](https://github.com/googleapis/google-cloud-dotnet/commit/eb3a95f79d6af2ca0b183f6d63ea2a60fdca279c))
- Update Go Bigtable import path ([commit eb3a95f](https://github.com/googleapis/google-cloud-dotnet/commit/eb3a95f79d6af2ca0b183f6d63ea2a60fdca279c))
