### PR TITLE
Release Google.Cloud.Functions.V1 version 2.7.0

### DIFF
--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.csproj
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Functions API (v1), which manages lightweight user-provided functions executed in response to events.</Description>
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.3.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Functions.V1/docs/history.md
+++ b/apis/Google.Cloud.Functions.V1/docs/history.md
@@ -1,5 +1,20 @@
 # Version history
 
+## Version 2.7.0, released 2024-08-13
+
+### New features
+
+- Added `build_service_account` field to CloudFunction ([commit 079e5b0](https://github.com/googleapis/google-cloud-dotnet/commit/079e5b09d5f5eda0408af303685bada9e2c0f97e))
+
+### Documentation improvements
+
+- A comment for field `runtime_version` in message `.google.cloud.functions.v1.CloudFunction` is changed ([commit 079e5b0](https://github.com/googleapis/google-cloud-dotnet/commit/079e5b09d5f5eda0408af303685bada9e2c0f97e))
+- A comment for field `docker_repository` in message `.google.cloud.functions.v1.CloudFunction` is changed ([commit 079e5b0](https://github.com/googleapis/google-cloud-dotnet/commit/079e5b09d5f5eda0408af303685bada9e2c0f97e))
+- A comment for field `automatic_update_policy` in message `.google.cloud.functions.v1.CloudFunction` is changed ([commit 079e5b0](https://github.com/googleapis/google-cloud-dotnet/commit/079e5b09d5f5eda0408af303685bada9e2c0f97e))
+- A comment for field `on_deploy_update_policy` in message `.google.cloud.functions.v1.CloudFunction` is changed ([commit 079e5b0](https://github.com/googleapis/google-cloud-dotnet/commit/079e5b09d5f5eda0408af303685bada9e2c0f97e))
+- A comment for field `url` in message `.google.cloud.functions.v1.SourceRepository` is changed ([commit 079e5b0](https://github.com/googleapis/google-cloud-dotnet/commit/079e5b09d5f5eda0408af303685bada9e2c0f97e))
+- A comment for field `url` in message `.google.cloud.functions.v1.HttpsTrigger` is changed ([commit 079e5b0](https://github.com/googleapis/google-cloud-dotnet/commit/079e5b09d5f5eda0408af303685bada9e2c0f97e))
+
 ## Version 2.6.0, released 2024-05-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2471,7 +2471,7 @@
     },
     {
       "id": "Google.Cloud.Functions.V1",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "type": "grpc",
       "productName": "Cloud Functions",
       "productUrl": "https://cloud.google.com/functions",
@@ -2480,9 +2480,9 @@
         "functions"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.2.0",
-        "Google.Cloud.Location": "2.2.0",
-        "Google.LongRunning": "3.2.0"
+        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Location": "2.3.0",
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/functions/v1",


### PR DESCRIPTION

Changes in this release:

### New features

- Added `build_service_account` field to CloudFunction ([commit 079e5b0](https://github.com/googleapis/google-cloud-dotnet/commit/079e5b09d5f5eda0408af303685bada9e2c0f97e))

### Documentation improvements

- A comment for field `runtime_version` in message `.google.cloud.functions.v1.CloudFunction` is changed ([commit 079e5b0](https://github.com/googleapis/google-cloud-dotnet/commit/079e5b09d5f5eda0408af303685bada9e2c0f97e))
- A comment for field `docker_repository` in message `.google.cloud.functions.v1.CloudFunction` is changed ([commit 079e5b0](https://github.com/googleapis/google-cloud-dotnet/commit/079e5b09d5f5eda0408af303685bada9e2c0f97e))
- A comment for field `automatic_update_policy` in message `.google.cloud.functions.v1.CloudFunction` is changed ([commit 079e5b0](https://github.com/googleapis/google-cloud-dotnet/commit/079e5b09d5f5eda0408af303685bada9e2c0f97e))
- A comment for field `on_deploy_update_policy` in message `.google.cloud.functions.v1.CloudFunction` is changed ([commit 079e5b0](https://github.com/googleapis/google-cloud-dotnet/commit/079e5b09d5f5eda0408af303685bada9e2c0f97e))
- A comment for field `url` in message `.google.cloud.functions.v1.SourceRepository` is changed ([commit 079e5b0](https://github.com/googleapis/google-cloud-dotnet/commit/079e5b09d5f5eda0408af303685bada9e2c0f97e))
- A comment for field `url` in message `.google.cloud.functions.v1.HttpsTrigger` is changed ([commit 079e5b0](https://github.com/googleapis/google-cloud-dotnet/commit/079e5b09d5f5eda0408af303685bada9e2c0f97e))
