### PR TITLE
Release Google.Cloud.Functions.V2 version 1.7.0

### DIFF
--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.csproj
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.6.0</Version>
+    <Version>1.7.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Functions API (v2), which manages lightweight user-provided functions executed in response to events.</Description>
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.3.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Functions.V2/docs/history.md
+++ b/apis/Google.Cloud.Functions.V2/docs/history.md
@@ -1,5 +1,22 @@
 # Version history
 
+## Version 1.7.0, released 2024-08-13
+
+### New features
+
+- Optional field for specifying a service account to use for the build. This helps navigate the change of historical default on new projects. For more details, see https://cloud.google.com/build/docs/cloud-build-service-account-updates ([commit d169759](https://github.com/googleapis/google-cloud-dotnet/commit/d1697594643e72eecbec96b932458873cb6845c5))
+- Optional fields for setting up automatic base image updates. ([commit d169759](https://github.com/googleapis/google-cloud-dotnet/commit/d1697594643e72eecbec96b932458873cb6845c5))
+- Optional field for specifying a revision on GetFunction. ([commit d169759](https://github.com/googleapis/google-cloud-dotnet/commit/d1697594643e72eecbec96b932458873cb6845c5))
+- Optional field for binary authorization policy. ([commit d169759](https://github.com/googleapis/google-cloud-dotnet/commit/d1697594643e72eecbec96b932458873cb6845c5))
+- Optional field for deploying a source from a GitHub repository. ([commit d169759](https://github.com/googleapis/google-cloud-dotnet/commit/d1697594643e72eecbec96b932458873cb6845c5))
+- Additional field on the output that specified whether the deployment supports Physical Zone Separation. ([commit d169759](https://github.com/googleapis/google-cloud-dotnet/commit/d1697594643e72eecbec96b932458873cb6845c5))
+- Generate upload URL now supports for specifying the GCF generation that the generated upload url will be used for. ([commit d169759](https://github.com/googleapis/google-cloud-dotnet/commit/d1697594643e72eecbec96b932458873cb6845c5))
+- ListRuntimes response now includes deprecation and decommissioning dates. ([commit d169759](https://github.com/googleapis/google-cloud-dotnet/commit/d1697594643e72eecbec96b932458873cb6845c5))
+
+### Documentation improvements
+
+- Refined description in several fields. ([commit d169759](https://github.com/googleapis/google-cloud-dotnet/commit/d1697594643e72eecbec96b932458873cb6845c5))
+
 ## Version 1.6.0, released 2024-05-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2494,7 +2494,7 @@
     },
     {
       "id": "Google.Cloud.Functions.V2",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "type": "grpc",
       "productName": "Cloud Functions",
       "productUrl": "https://cloud.google.com/functions",
@@ -2503,9 +2503,9 @@
         "functions"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.2.0",
-        "Google.Cloud.Location": "2.2.0",
-        "Google.LongRunning": "3.2.0"
+        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Location": "2.3.0",
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/functions/v2",


### PR DESCRIPTION

Changes in this release:

### New features

- Optional field for specifying a service account to use for the build. This helps navigate the change of historical default on new projects. For more details, see https://cloud.google.com/build/docs/cloud-build-service-account-updates ([commit d169759](https://github.com/googleapis/google-cloud-dotnet/commit/d1697594643e72eecbec96b932458873cb6845c5))
- Optional fields for setting up automatic base image updates. ([commit d169759](https://github.com/googleapis/google-cloud-dotnet/commit/d1697594643e72eecbec96b932458873cb6845c5))
- Optional field for specifying a revision on GetFunction. ([commit d169759](https://github.com/googleapis/google-cloud-dotnet/commit/d1697594643e72eecbec96b932458873cb6845c5))
- Optional field for binary authorization policy. ([commit d169759](https://github.com/googleapis/google-cloud-dotnet/commit/d1697594643e72eecbec96b932458873cb6845c5))
- Optional field for deploying a source from a GitHub repository. ([commit d169759](https://github.com/googleapis/google-cloud-dotnet/commit/d1697594643e72eecbec96b932458873cb6845c5))
- Additional field on the output that specified whether the deployment supports Physical Zone Separation. ([commit d169759](https://github.com/googleapis/google-cloud-dotnet/commit/d1697594643e72eecbec96b932458873cb6845c5))
- Generate upload URL now supports for specifying the GCF generation that the generated upload url will be used for. ([commit d169759](https://github.com/googleapis/google-cloud-dotnet/commit/d1697594643e72eecbec96b932458873cb6845c5))
- ListRuntimes response now includes deprecation and decommissioning dates. ([commit d169759](https://github.com/googleapis/google-cloud-dotnet/commit/d1697594643e72eecbec96b932458873cb6845c5))

### Documentation improvements

- Refined description in several fields. ([commit d169759](https://github.com/googleapis/google-cloud-dotnet/commit/d1697594643e72eecbec96b932458873cb6845c5))
