### PR TITLE
Release Google.Cloud.Functions.V2Beta version 1.0.0-beta07

### DIFF
--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.csproj
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta06</Version>
+    <Version>1.0.0-beta07</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Functions API (v2beta), which manages lightweight user-provided functions executed in response to events.</Description>
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" Version="[2.3.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Functions.V2Beta/docs/history.md
+++ b/apis/Google.Cloud.Functions.V2Beta/docs/history.md
@@ -1,5 +1,22 @@
 # Version history
 
+## Version 1.0.0-beta07, released 2024-08-13
+
+### New features
+
+- Optional field for specifying a service account to use for the build. This helps navigate the change of historical default on new projects. For more details, see https://cloud.google.com/build/docs/cloud-build-service-account-updates ([commit f6efb2e](https://github.com/googleapis/google-cloud-dotnet/commit/f6efb2e55db0631e884803c9268ef9c1c15c85fd))
+- Optional fields for setting up automatic base image updates. ([commit f6efb2e](https://github.com/googleapis/google-cloud-dotnet/commit/f6efb2e55db0631e884803c9268ef9c1c15c85fd))
+- Optional field for specifying a revision on GetFunction. ([commit f6efb2e](https://github.com/googleapis/google-cloud-dotnet/commit/f6efb2e55db0631e884803c9268ef9c1c15c85fd))
+- Optional field for binary authorization policy. ([commit f6efb2e](https://github.com/googleapis/google-cloud-dotnet/commit/f6efb2e55db0631e884803c9268ef9c1c15c85fd))
+- Optional field for deploying a source from a GitHub repository. ([commit f6efb2e](https://github.com/googleapis/google-cloud-dotnet/commit/f6efb2e55db0631e884803c9268ef9c1c15c85fd))
+- Additional field on the output that specified whether the deployment supports Physical Zone Separation. ([commit f6efb2e](https://github.com/googleapis/google-cloud-dotnet/commit/f6efb2e55db0631e884803c9268ef9c1c15c85fd))
+- Generate upload URL now supports for specifying the GCF generation that the generated upload url will be used for. ([commit f6efb2e](https://github.com/googleapis/google-cloud-dotnet/commit/f6efb2e55db0631e884803c9268ef9c1c15c85fd))
+- ListRuntimes response now includes deprecation and decommissioning dates. ([commit f6efb2e](https://github.com/googleapis/google-cloud-dotnet/commit/f6efb2e55db0631e884803c9268ef9c1c15c85fd))
+
+### Documentation improvements
+
+- Refined description in several fields. ([commit f6efb2e](https://github.com/googleapis/google-cloud-dotnet/commit/f6efb2e55db0631e884803c9268ef9c1c15c85fd))
+
 ## Version 1.0.0-beta06, released 2024-05-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2517,7 +2517,7 @@
     },
     {
       "id": "Google.Cloud.Functions.V2Beta",
-      "version": "1.0.0-beta06",
+      "version": "1.0.0-beta07",
       "type": "grpc",
       "productName": "Cloud Functions",
       "productUrl": "https://cloud.google.com/functions",
@@ -2526,9 +2526,9 @@
         "functions"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.2.0",
-        "Google.Cloud.Location": "2.2.0",
-        "Google.LongRunning": "3.2.0"
+        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Location": "2.3.0",
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/functions/v2beta",


### PR DESCRIPTION

Changes in this release:

### New features

- Optional field for specifying a service account to use for the build. This helps navigate the change of historical default on new projects. For more details, see https://cloud.google.com/build/docs/cloud-build-service-account-updates ([commit f6efb2e](https://github.com/googleapis/google-cloud-dotnet/commit/f6efb2e55db0631e884803c9268ef9c1c15c85fd))
- Optional fields for setting up automatic base image updates. ([commit f6efb2e](https://github.com/googleapis/google-cloud-dotnet/commit/f6efb2e55db0631e884803c9268ef9c1c15c85fd))
- Optional field for specifying a revision on GetFunction. ([commit f6efb2e](https://github.com/googleapis/google-cloud-dotnet/commit/f6efb2e55db0631e884803c9268ef9c1c15c85fd))
- Optional field for binary authorization policy. ([commit f6efb2e](https://github.com/googleapis/google-cloud-dotnet/commit/f6efb2e55db0631e884803c9268ef9c1c15c85fd))
- Optional field for deploying a source from a GitHub repository. ([commit f6efb2e](https://github.com/googleapis/google-cloud-dotnet/commit/f6efb2e55db0631e884803c9268ef9c1c15c85fd))
- Additional field on the output that specified whether the deployment supports Physical Zone Separation. ([commit f6efb2e](https://github.com/googleapis/google-cloud-dotnet/commit/f6efb2e55db0631e884803c9268ef9c1c15c85fd))
- Generate upload URL now supports for specifying the GCF generation that the generated upload url will be used for. ([commit f6efb2e](https://github.com/googleapis/google-cloud-dotnet/commit/f6efb2e55db0631e884803c9268ef9c1c15c85fd))
- ListRuntimes response now includes deprecation and decommissioning dates. ([commit f6efb2e](https://github.com/googleapis/google-cloud-dotnet/commit/f6efb2e55db0631e884803c9268ef9c1c15c85fd))

### Documentation improvements

- Refined description in several fields. ([commit f6efb2e](https://github.com/googleapis/google-cloud-dotnet/commit/f6efb2e55db0631e884803c9268ef9c1c15c85fd))
