### PR TITLE
Release Google.Cloud.Translate.V3 version 3.8.0

### DIFF
--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.csproj
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.7.0</Version>
+    <Version>3.8.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Translate v3 API. The Translate API translates text from one language to another.</Description>
@@ -12,7 +12,7 @@
     <PackageReference Include="Google.Api.Gax.Grpc" Version="[4.8.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.Iam.V1" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" Version="[2.3.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" Version="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" Version="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" Version="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Translate.V3/docs/history.md
+++ b/apis/Google.Cloud.Translate.V3/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+## Version 3.8.0, released 2024-08-13
+
+### New features
+
+- Add BigQuery Metastore Partition Service API version v1alpha ([commit 3bd0dfb](https://github.com/googleapis/google-cloud-dotnet/commit/3bd0dfb945087291bd84d226caf1d3dd93ddb033))
+- Adds AdaptiveMt HTML/Glossary support ([commit 06616a2](https://github.com/googleapis/google-cloud-dotnet/commit/06616a219e221491071eb0f4325182927088d748))
+- Adds protos for Custom Translation API (AutoML) ([commit 06616a2](https://github.com/googleapis/google-cloud-dotnet/commit/06616a219e221491071eb0f4325182927088d748))
+- Adds protos for Transliteration in V3 Advanced translate text ([commit 06616a2](https://github.com/googleapis/google-cloud-dotnet/commit/06616a219e221491071eb0f4325182927088d748))
+- Adds protos for Romanization APIs ([commit 06616a2](https://github.com/googleapis/google-cloud-dotnet/commit/06616a219e221491071eb0f4325182927088d748))
+
+### Documentation improvements
+
+- Fixes typos in docs ([commit 06616a2](https://github.com/googleapis/google-cloud-dotnet/commit/06616a219e221491071eb0f4325182927088d748))
+
 ## Version 3.7.0, released 2024-05-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5149,13 +5149,13 @@
       "productUrl": "https://cloud.google.com/translate/",
       "generator": "micro",
       "protoPath": "google/cloud/translate/v3",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Translate v3 API. The Translate API translates text from one language to another.",
       "dependencies": {
         "Google.Cloud.Iam.V1": "3.3.0",
         "Google.Cloud.Location": "2.3.0",
-        "Google.LongRunning": "3.2.0"
+        "Google.LongRunning": "3.3.0"
       },
       "tags": [
         "Translate",


### PR DESCRIPTION

Changes in this release:

### New features

- Add BigQuery Metastore Partition Service API version v1alpha ([commit 3bd0dfb](https://github.com/googleapis/google-cloud-dotnet/commit/3bd0dfb945087291bd84d226caf1d3dd93ddb033))
- Adds AdaptiveMt HTML/Glossary support ([commit 06616a2](https://github.com/googleapis/google-cloud-dotnet/commit/06616a219e221491071eb0f4325182927088d748))
- Adds protos for Custom Translation API (AutoML) ([commit 06616a2](https://github.com/googleapis/google-cloud-dotnet/commit/06616a219e221491071eb0f4325182927088d748))
- Adds protos for Transliteration in V3 Advanced translate text ([commit 06616a2](https://github.com/googleapis/google-cloud-dotnet/commit/06616a219e221491071eb0f4325182927088d748))
- Adds protos for Romanization APIs ([commit 06616a2](https://github.com/googleapis/google-cloud-dotnet/commit/06616a219e221491071eb0f4325182927088d748))

### Documentation improvements

- Fixes typos in docs ([commit 06616a2](https://github.com/googleapis/google-cloud-dotnet/commit/06616a219e221491071eb0f4325182927088d748))
