### PR TITLE
Release Google.Cloud.ApiHub.V1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.csproj
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Apigee API hub API, which lets you consolidate and organize information about all of the APIs of interest to your organization.</Description>

--- a/apis/Google.Cloud.ApiHub.V1/docs/history.md
+++ b/apis/Google.Cloud.ApiHub.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2024-09-04
+
+### Bug fixes
+
+- **BREAKING CHANGE** Remove gRPC support for client libraries ([commit ecf9305](https://github.com/googleapis/google-cloud-dotnet/commit/ecf9305b0613fb78a8f010aa7ac58f5fed102dcc))
+
 ## Version 1.0.0-beta01, released 2024-08-07
 
 Initial release.

--- a/apis/Google.Cloud.ApiHub.V1/smoketests.json
+++ b/apis/Google.Cloud.ApiHub.V1/smoketests.json
@@ -1,0 +1,40 @@
+[
+  {
+    "method": "ListLocations",
+    "client": "ApiHubClient",
+    "clientNavigationProperty": "LocationsClient",
+    "arguments": {
+      "request": {
+        "name": "projects/${PROJECT_ID}"
+      }
+    }
+  },
+  {
+    "method": "ListHostProjectRegistrations",
+    "client": "HostProjectRegistrationServiceClient",
+    "arguments": {
+      "parent": "projects/${PROJECT_ID}/locations/us-central1"
+    }
+  },
+  {
+    "method": "LookupApiHubInstance",
+    "client": "ProvisioningClient",
+    "arguments": {
+      "parent": "projects/${PROJECT_ID}/locations/us-central1"
+    }
+  },
+  {
+    "method": "ListRuntimeProjectAttachments",
+    "client": "RuntimeProjectAttachmentServiceClient",
+    "arguments": {
+      "parent": "projects/${PROJECT_ID}/locations/us-central1"
+    }
+  },
+  {
+    "method": "LookupRuntimeProjectAttachment",
+    "client": "RuntimeProjectAttachmentServiceClient",
+    "arguments": {
+      "name": "projects/${PROJECT_ID}/locations/us-central1"
+    }
+  }
+]

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -393,7 +393,7 @@
       "includeCommonResourcesProto": true,
       "shortName": "apihub",
       "serviceConfigFile": "apihub_v1.yaml",
-      "transport": "grpc+rest",
+      "transport": "rest",
       "restNumericEnums": true
     },
     {

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -372,7 +372,7 @@
     },
     {
       "id": "Google.Cloud.ApiHub.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "API hub",
       "productUrl": "https://cloud.google.com/apigee/docs/apihub/what-is-api-hub",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Remove gRPC support for client libraries ([commit ecf9305](https://github.com/googleapis/google-cloud-dotnet/commit/ecf9305b0613fb78a8f010aa7ac58f5fed102dcc))
