### PR TITLE
Release Google.Apps.Chat.V1 version 1.0.0-beta06

### DIFF
--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/Google.Apps.Chat.V1.csproj
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/Google.Apps.Chat.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta05</Version>
+    <Version>1.0.0-beta06</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Chat API, which lets you build Chat apps to integrate your services with Google Chat and manage Chat resources such as spaces, members, and messages.</Description>

--- a/apis/Google.Apps.Chat.V1/docs/history.md
+++ b/apis/Google.Apps.Chat.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta06, released 2024-09-09
+
+### New features
+
+- Add CHAT_SPACE link type support for GA launch ([commit e661468](https://github.com/googleapis/google-cloud-dotnet/commit/e661468ce2b7ec57d3cd786a88ead2eac14c792e))
+
 ## Version 1.0.0-beta05, released 2024-07-22
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -75,7 +75,7 @@
     },
     {
       "id": "Google.Apps.Chat.V1",
-      "version": "1.0.0-beta05",
+      "version": "1.0.0-beta06",
       "type": "grpc",
       "productName": "Google Chat",
       "productUrl": "https://developers.google.com/chat/concepts",


### PR DESCRIPTION

Changes in this release:

### New features

- Add CHAT_SPACE link type support for GA launch ([commit e661468](https://github.com/googleapis/google-cloud-dotnet/commit/e661468ce2b7ec57d3cd786a88ead2eac14c792e))
