### PR TITLE
Release Google.Cloud.AlloyDb.V1Beta version 1.0.0-beta08

### DIFF
--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.csproj
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta07</Version>
+    <Version>1.0.0-beta08</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AlloyDB API (v1beta). AlloyDB for PostgreSQL is an open source-compatible database service that provides a powerful option for migrating, modernizing, or building commercial-grade applications.</Description>

--- a/apis/Google.Cloud.AlloyDb.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+## Version 1.0.0-beta08, released 2024-09-09
+
+### New features
+
+- Support for enabling outbound public IP on an instance ([commit 189b96d](https://github.com/googleapis/google-cloud-dotnet/commit/189b96d0f47ffeabf37a4c1144f6e06cd570778c))
+- Support for getting outbound public IP addresses of an instance ([commit 189b96d](https://github.com/googleapis/google-cloud-dotnet/commit/189b96d0f47ffeabf37a4c1144f6e06cd570778c))
+- Support for setting maintenance update policy on a cluster ([commit 189b96d](https://github.com/googleapis/google-cloud-dotnet/commit/189b96d0f47ffeabf37a4c1144f6e06cd570778c))
+- Support for getting maintenance schedule of a cluster ([commit 189b96d](https://github.com/googleapis/google-cloud-dotnet/commit/189b96d0f47ffeabf37a4c1144f6e06cd570778c))
+
 ## Version 1.0.0-beta07, released 2024-06-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -280,7 +280,7 @@
     },
     {
       "id": "Google.Cloud.AlloyDb.V1Beta",
-      "version": "1.0.0-beta07",
+      "version": "1.0.0-beta08",
       "type": "grpc",
       "productName": "AlloyDB",
       "productUrl": "https://cloud.google.com/alloydb/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Support for enabling outbound public IP on an instance ([commit 189b96d](https://github.com/googleapis/google-cloud-dotnet/commit/189b96d0f47ffeabf37a4c1144f6e06cd570778c))
- Support for getting outbound public IP addresses of an instance ([commit 189b96d](https://github.com/googleapis/google-cloud-dotnet/commit/189b96d0f47ffeabf37a4c1144f6e06cd570778c))
- Support for setting maintenance update policy on a cluster ([commit 189b96d](https://github.com/googleapis/google-cloud-dotnet/commit/189b96d0f47ffeabf37a4c1144f6e06cd570778c))
- Support for getting maintenance schedule of a cluster ([commit 189b96d](https://github.com/googleapis/google-cloud-dotnet/commit/189b96d0f47ffeabf37a4c1144f6e06cd570778c))
