### PR TITLE
Release Google.Cloud.Batch.V1 version 2.12.0

### DIFF
--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.11.0</Version>
+    <Version>2.12.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1/docs/history.md
@@ -1,5 +1,20 @@
 # Version history
 
+## Version 2.12.0, released 2024-09-09
+
+### New features
+
+- Promote block_project_ssh_keys support to batch v1 API ([commit 6030568](https://github.com/googleapis/google-cloud-dotnet/commit/60305681af67012fa79e4c3713193fef99bad371))
+
+### Documentation improvements
+
+- Clarify tasks success criteria for background runnable ([commit 78ba76d](https://github.com/googleapis/google-cloud-dotnet/commit/78ba76d5029d509ea6e3eb509033350c51482986))
+- Batch CentOS images and HPC CentOS images are EOS ([commit f739754](https://github.com/googleapis/google-cloud-dotnet/commit/f7397543f18e1abed42ad38146d756f5a587b768))
+- Clarify required fields for Runnable.Container ([commit f739754](https://github.com/googleapis/google-cloud-dotnet/commit/f7397543f18e1abed42ad38146d756f5a587b768))
+- Clarify required oneof fields for Runnable.Script ([commit f739754](https://github.com/googleapis/google-cloud-dotnet/commit/f7397543f18e1abed42ad38146d756f5a587b768))
+- Clarify TaskSpec requires one or more runnables ([commit f739754](https://github.com/googleapis/google-cloud-dotnet/commit/f7397543f18e1abed42ad38146d756f5a587b768))
+- Refine usage scope for fields `task_execution` and `task_state` in StatusEvent ([commit fcfba8b](https://github.com/googleapis/google-cloud-dotnet/commit/fcfba8b509922bc275130bd77bea7945f7f42247))
+
 ## Version 2.11.0, released 2024-07-01
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -738,7 +738,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Promote block_project_ssh_keys support to batch v1 API ([commit 6030568](https://github.com/googleapis/google-cloud-dotnet/commit/60305681af67012fa79e4c3713193fef99bad371))

### Documentation improvements

- Clarify tasks success criteria for background runnable ([commit 78ba76d](https://github.com/googleapis/google-cloud-dotnet/commit/78ba76d5029d509ea6e3eb509033350c51482986))
- Batch CentOS images and HPC CentOS images are EOS ([commit f739754](https://github.com/googleapis/google-cloud-dotnet/commit/f7397543f18e1abed42ad38146d756f5a587b768))
- Clarify required fields for Runnable.Container ([commit f739754](https://github.com/googleapis/google-cloud-dotnet/commit/f7397543f18e1abed42ad38146d756f5a587b768))
- Clarify required oneof fields for Runnable.Script ([commit f739754](https://github.com/googleapis/google-cloud-dotnet/commit/f7397543f18e1abed42ad38146d756f5a587b768))
- Clarify TaskSpec requires one or more runnables ([commit f739754](https://github.com/googleapis/google-cloud-dotnet/commit/f7397543f18e1abed42ad38146d756f5a587b768))
- Refine usage scope for fields `task_execution` and `task_state` in StatusEvent ([commit fcfba8b](https://github.com/googleapis/google-cloud-dotnet/commit/fcfba8b509922bc275130bd77bea7945f7f42247))
