### PR TITLE
Release Google.Cloud.Container.V1 version 3.31.0

### DIFF
--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.30.0</Version>
+    <Version>3.31.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.</Description>

--- a/apis/Google.Cloud.Container.V1/docs/history.md
+++ b/apis/Google.Cloud.Container.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.31.0, released 2024-09-09
+
+### New features
+
+- Add ReleaseChannel EXTENDED value ([commit 4224abe](https://github.com/googleapis/google-cloud-dotnet/commit/4224abe8f61f1a0d8cf154b15841f4190099f7da))
+
+### Documentation improvements
+
+- Minor updates to reference documentation ([commit 863421b](https://github.com/googleapis/google-cloud-dotnet/commit/863421b016199052dae2363577079bb5cadf09c2))
+
 ## Version 3.30.0, released 2024-07-22
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1621,7 +1621,7 @@
       "protoPath": "google/container/v1",
       "productName": "Google Kubernetes Engine",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/reference/rest/",
-      "version": "3.30.0",
+      "version": "3.31.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.",
       "dependencies": {},


### PR DESCRIPTION

Changes in this release:

### New features

- Add ReleaseChannel EXTENDED value ([commit 4224abe](https://github.com/googleapis/google-cloud-dotnet/commit/4224abe8f61f1a0d8cf154b15841f4190099f7da))

### Documentation improvements

- Minor updates to reference documentation ([commit 863421b](https://github.com/googleapis/google-cloud-dotnet/commit/863421b016199052dae2363577079bb5cadf09c2))
