### PR TITLE
Release Google.Cloud.DiscoveryEngine.V1 version 1.4.0

### DIFF
--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.csproj
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Discovery Engine API (v1). Discovery Engine powers high-quality content recommendations on your digital properties for Discovery for Media.</Description>

--- a/apis/Google.Cloud.DiscoveryEngine.V1/docs/history.md
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/docs/history.md
@@ -1,5 +1,21 @@
 # Version history
 
+## Version 1.4.0, released 2024-09-09
+
+### New features
+
+- Promote search tuning service to v1 ([commit a266c61](https://github.com/googleapis/google-cloud-dotnet/commit/a266c618438f66605485d54ad99066eb19825107))
+- Promot user event purge to v1 ([commit a266c61](https://github.com/googleapis/google-cloud-dotnet/commit/a266c618438f66605485d54ad99066eb19825107))
+- Return structured document info in answers ([commit a266c61](https://github.com/googleapis/google-cloud-dotnet/commit/a266c618438f66605485d54ad99066eb19825107))
+- Return index status in document ([commit a266c61](https://github.com/googleapis/google-cloud-dotnet/commit/a266c618438f66605485d54ad99066eb19825107))
+- Support batch documents purge with GCS input ([commit a266c61](https://github.com/googleapis/google-cloud-dotnet/commit/a266c618438f66605485d54ad99066eb19825107))
+- Support batch get documents metadata by uri patterns ([commit a266c61](https://github.com/googleapis/google-cloud-dotnet/commit/a266c618438f66605485d54ad99066eb19825107))
+- Return joined status in user event ([commit a266c61](https://github.com/googleapis/google-cloud-dotnet/commit/a266c618438f66605485d54ad99066eb19825107))
+
+### Documentation improvements
+
+- Keep the API doc up-to-date with recent changes ([commit a266c61](https://github.com/googleapis/google-cloud-dotnet/commit/a266c618438f66605485d54ad99066eb19825107))
+
 ## Version 1.3.0, released 2024-07-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2101,7 +2101,7 @@
     },
     {
       "id": "Google.Cloud.DiscoveryEngine.V1",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "type": "grpc",
       "productName": "Discovery Engine",
       "productUrl": "https://cloud.google.com/discovery-engine/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Promote search tuning service to v1 ([commit a266c61](https://github.com/googleapis/google-cloud-dotnet/commit/a266c618438f66605485d54ad99066eb19825107))
- Promot user event purge to v1 ([commit a266c61](https://github.com/googleapis/google-cloud-dotnet/commit/a266c618438f66605485d54ad99066eb19825107))
- Return structured document info in answers ([commit a266c61](https://github.com/googleapis/google-cloud-dotnet/commit/a266c618438f66605485d54ad99066eb19825107))
- Return index status in document ([commit a266c61](https://github.com/googleapis/google-cloud-dotnet/commit/a266c618438f66605485d54ad99066eb19825107))
- Support batch documents purge with GCS input ([commit a266c61](https://github.com/googleapis/google-cloud-dotnet/commit/a266c618438f66605485d54ad99066eb19825107))
- Support batch get documents metadata by uri patterns ([commit a266c61](https://github.com/googleapis/google-cloud-dotnet/commit/a266c618438f66605485d54ad99066eb19825107))
- Return joined status in user event ([commit a266c61](https://github.com/googleapis/google-cloud-dotnet/commit/a266c618438f66605485d54ad99066eb19825107))

### Documentation improvements

- Keep the API doc up-to-date with recent changes ([commit a266c61](https://github.com/googleapis/google-cloud-dotnet/commit/a266c618438f66605485d54ad99066eb19825107))
