### PR TITLE
Release Google.Cloud.DiscoveryEngine.V1Beta version 1.0.0-beta17

### DIFF
--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.csproj
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta16</Version>
+    <Version>1.0.0-beta17</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Discovery Engine API (v1beta). Discovery Engine powers high-quality content recommendations on your digital properties for Discovery for Media.</Description>

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/docs/history.md
@@ -1,5 +1,22 @@
 # Version history
 
+## Version 1.0.0-beta17, released 2024-09-09
+
+### New features
+
+- Support natural language understanding in search ([commit ab4c17a](https://github.com/googleapis/google-cloud-dotnet/commit/ab4c17a2c3d9fa4b885aa1eeba921e02de1e91ff))
+- Allow set relevance threshold on search ([commit ab4c17a](https://github.com/googleapis/google-cloud-dotnet/commit/ab4c17a2c3d9fa4b885aa1eeba921e02de1e91ff))
+- Support one box search ([commit ab4c17a](https://github.com/googleapis/google-cloud-dotnet/commit/ab4c17a2c3d9fa4b885aa1eeba921e02de1e91ff))
+- Return structured document info in answers ([commit ab4c17a](https://github.com/googleapis/google-cloud-dotnet/commit/ab4c17a2c3d9fa4b885aa1eeba921e02de1e91ff))
+- Return index status in document ([commit ab4c17a](https://github.com/googleapis/google-cloud-dotnet/commit/ab4c17a2c3d9fa4b885aa1eeba921e02de1e91ff))
+- Support batch documents purge with GCS input ([commit ab4c17a](https://github.com/googleapis/google-cloud-dotnet/commit/ab4c17a2c3d9fa4b885aa1eeba921e02de1e91ff))
+- Support batch get documents metadata by uri patterns ([commit ab4c17a](https://github.com/googleapis/google-cloud-dotnet/commit/ab4c17a2c3d9fa4b885aa1eeba921e02de1e91ff))
+- Return joined status in user event ([commit ab4c17a](https://github.com/googleapis/google-cloud-dotnet/commit/ab4c17a2c3d9fa4b885aa1eeba921e02de1e91ff))
+
+### Documentation improvements
+
+- Keep the API doc up-to-date with recent changes ([commit ab4c17a](https://github.com/googleapis/google-cloud-dotnet/commit/ab4c17a2c3d9fa4b885aa1eeba921e02de1e91ff))
+
 ## Version 1.0.0-beta16, released 2024-07-29
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2124,7 +2124,7 @@
     },
     {
       "id": "Google.Cloud.DiscoveryEngine.V1Beta",
-      "version": "1.0.0-beta16",
+      "version": "1.0.0-beta17",
       "type": "grpc",
       "productName": "Discovery Engine",
       "productUrl": "https://cloud.google.com/discovery-engine/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Support natural language understanding in search ([commit ab4c17a](https://github.com/googleapis/google-cloud-dotnet/commit/ab4c17a2c3d9fa4b885aa1eeba921e02de1e91ff))
- Allow set relevance threshold on search ([commit ab4c17a](https://github.com/googleapis/google-cloud-dotnet/commit/ab4c17a2c3d9fa4b885aa1eeba921e02de1e91ff))
- Support one box search ([commit ab4c17a](https://github.com/googleapis/google-cloud-dotnet/commit/ab4c17a2c3d9fa4b885aa1eeba921e02de1e91ff))
- Return structured document info in answers ([commit ab4c17a](https://github.com/googleapis/google-cloud-dotnet/commit/ab4c17a2c3d9fa4b885aa1eeba921e02de1e91ff))
- Return index status in document ([commit ab4c17a](https://github.com/googleapis/google-cloud-dotnet/commit/ab4c17a2c3d9fa4b885aa1eeba921e02de1e91ff))
- Support batch documents purge with GCS input ([commit ab4c17a](https://github.com/googleapis/google-cloud-dotnet/commit/ab4c17a2c3d9fa4b885aa1eeba921e02de1e91ff))
- Support batch get documents metadata by uri patterns ([commit ab4c17a](https://github.com/googleapis/google-cloud-dotnet/commit/ab4c17a2c3d9fa4b885aa1eeba921e02de1e91ff))
- Return joined status in user event ([commit ab4c17a](https://github.com/googleapis/google-cloud-dotnet/commit/ab4c17a2c3d9fa4b885aa1eeba921e02de1e91ff))

### Documentation improvements

- Keep the API doc up-to-date with recent changes ([commit ab4c17a](https://github.com/googleapis/google-cloud-dotnet/commit/ab4c17a2c3d9fa4b885aa1eeba921e02de1e91ff))
