### PR TITLE
Release Google.Cloud.Dlp.V2 version 4.13.0

### DIFF
--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.csproj
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.12.0</Version>
+    <Version>4.13.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Data Loss Prevention API, which provides methods for detection of privacy-sensitive fragments in text, images, and Google Cloud Platform storage repositories.</Description>

--- a/apis/Google.Cloud.Dlp.V2/docs/history.md
+++ b/apis/Google.Cloud.Dlp.V2/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 4.13.0, released 2024-09-09
+
+### New features
+
+- Inspect template modified cadence discovery config for Cloud SQL ([commit 23f8df4](https://github.com/googleapis/google-cloud-dotnet/commit/23f8df41b49a13da263184e7723468f680120326))
+- File store data profiles can now be filtered by type and storage location ([commit 23f8df4](https://github.com/googleapis/google-cloud-dotnet/commit/23f8df41b49a13da263184e7723468f680120326))
+
+### Documentation improvements
+
+- Small improvements ([commit 23f8df4](https://github.com/googleapis/google-cloud-dotnet/commit/23f8df41b49a13da263184e7723468f680120326))
+
 ## Version 4.12.0, released 2024-08-13
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2151,7 +2151,7 @@
       "protoPath": "google/privacy/dlp/v2",
       "productName": "Google Cloud Data Loss Prevention",
       "productUrl": "https://cloud.google.com/dlp/",
-      "version": "4.12.0",
+      "version": "4.13.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Data Loss Prevention API, which provides methods for detection of privacy-sensitive fragments in text, images, and Google Cloud Platform storage repositories.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Inspect template modified cadence discovery config for Cloud SQL ([commit 23f8df4](https://github.com/googleapis/google-cloud-dotnet/commit/23f8df41b49a13da263184e7723468f680120326))
- File store data profiles can now be filtered by type and storage location ([commit 23f8df4](https://github.com/googleapis/google-cloud-dotnet/commit/23f8df41b49a13da263184e7723468f680120326))

### Documentation improvements

- Small improvements ([commit 23f8df4](https://github.com/googleapis/google-cloud-dotnet/commit/23f8df41b49a13da263184e7723468f680120326))
