### PR TITLE
Release Google.Cloud.StorageTransfer.V1 version 2.7.0

### DIFF
--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.csproj
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Transfers data from external data sources to a Google Cloud Storage bucket or between Google Cloud Storage buckets.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" VersionOverride="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.LongRunning" VersionOverride="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" VersionOverride="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.StorageTransfer.V1/docs/history.md
+++ b/apis/Google.Cloud.StorageTransfer.V1/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+## Version 2.7.0, released 2024-09-09
+
+### New features
+
+- Add HDFS configuration ([commit 5c69ed3](https://github.com/googleapis/google-cloud-dotnet/commit/5c69ed3b8486cabbec36853f4489d3b8d77a93a6))
+- Add GCS Managed Folders ([commit 5c69ed3](https://github.com/googleapis/google-cloud-dotnet/commit/5c69ed3b8486cabbec36853f4489d3b8d77a93a6))
+- Add S3 Managed Private Network ([commit 5c69ed3](https://github.com/googleapis/google-cloud-dotnet/commit/5c69ed3b8486cabbec36853f4489d3b8d77a93a6))
+- Add S3 Cloudfront Domain ([commit 5c69ed3](https://github.com/googleapis/google-cloud-dotnet/commit/5c69ed3b8486cabbec36853f4489d3b8d77a93a6))
+
 ## Version 2.6.0, released 2024-05-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4931,7 +4931,7 @@
     },
     {
       "id": "Google.Cloud.StorageTransfer.V1",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "type": "grpc",
       "productName": "Storage Transfer",
       "productUrl": "https://cloud.google.com/storage-transfer-service",
@@ -4943,7 +4943,7 @@
         "gcs"
       ],
       "dependencies": {
-        "Google.LongRunning": "3.2.0"
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/storagetransfer/v1",


### PR DESCRIPTION

Changes in this release:

### New features

- Add HDFS configuration ([commit 5c69ed3](https://github.com/googleapis/google-cloud-dotnet/commit/5c69ed3b8486cabbec36853f4489d3b8d77a93a6))
- Add GCS Managed Folders ([commit 5c69ed3](https://github.com/googleapis/google-cloud-dotnet/commit/5c69ed3b8486cabbec36853f4489d3b8d77a93a6))
- Add S3 Managed Private Network ([commit 5c69ed3](https://github.com/googleapis/google-cloud-dotnet/commit/5c69ed3b8486cabbec36853f4489d3b8d77a93a6))
- Add S3 Cloudfront Domain ([commit 5c69ed3](https://github.com/googleapis/google-cloud-dotnet/commit/5c69ed3b8486cabbec36853f4489d3b8d77a93a6))
