### PR TITLE
Release Google.Cloud.TextToSpeech.V1 version 3.7.0

### DIFF
--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.csproj
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.6.0</Version>
+    <Version>3.7.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Text-to-Speech API v1, synthesizes natural-sounding speech by applying powerful neural network models.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" VersionOverride="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.LongRunning" VersionOverride="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" VersionOverride="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.TextToSpeech.V1/docs/history.md
+++ b/apis/Google.Cloud.TextToSpeech.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 3.7.0, released 2024-09-09
+
+### New features
+
+- A new method `StreamingSynthesize` is added to service `TextToSpeech` ([commit 7a34ef0](https://github.com/googleapis/google-cloud-dotnet/commit/7a34ef081baa8b944e2d8d689336ce6b15e5b5e2))
+
+### Documentation improvements
+
+- Update Long Audio capabilities to include SSML ([commit 05630e2](https://github.com/googleapis/google-cloud-dotnet/commit/05630e2e7806e8894ab892a428b83cbeb187ee37))
+- A comment for field `name` in message `.google.cloud.texttospeech.v1.VoiceSelectionParams` is changed ([commit 7a34ef0](https://github.com/googleapis/google-cloud-dotnet/commit/7a34ef081baa8b944e2d8d689336ce6b15e5b5e2))
+
 ## Version 3.6.0, released 2024-05-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5091,11 +5091,11 @@
       "protoPath": "google/cloud/texttospeech/v1",
       "productName": "Google Cloud Text-to-Speech",
       "productUrl": "https://cloud.google.com/text-to-speech",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Text-to-Speech API v1, synthesizes natural-sounding speech by applying powerful neural network models.",
       "dependencies": {
-        "Google.LongRunning": "3.2.0"
+        "Google.LongRunning": "3.3.0"
       },
       "tags": [
         "Speech",


### PR DESCRIPTION

Changes in this release:

### New features

- A new method `StreamingSynthesize` is added to service `TextToSpeech` ([commit 7a34ef0](https://github.com/googleapis/google-cloud-dotnet/commit/7a34ef081baa8b944e2d8d689336ce6b15e5b5e2))

### Documentation improvements

- Update Long Audio capabilities to include SSML ([commit 05630e2](https://github.com/googleapis/google-cloud-dotnet/commit/05630e2e7806e8894ab892a428b83cbeb187ee37))
- A comment for field `name` in message `.google.cloud.texttospeech.v1.VoiceSelectionParams` is changed ([commit 7a34ef0](https://github.com/googleapis/google-cloud-dotnet/commit/7a34ef081baa8b944e2d8d689336ce6b15e5b5e2))
