### PR TITLE
Release Google.Cloud.TextToSpeech.V1Beta1 version 2.0.0-beta08

### DIFF
--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.csproj
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta07</Version>
+    <Version>2.0.0-beta08</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Text-to-Speech API v1beta1, synthesizes natural-sounding speech by applying powerful neural network models.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" VersionOverride="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.LongRunning" VersionOverride="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" VersionOverride="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 2.0.0-beta08, released 2024-09-09
+
+### New features
+
+- A new method `StreamingSynthesize` is added to service `TextToSpeech` ([commit 6998d73](https://github.com/googleapis/google-cloud-dotnet/commit/6998d73ace75a0f5e6330403e9fe6fd56c8d829a))
+
+### Documentation improvements
+
+- Update Long Audio capabilities to include SSML ([commit 6ed33a1](https://github.com/googleapis/google-cloud-dotnet/commit/6ed33a1d0a312e9c66cbef9ae402806376be6b6e))
+- A comment for field `name` in message `.google.cloud.texttospeech.v1beta1.VoiceSelectionParams` is changed ([commit 6998d73](https://github.com/googleapis/google-cloud-dotnet/commit/6998d73ace75a0f5e6330403e9fe6fd56c8d829a))
+
 ## Version 2.0.0-beta07, released 2024-05-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5109,7 +5109,7 @@
     },
     {
       "id": "Google.Cloud.TextToSpeech.V1Beta1",
-      "version": "2.0.0-beta07",
+      "version": "2.0.0-beta08",
       "type": "grpc",
       "productName": "Google Cloud Text-to-Speech",
       "productUrl": "https://cloud.google.com/text-to-speech",
@@ -5119,7 +5119,7 @@
         "Text-to-speech"
       ],
       "dependencies": {
-        "Google.LongRunning": "3.2.0"
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/texttospeech/v1beta1",


### PR DESCRIPTION

Changes in this release:

### New features

- A new method `StreamingSynthesize` is added to service `TextToSpeech` ([commit 6998d73](https://github.com/googleapis/google-cloud-dotnet/commit/6998d73ace75a0f5e6330403e9fe6fd56c8d829a))

### Documentation improvements

- Update Long Audio capabilities to include SSML ([commit 6ed33a1](https://github.com/googleapis/google-cloud-dotnet/commit/6ed33a1d0a312e9c66cbef9ae402806376be6b6e))
- A comment for field `name` in message `.google.cloud.texttospeech.v1beta1.VoiceSelectionParams` is changed ([commit 6998d73](https://github.com/googleapis/google-cloud-dotnet/commit/6998d73ace75a0f5e6330403e9fe6fd56c8d829a))
