### PR TITLE
Release Google.Apps.Chat.V1 version 1.0.0-beta07

### DIFF
--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/Google.Apps.Chat.V1.csproj
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/Google.Apps.Chat.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta06</Version>
+    <Version>1.0.0-beta07</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Chat API, which lets you build Chat apps to integrate your services with Google Chat and manage Chat resources such as spaces, members, and messages.</Description>

--- a/apis/Google.Apps.Chat.V1/docs/history.md
+++ b/apis/Google.Apps.Chat.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.0.0-beta07, released 2024-09-16
+
+### New features
+
+- If you're a domain administrator or a delegated administrator, you can now include the `useAdminAccess` parameter when you call the Chat API with your administrator privileges with the following methods to manage Chat spaces and memberships in your Workspace organization: ([commit a6692fa](https://github.com/googleapis/google-cloud-dotnet/commit/a6692fa38db1a6e484574a834a8abc797fdc12e8))
+
+### Documentation improvements
+
+- A comment for field `filter` in message `.google.chat.v1.ListMembershipsRequest` is updated to support `!=` operator ([commit a6692fa](https://github.com/googleapis/google-cloud-dotnet/commit/a6692fa38db1a6e484574a834a8abc797fdc12e8))
+
 ## Version 1.0.0-beta06, released 2024-09-09
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -75,7 +75,7 @@
     },
     {
       "id": "Google.Apps.Chat.V1",
-      "version": "1.0.0-beta06",
+      "version": "1.0.0-beta07",
       "type": "grpc",
       "productName": "Google Chat",
       "productUrl": "https://developers.google.com/chat/concepts",


### PR DESCRIPTION

Changes in this release:

### New features

- If you're a domain administrator or a delegated administrator, you can now include the `useAdminAccess` parameter when you call the Chat API with your administrator privileges with the following methods to manage Chat spaces and memberships in your Workspace organization: ([commit a6692fa](https://github.com/googleapis/google-cloud-dotnet/commit/a6692fa38db1a6e484574a834a8abc797fdc12e8))

### Documentation improvements

- A comment for field `filter` in message `.google.chat.v1.ListMembershipsRequest` is updated to support `!=` operator ([commit a6692fa](https://github.com/googleapis/google-cloud-dotnet/commit/a6692fa38db1a6e484574a834a8abc797fdc12e8))
