### PR TITLE
Release Google.Cloud.Batch.V1Alpha version 1.0.0-alpha31

### DIFF
--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha30</Version>
+    <Version>1.0.0-alpha31</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1alpha), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1Alpha/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 1.0.0-alpha31, released 2024-09-16
+
+### New features
+
+- A new value `CANCELLATION_IN_PROGRESS` is added to enum `State` ([commit 7fbb002](https://github.com/googleapis/google-cloud-dotnet/commit/7fbb002c34e55831c8aba719a637756a2bc7981b))
+- A new value `CANCELLED` is added to enum `State` ([commit 7fbb002](https://github.com/googleapis/google-cloud-dotnet/commit/7fbb002c34e55831c8aba719a637756a2bc7981b))
+
+### Documentation improvements
+
+- Clarify tasks success criteria for background runnable ([commit 3b490fe](https://github.com/googleapis/google-cloud-dotnet/commit/3b490fe4d77e8d6624cf20759314d770548ff4d7))
+- Batch CentOS images and HPC CentOS images are EOS ([commit 5cbb834](https://github.com/googleapis/google-cloud-dotnet/commit/5cbb83416de1f5828179356ae16247bb09bb1829))
+
 ## Version 1.0.0-alpha30, released 2024-08-13
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -761,7 +761,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1Alpha",
-      "version": "1.0.0-alpha30",
+      "version": "1.0.0-alpha31",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- A new value `CANCELLATION_IN_PROGRESS` is added to enum `State` ([commit 7fbb002](https://github.com/googleapis/google-cloud-dotnet/commit/7fbb002c34e55831c8aba719a637756a2bc7981b))
- A new value `CANCELLED` is added to enum `State` ([commit 7fbb002](https://github.com/googleapis/google-cloud-dotnet/commit/7fbb002c34e55831c8aba719a637756a2bc7981b))

### Documentation improvements

- Clarify tasks success criteria for background runnable ([commit 3b490fe](https://github.com/googleapis/google-cloud-dotnet/commit/3b490fe4d77e8d6624cf20759314d770548ff4d7))
- Batch CentOS images and HPC CentOS images are EOS ([commit 5cbb834](https://github.com/googleapis/google-cloud-dotnet/commit/5cbb83416de1f5828179356ae16247bb09bb1829))
