### PR TITLE
Release Google.Cloud.CloudControlsPartner.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.csproj
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Controls Partner API (v1) which provides insights about your customers and their Assured Workloads based on your Sovereign Controls by Partners offering.</Description>

--- a/apis/Google.Cloud.CloudControlsPartner.V1/docs/history.md
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 1.1.0, released 2024-09-16
+
+### New features
+
+- Field behavior for field `customer_onboarding_state` in message `.google.cloud.cloudcontrolspartner.v1.Customer` is changed ([commit e63d70b](https://github.com/googleapis/google-cloud-dotnet/commit/e63d70bd6da943c388877d3d3b8a5166d35d6b8e))
+- Field behavior for field `is_onboarded` in message `.google.cloud.cloudcontrolspartner.v1.Customer` is changed ([commit e63d70b](https://github.com/googleapis/google-cloud-dotnet/commit/e63d70bd6da943c388877d3d3b8a5166d35d6b8e))
+- A new value `ACCESS_TRANSPARENCY_LOGS_SUPPORT_CASE_VIEWER` is added to enum `.google.cloud.cloudcontrolspartner.v1.PartnerPermissions.Permission` ([commit e63d70b](https://github.com/googleapis/google-cloud-dotnet/commit/e63d70bd6da943c388877d3d3b8a5166d35d6b8e))
+
+### Documentation improvements
+
+- A comment for field `display_name` in message `.google.cloud.cloudcontrolspartner.v1.Customer` is changed ([commit e63d70b](https://github.com/googleapis/google-cloud-dotnet/commit/e63d70bd6da943c388877d3d3b8a5166d35d6b8e))
+- Mark the accessApprovalRequests.list method as deprecated ([commit 74dcad9](https://github.com/googleapis/google-cloud-dotnet/commit/74dcad9d131f9ecc63c062b3a8920aa5dab122ea))
+
 ## Version 1.0.0, released 2024-05-24
 
 No API surface changes; just dependency updates and promotion to GA.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1359,7 +1359,7 @@
     },
     {
       "id": "Google.Cloud.CloudControlsPartner.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Cloud Controls Partner",
       "productUrl": "https://cloud.google.com/sovereign-controls-by-partners/docs/sovereign-partners/reference/rest",


### PR DESCRIPTION

Changes in this release:

### New features

- Field behavior for field `customer_onboarding_state` in message `.google.cloud.cloudcontrolspartner.v1.Customer` is changed ([commit e63d70b](https://github.com/googleapis/google-cloud-dotnet/commit/e63d70bd6da943c388877d3d3b8a5166d35d6b8e))
- Field behavior for field `is_onboarded` in message `.google.cloud.cloudcontrolspartner.v1.Customer` is changed ([commit e63d70b](https://github.com/googleapis/google-cloud-dotnet/commit/e63d70bd6da943c388877d3d3b8a5166d35d6b8e))
- A new value `ACCESS_TRANSPARENCY_LOGS_SUPPORT_CASE_VIEWER` is added to enum `.google.cloud.cloudcontrolspartner.v1.PartnerPermissions.Permission` ([commit e63d70b](https://github.com/googleapis/google-cloud-dotnet/commit/e63d70bd6da943c388877d3d3b8a5166d35d6b8e))

### Documentation improvements

- A comment for field `display_name` in message `.google.cloud.cloudcontrolspartner.v1.Customer` is changed ([commit e63d70b](https://github.com/googleapis/google-cloud-dotnet/commit/e63d70bd6da943c388877d3d3b8a5166d35d6b8e))
- Mark the accessApprovalRequests.list method as deprecated ([commit 74dcad9](https://github.com/googleapis/google-cloud-dotnet/commit/74dcad9d131f9ecc63c062b3a8920aa5dab122ea))
