### PR TITLE
Release Google.Cloud.CloudControlsPartner.V1Beta version 1.0.0-beta03

### DIFF
--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.csproj
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Controls Partner API (v1beta) which provides insights about your customers and their Assured Workloads based on your Sovereign Controls by Partners offering.</Description>

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2024-09-16
+
+### New features
+
+- Field behavior for field `customer_onboarding_state` in message `.google.cloud.cloudcontrolspartner.v1beta.Customer` is changed ([commit 4a276df](https://github.com/googleapis/google-cloud-dotnet/commit/4a276df641842fbb9db55f2622e49b2de6fd0b6d))
+- Field behavior for field `is_onboarded` in message `.google.cloud.cloudcontrolspartner.v1beta.Customer` is changed ([commit 4a276df](https://github.com/googleapis/google-cloud-dotnet/commit/4a276df641842fbb9db55f2622e49b2de6fd0b6d))
+- A new value `ACCESS_TRANSPARENCY_LOGS_SUPPORT_CASE_VIEWER` is added to enum `.google.cloud.cloudcontrolspartner.v1beta.PartnerPermissions.Permission` ([commit 4a276df](https://github.com/googleapis/google-cloud-dotnet/commit/4a276df641842fbb9db55f2622e49b2de6fd0b6d))
+
+### Documentation improvements
+
+- A comment for field `display_name` in message `.google.cloud.cloudcontrolspartner.v1beta.Customer` is changed ([commit 4a276df](https://github.com/googleapis/google-cloud-dotnet/commit/4a276df641842fbb9db55f2622e49b2de6fd0b6d))
+- Mark the accessApprovalRequests.list method as deprecated ([commit 95e9579](https://github.com/googleapis/google-cloud-dotnet/commit/95e9579f858426b4ca74a995818e37d777c64250))
+
 ## Version 1.0.0-beta02, released 2024-05-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1380,7 +1380,7 @@
     },
     {
       "id": "Google.Cloud.CloudControlsPartner.V1Beta",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "Cloud Controls Partner",
       "productUrl": "https://cloud.google.com/sovereign-controls-by-partners/docs/sovereign-partners/reference/rest",


### PR DESCRIPTION

Changes in this release:

### New features

- Field behavior for field `customer_onboarding_state` in message `.google.cloud.cloudcontrolspartner.v1beta.Customer` is changed ([commit 4a276df](https://github.com/googleapis/google-cloud-dotnet/commit/4a276df641842fbb9db55f2622e49b2de6fd0b6d))
- Field behavior for field `is_onboarded` in message `.google.cloud.cloudcontrolspartner.v1beta.Customer` is changed ([commit 4a276df](https://github.com/googleapis/google-cloud-dotnet/commit/4a276df641842fbb9db55f2622e49b2de6fd0b6d))
- A new value `ACCESS_TRANSPARENCY_LOGS_SUPPORT_CASE_VIEWER` is added to enum `.google.cloud.cloudcontrolspartner.v1beta.PartnerPermissions.Permission` ([commit 4a276df](https://github.com/googleapis/google-cloud-dotnet/commit/4a276df641842fbb9db55f2622e49b2de6fd0b6d))

### Documentation improvements

- A comment for field `display_name` in message `.google.cloud.cloudcontrolspartner.v1beta.Customer` is changed ([commit 4a276df](https://github.com/googleapis/google-cloud-dotnet/commit/4a276df641842fbb9db55f2622e49b2de6fd0b6d))
- Mark the accessApprovalRequests.list method as deprecated ([commit 95e9579](https://github.com/googleapis/google-cloud-dotnet/commit/95e9579f858426b4ca74a995818e37d777c64250))
