### PR TITLE
Release Google.Cloud.Dataproc.V1 version 5.14.0

### DIFF
--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.13.0</Version>
+    <Version>5.14.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataproc API, which manages Hadoop-based clusters and jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Dataproc.V1/docs/history.md
+++ b/apis/Google.Cloud.Dataproc.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 5.14.0, released 2024-09-16
+
+### New features
+
+- Add resource reference for KMS keys and fix comments ([commit 2a39cfd](https://github.com/googleapis/google-cloud-dotnet/commit/2a39cfd6e0994f9aeeec70fae4af878d22a29d09))
+- Add support for new Dataproc features ([commit 2a8cd75](https://github.com/googleapis/google-cloud-dotnet/commit/2a8cd7532c01b59e5f62dfe7655a991dab958181))
+- Add support for new Dataproc features ([commit 25f2519](https://github.com/googleapis/google-cloud-dotnet/commit/25f2519badff8e1691db0efc8af634102493b2e8))
+
 ## Version 5.13.0, released 2024-09-09
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1776,7 +1776,7 @@
       "protoPath": "google/cloud/dataproc/v1",
       "productName": "Google Cloud Dataproc",
       "productUrl": "https://cloud.google.com/dataproc/docs/concepts/overview",
-      "version": "5.13.0",
+      "version": "5.14.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Dataproc API, which manages Hadoop-based clusters and jobs on Google Cloud Platform.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Add resource reference for KMS keys and fix comments ([commit 2a39cfd](https://github.com/googleapis/google-cloud-dotnet/commit/2a39cfd6e0994f9aeeec70fae4af878d22a29d09))
- Add support for new Dataproc features ([commit 2a8cd75](https://github.com/googleapis/google-cloud-dotnet/commit/2a8cd7532c01b59e5f62dfe7655a991dab958181))
- Add support for new Dataproc features ([commit 25f2519](https://github.com/googleapis/google-cloud-dotnet/commit/25f2519badff8e1691db0efc8af634102493b2e8))
