### PR TITLE
Release Google.Cloud.NetApp.V1 version 1.5.0

### DIFF
--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.csproj
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.4.0</Version>
+    <Version>1.5.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud NetApp Volumes API, which is a fully-managed, cloud-based data storage service that provides advanced data management capabilities and highly scalable performance with global availability.</Description>

--- a/apis/Google.Cloud.NetApp.V1/docs/history.md
+++ b/apis/Google.Cloud.NetApp.V1/docs/history.md
@@ -1,5 +1,14 @@
 # Version history
 
+## Version 1.5.0, released 2024-09-16
+
+### New features
+
+- A new rpc 'SwitchActiveReplicaZone' is added to service 'google.cloud.netapp.v1.NetApp' ([commit ba31386](https://github.com/googleapis/google-cloud-dotnet/commit/ba313865bce91eaafad141e100b10afb67d683cf))
+- A new message 'google.cloud.netapp.v1.SwitchActiveReplicaZoneRequest' is added ([commit ba31386](https://github.com/googleapis/google-cloud-dotnet/commit/ba313865bce91eaafad141e100b10afb67d683cf))
+- A new field 'allow_auto_tiering' in message 'google.cloud.netapp.v1.StoragePool' is added ([commit ba31386](https://github.com/googleapis/google-cloud-dotnet/commit/ba313865bce91eaafad141e100b10afb67d683cf))
+- A new field 'cold_tier_size_gib' in message 'google.cloud.netapp.v1.Volume' is added ([commit ba31386](https://github.com/googleapis/google-cloud-dotnet/commit/ba313865bce91eaafad141e100b10afb67d683cf))
+
 ## Version 1.4.0, released 2024-08-05
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3324,7 +3324,7 @@
     },
     {
       "id": "Google.Cloud.NetApp.V1",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "type": "grpc",
       "productName": "NetApp",
       "productUrl": "https://cloud.google.com/netapp/volumes/docs/discover/overview",


### PR DESCRIPTION

Changes in this release:

### New features

- A new rpc 'SwitchActiveReplicaZone' is added to service 'google.cloud.netapp.v1.NetApp' ([commit ba31386](https://github.com/googleapis/google-cloud-dotnet/commit/ba313865bce91eaafad141e100b10afb67d683cf))
- A new message 'google.cloud.netapp.v1.SwitchActiveReplicaZoneRequest' is added ([commit ba31386](https://github.com/googleapis/google-cloud-dotnet/commit/ba313865bce91eaafad141e100b10afb67d683cf))
- A new field 'allow_auto_tiering' in message 'google.cloud.netapp.v1.StoragePool' is added ([commit ba31386](https://github.com/googleapis/google-cloud-dotnet/commit/ba313865bce91eaafad141e100b10afb67d683cf))
- A new field 'cold_tier_size_gib' in message 'google.cloud.netapp.v1.Volume' is added ([commit ba31386](https://github.com/googleapis/google-cloud-dotnet/commit/ba313865bce91eaafad141e100b10afb67d683cf))
