### PR TITLE
Release Google.Cloud.Orchestration.Airflow.Service.V1 version 2.9.0

### DIFF
--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.csproj
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.8.0</Version>
+    <Version>2.9.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Cloud Composer API, which manages Apache Airflow environments on Google Cloud Platform.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" VersionOverride="[4.8.0, 5.0.0)" />
-    <PackageReference Include="Google.LongRunning" VersionOverride="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" VersionOverride="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/docs/history.md
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/docs/history.md
@@ -1,5 +1,21 @@
 # Version history
 
+## Version 2.9.0, released 2024-09-16
+
+### New features
+
+- A new method `CheckUpgrade` is added to service `Environments` ([commit a8d79de](https://github.com/googleapis/google-cloud-dotnet/commit/a8d79de02811259f0014ac96c553da388b6b0cc8))
+- A new field `satisfies_pzi` is added to message `.google.cloud.orchestration.airflow.service.v1.Environment` ([commit a8d79de](https://github.com/googleapis/google-cloud-dotnet/commit/a8d79de02811259f0014ac96c553da388b6b0cc8))
+- A new message `CheckUpgradeRequest` is added ([commit a8d79de](https://github.com/googleapis/google-cloud-dotnet/commit/a8d79de02811259f0014ac96c553da388b6b0cc8))
+- A new field `airflow_metadata_retention_config` is added to message `.google.cloud.orchestration.airflow.service.v1.DataRetentionConfig` ([commit a8d79de](https://github.com/googleapis/google-cloud-dotnet/commit/a8d79de02811259f0014ac96c553da388b6b0cc8))
+- A new message `AirflowMetadataRetentionPolicyConfig` is added ([commit a8d79de](https://github.com/googleapis/google-cloud-dotnet/commit/a8d79de02811259f0014ac96c553da388b6b0cc8))
+
+### Documentation improvements
+
+- A comment for field `maintenance_window` in message `.google.cloud.orchestration.airflow.service.v1.EnvironmentConfig` is changed ([commit a8d79de](https://github.com/googleapis/google-cloud-dotnet/commit/a8d79de02811259f0014ac96c553da388b6b0cc8))
+- A comment for message `WorkloadsConfig` is changed ([commit a8d79de](https://github.com/googleapis/google-cloud-dotnet/commit/a8d79de02811259f0014ac96c553da388b6b0cc8))
+- A comment for field `storage_mode` in message `.google.cloud.orchestration.airflow.service.v1.TaskLogsRetentionConfig` is changed ([commit a8d79de](https://github.com/googleapis/google-cloud-dotnet/commit/a8d79de02811259f0014ac96c553da388b6b0cc8))
+
 ## Version 2.8.0, released 2024-05-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3564,7 +3564,7 @@
     },
     {
       "id": "Google.Cloud.Orchestration.Airflow.Service.V1",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "type": "grpc",
       "productName": "Cloud Composer",
       "productUrl": "https://cloud.google.com/composer/docs/",
@@ -3575,7 +3575,7 @@
         "orchestration"
       ],
       "dependencies": {
-        "Google.LongRunning": "3.2.0"
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/orchestration/airflow/service/v1",


### PR DESCRIPTION

Changes in this release:

### New features

- A new method `CheckUpgrade` is added to service `Environments` ([commit a8d79de](https://github.com/googleapis/google-cloud-dotnet/commit/a8d79de02811259f0014ac96c553da388b6b0cc8))
- A new field `satisfies_pzi` is added to message `.google.cloud.orchestration.airflow.service.v1.Environment` ([commit a8d79de](https://github.com/googleapis/google-cloud-dotnet/commit/a8d79de02811259f0014ac96c553da388b6b0cc8))
- A new message `CheckUpgradeRequest` is added ([commit a8d79de](https://github.com/googleapis/google-cloud-dotnet/commit/a8d79de02811259f0014ac96c553da388b6b0cc8))
- A new field `airflow_metadata_retention_config` is added to message `.google.cloud.orchestration.airflow.service.v1.DataRetentionConfig` ([commit a8d79de](https://github.com/googleapis/google-cloud-dotnet/commit/a8d79de02811259f0014ac96c553da388b6b0cc8))
- A new message `AirflowMetadataRetentionPolicyConfig` is added ([commit a8d79de](https://github.com/googleapis/google-cloud-dotnet/commit/a8d79de02811259f0014ac96c553da388b6b0cc8))

### Documentation improvements

- A comment for field `maintenance_window` in message `.google.cloud.orchestration.airflow.service.v1.EnvironmentConfig` is changed ([commit a8d79de](https://github.com/googleapis/google-cloud-dotnet/commit/a8d79de02811259f0014ac96c553da388b6b0cc8))
- A comment for message `WorkloadsConfig` is changed ([commit a8d79de](https://github.com/googleapis/google-cloud-dotnet/commit/a8d79de02811259f0014ac96c553da388b6b0cc8))
- A comment for field `storage_mode` in message `.google.cloud.orchestration.airflow.service.v1.TaskLogsRetentionConfig` is changed ([commit a8d79de](https://github.com/googleapis/google-cloud-dotnet/commit/a8d79de02811259f0014ac96c553da388b6b0cc8))
