### PR TITLE
Release Google.Cloud.AIPlatform.V1 version 3.8.0

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.7.0</Version>
+    <Version>3.8.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform API (v1), which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+## Version 3.8.0, released 2024-09-26
+
+### New features
+
+- Add TunedModelRef and RebaseTunedModel Api for Vertex GenAiTuningService ([commit d139bd8](https://github.com/googleapis/google-cloud-dotnet/commit/d139bd8d89a9d80965eaa7b011edee608266b622))
+- Add CIVIC_INTEGRITY category to SafetySettings for prediction service ([commit bfe994b](https://github.com/googleapis/google-cloud-dotnet/commit/bfe994b519b81d40c1352093956be04b0517d4f8))
+- A new field `generation_config` is added to message `.google.cloud.aiplatform.v1.CountTokensRequest` ([commit ba7bd07](https://github.com/googleapis/google-cloud-dotnet/commit/ba7bd0711d214682c47fe867a28fea446ecffa96))
+- A new field `labels` is added to message `.google.cloud.aiplatform.v1.GenerateContentRequest` ([commit ba7bd07](https://github.com/googleapis/google-cloud-dotnet/commit/ba7bd0711d214682c47fe867a28fea446ecffa96))
+- A new field `property_ordering` is added to message `.google.cloud.aiplatform.v1.Schema` ([commit eda71ab](https://github.com/googleapis/google-cloud-dotnet/commit/eda71ab7b64b017de6b983a80a48ae4b04609de8))
+
+### Documentation improvements
+
+- Limit comment `SupervisedTuningSpec` for 1p tuning ([commit d139bd8](https://github.com/googleapis/google-cloud-dotnet/commit/d139bd8d89a9d80965eaa7b011edee608266b622))
+
 ## Version 3.7.0, released 2024-09-09
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -371,7 +371,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "type": "grpc",
       "productName": "Cloud AI Platform",
       "productUrl": "https://cloud.google.com/ai-platform/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add TunedModelRef and RebaseTunedModel Api for Vertex GenAiTuningService ([commit d139bd8](https://github.com/googleapis/google-cloud-dotnet/commit/d139bd8d89a9d80965eaa7b011edee608266b622))
- Add CIVIC_INTEGRITY category to SafetySettings for prediction service ([commit bfe994b](https://github.com/googleapis/google-cloud-dotnet/commit/bfe994b519b81d40c1352093956be04b0517d4f8))
- A new field `generation_config` is added to message `.google.cloud.aiplatform.v1.CountTokensRequest` ([commit ba7bd07](https://github.com/googleapis/google-cloud-dotnet/commit/ba7bd0711d214682c47fe867a28fea446ecffa96))
- A new field `labels` is added to message `.google.cloud.aiplatform.v1.GenerateContentRequest` ([commit ba7bd07](https://github.com/googleapis/google-cloud-dotnet/commit/ba7bd0711d214682c47fe867a28fea446ecffa96))
- A new field `property_ordering` is added to message `.google.cloud.aiplatform.v1.Schema` ([commit eda71ab](https://github.com/googleapis/google-cloud-dotnet/commit/eda71ab7b64b017de6b983a80a48ae4b04609de8))

### Documentation improvements

- Limit comment `SupervisedTuningSpec` for 1p tuning ([commit d139bd8](https://github.com/googleapis/google-cloud-dotnet/commit/d139bd8d89a9d80965eaa7b011edee608266b622))
