### PR TITLE
Release Google.Cloud.BackupDR.V1 version 1.2.0

### DIFF
--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.csproj
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Backup and DR service, which is a powerful, centralized, cloud-first backup and disaster recovery solution for cloud-based and hybrid workloads.</Description>

--- a/apis/Google.Cloud.BackupDR.V1/docs/history.md
+++ b/apis/Google.Cloud.BackupDR.V1/docs/history.md
@@ -1,5 +1,24 @@
 # Version history
 
+## Version 1.2.0, released 2024-09-26
+
+### New features
+
+- Client library for the backupvault api is added ([commit a873918](https://github.com/googleapis/google-cloud-dotnet/commit/a8739185eb39dedeab0eed11d4c382d553d5afd1))
+- Add backupplan proto ([commit a873918](https://github.com/googleapis/google-cloud-dotnet/commit/a8739185eb39dedeab0eed11d4c382d553d5afd1))
+- Add backupplanassociation proto ([commit a873918](https://github.com/googleapis/google-cloud-dotnet/commit/a8739185eb39dedeab0eed11d4c382d553d5afd1))
+- Add backupvault_ba proto ([commit a873918](https://github.com/googleapis/google-cloud-dotnet/commit/a8739185eb39dedeab0eed11d4c382d553d5afd1))
+- Add backupvault_gce proto ([commit a873918](https://github.com/googleapis/google-cloud-dotnet/commit/a8739185eb39dedeab0eed11d4c382d553d5afd1))
+
+### Documentation improvements
+
+- A comment for field `oauth2_client_id` in message `.google.cloud.backupdr.v1.ManagementServer` is changed ([commit a873918](https://github.com/googleapis/google-cloud-dotnet/commit/a8739185eb39dedeab0eed11d4c382d553d5afd1))
+- A comment for field `parent` in message `.google.cloud.backupdr.v1.ListManagementServersRequest` is changed ([commit a873918](https://github.com/googleapis/google-cloud-dotnet/commit/a8739185eb39dedeab0eed11d4c382d553d5afd1))
+- A comment for field `management_servers` in message `.google.cloud.backupdr.v1.ListManagementServersResponse` is changed ([commit a873918](https://github.com/googleapis/google-cloud-dotnet/commit/a8739185eb39dedeab0eed11d4c382d553d5afd1))
+- A comment for field `name` in message `.google.cloud.backupdr.v1.GetManagementServerRequest` is changed ([commit a873918](https://github.com/googleapis/google-cloud-dotnet/commit/a8739185eb39dedeab0eed11d4c382d553d5afd1))
+- A comment for field `parent` in message `.google.cloud.backupdr.v1.CreateManagementServerRequest` is changed ([commit a873918](https://github.com/googleapis/google-cloud-dotnet/commit/a8739185eb39dedeab0eed11d4c382d553d5afd1))
+- A comment for field `requested_cancellation` in message `.google.cloud.backupdr.v1.OperationMetadata` is changed ([commit a873918](https://github.com/googleapis/google-cloud-dotnet/commit/a8739185eb39dedeab0eed11d4c382d553d5afd1))
+
 ## Version 1.1.0, released 2024-06-24
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -712,7 +712,7 @@
     },
     {
       "id": "Google.Cloud.BackupDR.V1",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "type": "grpc",
       "productName": "Backup and DR Service",
       "productUrl": "https://cloud.google.com/backup-disaster-recovery/docs/concepts/backup-dr",


### PR DESCRIPTION

Changes in this release:

### New features

- Client library for the backupvault api is added ([commit a873918](https://github.com/googleapis/google-cloud-dotnet/commit/a8739185eb39dedeab0eed11d4c382d553d5afd1))
- Add backupplan proto ([commit a873918](https://github.com/googleapis/google-cloud-dotnet/commit/a8739185eb39dedeab0eed11d4c382d553d5afd1))
- Add backupplanassociation proto ([commit a873918](https://github.com/googleapis/google-cloud-dotnet/commit/a8739185eb39dedeab0eed11d4c382d553d5afd1))
- Add backupvault_ba proto ([commit a873918](https://github.com/googleapis/google-cloud-dotnet/commit/a8739185eb39dedeab0eed11d4c382d553d5afd1))
- Add backupvault_gce proto ([commit a873918](https://github.com/googleapis/google-cloud-dotnet/commit/a8739185eb39dedeab0eed11d4c382d553d5afd1))

### Documentation improvements

- A comment for field `oauth2_client_id` in message `.google.cloud.backupdr.v1.ManagementServer` is changed ([commit a873918](https://github.com/googleapis/google-cloud-dotnet/commit/a8739185eb39dedeab0eed11d4c382d553d5afd1))
- A comment for field `parent` in message `.google.cloud.backupdr.v1.ListManagementServersRequest` is changed ([commit a873918](https://github.com/googleapis/google-cloud-dotnet/commit/a8739185eb39dedeab0eed11d4c382d553d5afd1))
- A comment for field `management_servers` in message `.google.cloud.backupdr.v1.ListManagementServersResponse` is changed ([commit a873918](https://github.com/googleapis/google-cloud-dotnet/commit/a8739185eb39dedeab0eed11d4c382d553d5afd1))
- A comment for field `name` in message `.google.cloud.backupdr.v1.GetManagementServerRequest` is changed ([commit a873918](https://github.com/googleapis/google-cloud-dotnet/commit/a8739185eb39dedeab0eed11d4c382d553d5afd1))
- A comment for field `parent` in message `.google.cloud.backupdr.v1.CreateManagementServerRequest` is changed ([commit a873918](https://github.com/googleapis/google-cloud-dotnet/commit/a8739185eb39dedeab0eed11d4c382d553d5afd1))
- A comment for field `requested_cancellation` in message `.google.cloud.backupdr.v1.OperationMetadata` is changed ([commit a873918](https://github.com/googleapis/google-cloud-dotnet/commit/a8739185eb39dedeab0eed11d4c382d553d5afd1))
