### PR TITLE
Release Google.Cloud.Bigtable.Admin.V2 version 3.21.0

### DIFF
--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.20.0</Version>
+    <Version>3.21.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Bigtable Instance and Table Admin APIs.</Description>

--- a/apis/Google.Cloud.Bigtable.Admin.V2/docs/history.md
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.21.0, released 2024-09-26
+
+### New features
+
+- Add support for Cloud Bigtable Node Scaling Factor for CBT Clusters ([commit 75f928c](https://github.com/googleapis/google-cloud-dotnet/commit/75f928cf788216909bc61155af1202558050bc7f))
+
 ## Version 3.20.0, released 2024-09-16
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1120,7 +1120,7 @@
       "protoPath": "google/bigtable/admin/v2",
       "productName": "Google Cloud Bigtable Administration",
       "productUrl": "https://cloud.google.com/bigtable/",
-      "version": "3.20.0",
+      "version": "3.21.0",
       "commonResourcesConfig": "apis/Google.Cloud.Bigtable.Common.V2/CommonResourcesConfig.json",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Bigtable Instance and Table Admin APIs.",


### PR DESCRIPTION

Changes in this release:

### New features

- Add support for Cloud Bigtable Node Scaling Factor for CBT Clusters ([commit 75f928c](https://github.com/googleapis/google-cloud-dotnet/commit/75f928cf788216909bc61155af1202558050bc7f))
