### PR TITLE
Release Google.Cloud.Dataproc.V1 version 5.15.0

### DIFF
--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.14.0</Version>
+    <Version>5.15.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataproc API, which manages Hadoop-based clusters and jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Dataproc.V1/docs/history.md
+++ b/apis/Google.Cloud.Dataproc.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 5.15.0, released 2024-09-26
+
+### New features
+
+- Add support for Spark Connect sessions in Dataproc Serverless for Spark ([commit 2a56544](https://github.com/googleapis/google-cloud-dotnet/commit/2a5654405a1350a08e95dde23c034ca49a3f19b5))
+
+### Documentation improvements
+
+- Update docs for `filter` field in `ListSessionsRequest` ([commit 2a56544](https://github.com/googleapis/google-cloud-dotnet/commit/2a5654405a1350a08e95dde23c034ca49a3f19b5))
+
 ## Version 5.14.0, released 2024-09-16
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1798,7 +1798,7 @@
       "protoPath": "google/cloud/dataproc/v1",
       "productName": "Google Cloud Dataproc",
       "productUrl": "https://cloud.google.com/dataproc/docs/concepts/overview",
-      "version": "5.14.0",
+      "version": "5.15.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Dataproc API, which manages Hadoop-based clusters and jobs on Google Cloud Platform.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Add support for Spark Connect sessions in Dataproc Serverless for Spark ([commit 2a56544](https://github.com/googleapis/google-cloud-dotnet/commit/2a5654405a1350a08e95dde23c034ca49a3f19b5))

### Documentation improvements

- Update docs for `filter` field in `ListSessionsRequest` ([commit 2a56544](https://github.com/googleapis/google-cloud-dotnet/commit/2a5654405a1350a08e95dde23c034ca49a3f19b5))
