### PR TITLE
Release Google.Cloud.Dialogflow.V2 version 4.22.0

### DIFF
--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.21.0</Version>
+    <Version>4.22.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Dialogflow API (v2).</Description>

--- a/apis/Google.Cloud.Dialogflow.V2/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.V2/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 4.22.0, released 2024-09-26
+
+### New features
+
+- Created new boolean fields in conversation dataset for zone isolation and zone separation compliance status ([commit 1a9f58d](https://github.com/googleapis/google-cloud-dotnet/commit/1a9f58dd2cf7690fc50ec780c2f573ccda43eccb))
+- Add ALAW encoding value to Audio encoding enum ([commit 1a9f58d](https://github.com/googleapis/google-cloud-dotnet/commit/1a9f58dd2cf7690fc50ec780c2f573ccda43eccb))
+- Created new boolean fields in conversation model for zone isolation and zone separation compliance status ([commit 24e7f8f](https://github.com/googleapis/google-cloud-dotnet/commit/24e7f8f17a28c721b9eae24260db021a42292583))
+
 ## Version 4.21.0, released 2024-08-05
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2081,7 +2081,7 @@
       "protoPath": "google/cloud/dialogflow/v2",
       "productName": "Google Cloud Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow-enterprise/",
-      "version": "4.21.0",
+      "version": "4.22.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Dialogflow API (v2).",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Created new boolean fields in conversation dataset for zone isolation and zone separation compliance status ([commit 1a9f58d](https://github.com/googleapis/google-cloud-dotnet/commit/1a9f58dd2cf7690fc50ec780c2f573ccda43eccb))
- Add ALAW encoding value to Audio encoding enum ([commit 1a9f58d](https://github.com/googleapis/google-cloud-dotnet/commit/1a9f58dd2cf7690fc50ec780c2f573ccda43eccb))
- Created new boolean fields in conversation model for zone isolation and zone separation compliance status ([commit 24e7f8f](https://github.com/googleapis/google-cloud-dotnet/commit/24e7f8f17a28c721b9eae24260db021a42292583))
