### PR TITLE
Release Google.Cloud.Dlp.V2 version 4.14.0

### DIFF
--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.csproj
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.13.0</Version>
+    <Version>4.14.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Data Loss Prevention API, which provides methods for detection of privacy-sensitive fragments in text, images, and Google Cloud Platform storage repositories.</Description>

--- a/apis/Google.Cloud.Dlp.V2/docs/history.md
+++ b/apis/Google.Cloud.Dlp.V2/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 4.14.0, released 2024-09-26
+
+### New features
+
+- Action for publishing data profiles to SecOps (formelly known as Chronicle) ([commit d6641c2](https://github.com/googleapis/google-cloud-dotnet/commit/d6641c27d51c828d5c6d5930d93b30d79a6782e3))
+- Action for publishing data profiles to Security Command Center ([commit d6641c2](https://github.com/googleapis/google-cloud-dotnet/commit/d6641c27d51c828d5c6d5930d93b30d79a6782e3))
+- Discovery configs for AWS S3 buckets ([commit d6641c2](https://github.com/googleapis/google-cloud-dotnet/commit/d6641c27d51c828d5c6d5930d93b30d79a6782e3))
+
+### Documentation improvements
+
+- Small improvements and clarifications ([commit d6641c2](https://github.com/googleapis/google-cloud-dotnet/commit/d6641c27d51c828d5c6d5930d93b30d79a6782e3))
+
 ## Version 4.13.0, released 2024-09-09
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2173,7 +2173,7 @@
       "protoPath": "google/privacy/dlp/v2",
       "productName": "Google Cloud Data Loss Prevention",
       "productUrl": "https://cloud.google.com/dlp/",
-      "version": "4.13.0",
+      "version": "4.14.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Data Loss Prevention API, which provides methods for detection of privacy-sensitive fragments in text, images, and Google Cloud Platform storage repositories.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Action for publishing data profiles to SecOps (formelly known as Chronicle) ([commit d6641c2](https://github.com/googleapis/google-cloud-dotnet/commit/d6641c27d51c828d5c6d5930d93b30d79a6782e3))
- Action for publishing data profiles to Security Command Center ([commit d6641c2](https://github.com/googleapis/google-cloud-dotnet/commit/d6641c27d51c828d5c6d5930d93b30d79a6782e3))
- Discovery configs for AWS S3 buckets ([commit d6641c2](https://github.com/googleapis/google-cloud-dotnet/commit/d6641c27d51c828d5c6d5930d93b30d79a6782e3))

### Documentation improvements

- Small improvements and clarifications ([commit d6641c2](https://github.com/googleapis/google-cloud-dotnet/commit/d6641c27d51c828d5c6d5930d93b30d79a6782e3))
