### PR TITLE
Release Google.Cloud.GdcHardwareManagement.V1Alpha version 1.0.0-alpha02

### DIFF
--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.csproj
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha01</Version>
+    <Version>1.0.0-alpha02</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Distributed Cloud Hardware Management API (v1alpha)</Description>

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 1.0.0-alpha02, released 2024-09-26
+
+### New features
+
+- Add an order type field to distinguish a fulfillment request from a sales inquiry ([commit 0a66c68](https://github.com/googleapis/google-cloud-dotnet/commit/0a66c68ce14f9baaba295bfc06a624be78729bc7))
+- Add support to mark comments as read or unread ([commit 0a66c68](https://github.com/googleapis/google-cloud-dotnet/commit/0a66c68ce14f9baaba295bfc06a624be78729bc7))
+- Rename zone state signal READY_FOR_SITE_TURNUP to FACTORY_TURNUP_CHECKS_PASSED ([commit 0a66c68](https://github.com/googleapis/google-cloud-dotnet/commit/0a66c68ce14f9baaba295bfc06a624be78729bc7))
+
+### Documentation improvements
+
+- Clarify how access_times are used ([commit 0a66c68](https://github.com/googleapis/google-cloud-dotnet/commit/0a66c68ce14f9baaba295bfc06a624be78729bc7))
+
 ## Version 1.0.0-alpha01, released 2024-06-26
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2608,7 +2608,7 @@
     },
     {
       "id": "Google.Cloud.GdcHardwareManagement.V1Alpha",
-      "version": "1.0.0-alpha01",
+      "version": "1.0.0-alpha02",
       "type": "grpc",
       "productName": "GDC Hardware Management",
       "productUrl": "https://cloud.google.com/distributed-cloud/edge/latest/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add an order type field to distinguish a fulfillment request from a sales inquiry ([commit 0a66c68](https://github.com/googleapis/google-cloud-dotnet/commit/0a66c68ce14f9baaba295bfc06a624be78729bc7))
- Add support to mark comments as read or unread ([commit 0a66c68](https://github.com/googleapis/google-cloud-dotnet/commit/0a66c68ce14f9baaba295bfc06a624be78729bc7))
- Rename zone state signal READY_FOR_SITE_TURNUP to FACTORY_TURNUP_CHECKS_PASSED ([commit 0a66c68](https://github.com/googleapis/google-cloud-dotnet/commit/0a66c68ce14f9baaba295bfc06a624be78729bc7))

### Documentation improvements

- Clarify how access_times are used ([commit 0a66c68](https://github.com/googleapis/google-cloud-dotnet/commit/0a66c68ce14f9baaba295bfc06a624be78729bc7))
