### PR TITLE
Release Google.Cloud.Logging.Log4Net version 4.4.0

### DIFF
--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.3.0</Version>
+    <Version>4.4.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Log4Net client library for the Google Cloud Logging API.</Description>
@@ -11,7 +11,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" VersionOverride="[4.9.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.DevTools.Common" VersionOverride="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Logging.V2" VersionOverride="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Cloud.Logging.V2" VersionOverride="[4.4.0, 5.0.0)" />
     <PackageReference Include="Grpc.Core" VersionOverride="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
     <PackageReference Include="log4net" />
   </ItemGroup>

--- a/apis/Google.Cloud.Logging.Log4Net/docs/history.md
+++ b/apis/Google.Cloud.Logging.Log4Net/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 4.4.0, released 2024-09-26
+
+### New features
+
+- Update log4net dependency. ([commit 0ab782a](https://github.com/googleapis/google-cloud-dotnet/commit/0ab782a2c14733e86fcdf9854465000ba0ed01c6))
+
 ## Version 4.3.0, released 2024-03-28
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3020,7 +3020,7 @@
     },
     {
       "id": "Google.Cloud.Logging.Log4Net",
-      "version": "4.3.0",
+      "version": "4.4.0",
       "type": "other",
       "metadataType": "INTEGRATION",
       "description": "Log4Net client library for the Google Cloud Logging API.",
@@ -3032,7 +3032,7 @@
       "dependencies": {
         "Google.Api.Gax.Grpc": "default",
         "Google.Cloud.DevTools.Common": "3.2.0",
-        "Google.Cloud.Logging.V2": "4.3.0",
+        "Google.Cloud.Logging.V2": "4.4.0",
         "Grpc.Core": "default",
         "log4net": "default"
       },


### PR DESCRIPTION

Changes in this release:

### New features

- Update log4net dependency. ([commit 0ab782a](https://github.com/googleapis/google-cloud-dotnet/commit/0ab782a2c14733e86fcdf9854465000ba0ed01c6))
