### PR TITLE
Release Google.Cloud.Logging.NLog version 5.2.0

### DIFF
--- a/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.csproj
+++ b/apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.1.0</Version>
+    <Version>5.2.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>NLog target for the Google Cloud Logging API.</Description>
@@ -11,7 +11,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" VersionOverride="[4.9.0, 5.0.0)" />
     <PackageReference Include="Google.Cloud.DevTools.Common" VersionOverride="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Logging.V2" VersionOverride="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Google.Cloud.Logging.V2" VersionOverride="[4.4.0, 5.0.0)" />
     <PackageReference Include="Grpc.Core" VersionOverride="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
     <PackageReference Include="NLog" />
   </ItemGroup>

--- a/apis/Google.Cloud.Logging.NLog/docs/history.md
+++ b/apis/Google.Cloud.Logging.NLog/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 5.2.0, released 2024-09-26
+
+### New features
+
+- Update NLog to 5.3.4 ([commit a2da879](https://github.com/googleapis/google-cloud-dotnet/commit/a2da87980e97abad96012e342077ba49bdd5921b))
+
 ## Version 5.1.0, released 2024-03-28
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3060,7 +3060,7 @@
     },
     {
       "id": "Google.Cloud.Logging.NLog",
-      "version": "5.1.0",
+      "version": "5.2.0",
       "type": "other",
       "metadataType": "INTEGRATION",
       "description": "NLog target for the Google Cloud Logging API.",
@@ -3072,7 +3072,7 @@
       "dependencies": {
         "Google.Api.Gax.Grpc": "default",
         "Google.Cloud.DevTools.Common": "3.2.0",
-        "Google.Cloud.Logging.V2": "4.3.0",
+        "Google.Cloud.Logging.V2": "4.4.0",
         "Grpc.Core": "default",
         "NLog": "default"
       },


### PR DESCRIPTION

Changes in this release:

### New features

- Update NLog to 5.3.4 ([commit a2da879](https://github.com/googleapis/google-cloud-dotnet/commit/a2da87980e97abad96012e342077ba49bdd5921b))
