### PR TITLE
Release Google.Cloud.OrgPolicy.V2 version 2.7.0

### DIFF
--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.csproj
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Organization Policy API (v2), which allows users to configure governance rules on their GCP resources across the Cloud Resource Hierarchy.</Description>

--- a/apis/Google.Cloud.OrgPolicy.V2/docs/history.md
+++ b/apis/Google.Cloud.OrgPolicy.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.7.0, released 2024-09-26
+
+### New features
+
+- Support adding constraints to new method types REMOVE_GRANTS and GOVERN_TAGS ([commit f49e16e](https://github.com/googleapis/google-cloud-dotnet/commit/f49e16e0aff289c5d4932bd6b503ac5e1cf739c8))
+
 ## Version 2.6.0, released 2024-05-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3646,7 +3646,7 @@
     },
     {
       "id": "Google.Cloud.OrgPolicy.V2",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "type": "grpc",
       "productName": "Organization Policy",
       "productUrl": "https://cloud.google.com/resource-manager/docs/organization-policy/overview",


### PR DESCRIPTION

Changes in this release:

### New features

- Support adding constraints to new method types REMOVE_GRANTS and GOVERN_TAGS ([commit f49e16e](https://github.com/googleapis/google-cloud-dotnet/commit/f49e16e0aff289c5d4932bd6b503ac5e1cf739c8))
