### PR TITLE
Release Google.Cloud.Parallelstore.V1Beta version 1.0.0-beta06

### DIFF
--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.csproj
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta05</Version>
+    <Version>1.0.0-beta06</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to manage the Parallelstore high performance, managed parallel file service.</Description>

--- a/apis/Google.Cloud.Parallelstore.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.0.0-beta06, released 2024-09-26
+
+### New features
+
+- Add UPGRADING state to Parallelstore state ([commit d248b5d](https://github.com/googleapis/google-cloud-dotnet/commit/d248b5dc5dff4ee40febb87beb8b8011a1092b53))
+
+### Documentation improvements
+
+- Cleanup of Parallelstore API descriptions ([commit d248b5d](https://github.com/googleapis/google-cloud-dotnet/commit/d248b5dc5dff4ee40febb87beb8b8011a1092b53))
+
 ## Version 1.0.0-beta05, released 2024-08-05
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3784,7 +3784,7 @@
     },
     {
       "id": "Google.Cloud.Parallelstore.V1Beta",
-      "version": "1.0.0-beta05",
+      "version": "1.0.0-beta06",
       "type": "grpc",
       "productName": "Parallelstore",
       "productUrl": "http://cloud/parallelstore?hl=en",


### PR DESCRIPTION

Changes in this release:

### New features

- Add UPGRADING state to Parallelstore state ([commit d248b5d](https://github.com/googleapis/google-cloud-dotnet/commit/d248b5dc5dff4ee40febb87beb8b8011a1092b53))

### Documentation improvements

- Cleanup of Parallelstore API descriptions ([commit d248b5d](https://github.com/googleapis/google-cloud-dotnet/commit/d248b5dc5dff4ee40febb87beb8b8011a1092b53))
