### PR TITLE
Release Google.Cloud.PubSub.V1 version 3.17.0

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.16.0</Version>
+    <Version>3.17.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.</Description>

--- a/apis/Google.Cloud.PubSub.V1/docs/history.md
+++ b/apis/Google.Cloud.PubSub.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 3.17.0, released 2024-09-26
+
+### New features
+
+- Add ingestion Cloud Storage fields and Platform Logging fields to Topic ([commit 5098b56](https://github.com/googleapis/google-cloud-dotnet/commit/5098b5604184c78fac6ba0161a7e081d530f8dd3))
+- Return listing information for subscriptions created via Analytics Hub ([commit ce5de77](https://github.com/googleapis/google-cloud-dotnet/commit/ce5de77b8f709c832d824bc739a68182183bec84))
+
+### Documentation improvements
+
+- Update documentation for 31 day subscription message retention ([commit 950f588](https://github.com/googleapis/google-cloud-dotnet/commit/950f5886f0486b86a899a7fe4aaa8b86979b2b89))
+
 ## Version 3.16.0, released 2024-07-22
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3962,7 +3962,7 @@
       "protoPath": "google/pubsub/v1",
       "productName": "Cloud Pub/Sub",
       "productUrl": "https://cloud.google.com/pubsub/",
-      "version": "3.16.0",
+      "version": "3.17.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",


### PR DESCRIPTION

Changes in this release:

### New features

- Add ingestion Cloud Storage fields and Platform Logging fields to Topic ([commit 5098b56](https://github.com/googleapis/google-cloud-dotnet/commit/5098b5604184c78fac6ba0161a7e081d530f8dd3))
- Return listing information for subscriptions created via Analytics Hub ([commit ce5de77](https://github.com/googleapis/google-cloud-dotnet/commit/ce5de77b8f709c832d824bc739a68182183bec84))

### Documentation improvements

- Update documentation for 31 day subscription message retention ([commit 950f588](https://github.com/googleapis/google-cloud-dotnet/commit/950f5886f0486b86a899a7fe4aaa8b86979b2b89))
