### PR TITLE
Release Google.Maps.Places.V1 version 1.0.0-beta09

### DIFF
--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1/Google.Maps.Places.V1.csproj
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1/Google.Maps.Places.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta08</Version>
+    <Version>1.0.0-beta09</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Places API, which allows developers to access a variety of search and retrieval endpoints for a Place.</Description>

--- a/apis/Google.Maps.Places.V1/docs/history.md
+++ b/apis/Google.Maps.Places.V1/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 1.0.0-beta09, released 2024-09-26
+
+### New features
+
+- Add `routing_parameters` to SearchNearbyRequest and SearchTextRequest ([commit 4f73b95](https://github.com/googleapis/google-cloud-dotnet/commit/4f73b95dcd2442f05b5aee911fb6142d00d2be19))
+- Add `search_along_route_parameters` to SearchTextRequest ([commit 4f73b95](https://github.com/googleapis/google-cloud-dotnet/commit/4f73b95dcd2442f05b5aee911fb6142d00d2be19))
+- Add `routing_summaries` to SearchNearbyResponse and SearchTextResponse ([commit 4f73b95](https://github.com/googleapis/google-cloud-dotnet/commit/4f73b95dcd2442f05b5aee911fb6142d00d2be19))
+
+### Documentation improvements
+
+- A comment for field `contextual_contents` in message `.google.maps.places.v1.SearchTextResponse` is changed to be more assertive ([commit 4f73b95](https://github.com/googleapis/google-cloud-dotnet/commit/4f73b95dcd2442f05b5aee911fb6142d00d2be19))
+- A comment for field `open_now` in message `.google.maps.places.v1.Place` is changed to clarify what it means with new-since-previous-comment current and secondary opening hours fields ([commit 4f73b95](https://github.com/googleapis/google-cloud-dotnet/commit/4f73b95dcd2442f05b5aee911fb6142d00d2be19))
+
 ## Version 1.0.0-beta08, released 2024-06-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5853,7 +5853,7 @@
     },
     {
       "id": "Google.Maps.Places.V1",
-      "version": "1.0.0-beta08",
+      "version": "1.0.0-beta09",
       "type": "grpc",
       "productName": "Places API",
       "productUrl": "https://developers.google.com/maps/documentation/places/web-service/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add `routing_parameters` to SearchNearbyRequest and SearchTextRequest ([commit 4f73b95](https://github.com/googleapis/google-cloud-dotnet/commit/4f73b95dcd2442f05b5aee911fb6142d00d2be19))
- Add `search_along_route_parameters` to SearchTextRequest ([commit 4f73b95](https://github.com/googleapis/google-cloud-dotnet/commit/4f73b95dcd2442f05b5aee911fb6142d00d2be19))
- Add `routing_summaries` to SearchNearbyResponse and SearchTextResponse ([commit 4f73b95](https://github.com/googleapis/google-cloud-dotnet/commit/4f73b95dcd2442f05b5aee911fb6142d00d2be19))

### Documentation improvements

- A comment for field `contextual_contents` in message `.google.maps.places.v1.SearchTextResponse` is changed to be more assertive ([commit 4f73b95](https://github.com/googleapis/google-cloud-dotnet/commit/4f73b95dcd2442f05b5aee911fb6142d00d2be19))
- A comment for field `open_now` in message `.google.maps.places.v1.Place` is changed to clarify what it means with new-since-previous-comment current and secondary opening hours fields ([commit 4f73b95](https://github.com/googleapis/google-cloud-dotnet/commit/4f73b95dcd2442f05b5aee911fb6142d00d2be19))
