### PR TITLE
Release Google.Shopping.Merchant.Accounts.V1Beta version 1.0.0-beta02

### DIFF
--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.csproj
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Merchant Accounts API (v1beta) which allows developers to programmatically manage conversion sources.</Description>

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/docs/history.md
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/docs/history.md
@@ -1,5 +1,26 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2024-09-26
+
+### Bug fixes
+
+- **BREAKING CHANGE** The type of an existing field `time_zone` is changed from `message` to `string` in message `.google.shopping.merchant.accounts.v1beta.ListAccountIssuesRequest` ([commit 6cfb1ff](https://github.com/googleapis/google-cloud-dotnet/commit/6cfb1ffdc3b8d3abd2853c589949be9cf1f31caa))
+- **BREAKING CHANGE** An existing field `account_aggregation` is removed from message `.google.shopping.merchant.accounts.v1beta.CreateAndConfigureAccountRequest` ([commit 6cfb1ff](https://github.com/googleapis/google-cloud-dotnet/commit/6cfb1ffdc3b8d3abd2853c589949be9cf1f31caa))
+- **BREAKING CHANGE** Changed field behavior for an existing field `service` in message `.google.shopping.merchant.accounts.v1beta.CreateAndConfigureAccountRequest` ([commit 6cfb1ff](https://github.com/googleapis/google-cloud-dotnet/commit/6cfb1ffdc3b8d3abd2853c589949be9cf1f31caa))
+- **BREAKING CHANGE** Changed field behavior for an existing field `region_code` in message `.google.shopping.merchant.accounts.v1beta.RetrieveLatestTermsOfServiceRequest` ([commit 6cfb1ff](https://github.com/googleapis/google-cloud-dotnet/commit/6cfb1ffdc3b8d3abd2853c589949be9cf1f31caa))
+- **BREAKING CHANGE** Changed field behavior for an existing field `kind` in message `.google.shopping.merchant.accounts.v1beta.RetrieveLatestTermsOfServiceRequest` ([commit 6cfb1ff](https://github.com/googleapis/google-cloud-dotnet/commit/6cfb1ffdc3b8d3abd2853c589949be9cf1f31caa))
+
+### New features
+
+- A new field `account_aggregation` is added to message `.google.shopping.merchant.accounts.v1beta.CreateAndConfigureAccountRequest` ([commit 6cfb1ff](https://github.com/googleapis/google-cloud-dotnet/commit/6cfb1ffdc3b8d3abd2853c589949be9cf1f31caa))
+- A new message `AccountAggregation` is added ([commit 6cfb1ff](https://github.com/googleapis/google-cloud-dotnet/commit/6cfb1ffdc3b8d3abd2853c589949be9cf1f31caa))
+- A new service `AutofeedSettingsService` is added ([commit 6cfb1ff](https://github.com/googleapis/google-cloud-dotnet/commit/6cfb1ffdc3b8d3abd2853c589949be9cf1f31caa))
+- A new message `AutofeedSettings` is added ([commit 6cfb1ff](https://github.com/googleapis/google-cloud-dotnet/commit/6cfb1ffdc3b8d3abd2853c589949be9cf1f31caa))
+- A new resource_definition `merchantapi.googleapis.com/AutofeedSettings` is added ([commit 6cfb1ff](https://github.com/googleapis/google-cloud-dotnet/commit/6cfb1ffdc3b8d3abd2853c589949be9cf1f31caa))
+- A new message `GetAutofeedSettingsRequest` is added ([commit 6cfb1ff](https://github.com/googleapis/google-cloud-dotnet/commit/6cfb1ffdc3b8d3abd2853c589949be9cf1f31caa))
+- A new message `UpdateAutofeedSettingsRequest` is added ([commit 6cfb1ff](https://github.com/googleapis/google-cloud-dotnet/commit/6cfb1ffdc3b8d3abd2853c589949be9cf1f31caa))
+- A new field `korean_business_registration_number` is added to message `.google.shopping.merchant.accounts.v1beta.BusinessInfo` ([commit 6cfb1ff](https://github.com/googleapis/google-cloud-dotnet/commit/6cfb1ffdc3b8d3abd2853c589949be9cf1f31caa))
+
 ## Version 1.0.0-beta01, released 2024-06-13
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5941,7 +5941,7 @@
     },
     {
       "id": "Google.Shopping.Merchant.Accounts.V1Beta",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Merchant",
       "productUrl": "https://developers.google.com/merchant/api",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** The type of an existing field `time_zone` is changed from `message` to `string` in message `.google.shopping.merchant.accounts.v1beta.ListAccountIssuesRequest` ([commit 6cfb1ff](https://github.com/googleapis/google-cloud-dotnet/commit/6cfb1ffdc3b8d3abd2853c589949be9cf1f31caa))
- **BREAKING CHANGE** An existing field `account_aggregation` is removed from message `.google.shopping.merchant.accounts.v1beta.CreateAndConfigureAccountRequest` ([commit 6cfb1ff](https://github.com/googleapis/google-cloud-dotnet/commit/6cfb1ffdc3b8d3abd2853c589949be9cf1f31caa))
- **BREAKING CHANGE** Changed field behavior for an existing field `service` in message `.google.shopping.merchant.accounts.v1beta.CreateAndConfigureAccountRequest` ([commit 6cfb1ff](https://github.com/googleapis/google-cloud-dotnet/commit/6cfb1ffdc3b8d3abd2853c589949be9cf1f31caa))
- **BREAKING CHANGE** Changed field behavior for an existing field `region_code` in message `.google.shopping.merchant.accounts.v1beta.RetrieveLatestTermsOfServiceRequest` ([commit 6cfb1ff](https://github.com/googleapis/google-cloud-dotnet/commit/6cfb1ffdc3b8d3abd2853c589949be9cf1f31caa))
- **BREAKING CHANGE** Changed field behavior for an existing field `kind` in message `.google.shopping.merchant.accounts.v1beta.RetrieveLatestTermsOfServiceRequest` ([commit 6cfb1ff](https://github.com/googleapis/google-cloud-dotnet/commit/6cfb1ffdc3b8d3abd2853c589949be9cf1f31caa))

### New features

- A new field `account_aggregation` is added to message `.google.shopping.merchant.accounts.v1beta.CreateAndConfigureAccountRequest` ([commit 6cfb1ff](https://github.com/googleapis/google-cloud-dotnet/commit/6cfb1ffdc3b8d3abd2853c589949be9cf1f31caa))
- A new message `AccountAggregation` is added ([commit 6cfb1ff](https://github.com/googleapis/google-cloud-dotnet/commit/6cfb1ffdc3b8d3abd2853c589949be9cf1f31caa))
- A new service `AutofeedSettingsService` is added ([commit 6cfb1ff](https://github.com/googleapis/google-cloud-dotnet/commit/6cfb1ffdc3b8d3abd2853c589949be9cf1f31caa))
- A new message `AutofeedSettings` is added ([commit 6cfb1ff](https://github.com/googleapis/google-cloud-dotnet/commit/6cfb1ffdc3b8d3abd2853c589949be9cf1f31caa))
- A new resource_definition `merchantapi.googleapis.com/AutofeedSettings` is added ([commit 6cfb1ff](https://github.com/googleapis/google-cloud-dotnet/commit/6cfb1ffdc3b8d3abd2853c589949be9cf1f31caa))
- A new message `GetAutofeedSettingsRequest` is added ([commit 6cfb1ff](https://github.com/googleapis/google-cloud-dotnet/commit/6cfb1ffdc3b8d3abd2853c589949be9cf1f31caa))
- A new message `UpdateAutofeedSettingsRequest` is added ([commit 6cfb1ff](https://github.com/googleapis/google-cloud-dotnet/commit/6cfb1ffdc3b8d3abd2853c589949be9cf1f31caa))
- A new field `korean_business_registration_number` is added to message `.google.shopping.merchant.accounts.v1beta.BusinessInfo` ([commit 6cfb1ff](https://github.com/googleapis/google-cloud-dotnet/commit/6cfb1ffdc3b8d3abd2853c589949be9cf1f31caa))
