### PR TITLE
Release Firestore libraries version 3.9.0

### DIFF
--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.8.0</Version>
+    <Version>3.9.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Low-level Google client library to access the Firestore API. Users are recommended to use the Google.Cloud.Firestore package instead.</Description>

--- a/apis/Google.Cloud.Firestore.V1/docs/history.md
+++ b/apis/Google.Cloud.Firestore.V1/docs/history.md
@@ -4,6 +4,17 @@ This package is primarily a dependency of Google.Cloud.Firestore. See the
 [Google.Cloud.Firestore version history](https://googleapis.dev/dotnet/Google.Cloud.Firestore/latest/history.html)
 for more details.
 
+## Version 3.9.0, released 2024-09-26
+
+### New features
+
+- Expose the `FindNearest.distance_result_field` parameter ([commit 90e89c5](https://github.com/googleapis/google-cloud-dotnet/commit/90e89c54a34ab97ac383fb7fc7ccd308cd9ba189))
+- Expose the `FindNearest.distance_threshold` parameter ([commit 90e89c5](https://github.com/googleapis/google-cloud-dotnet/commit/90e89c54a34ab97ac383fb7fc7ccd308cd9ba189))
+
+### Documentation improvements
+
+- Minor documentation clarifications on FindNearest DistanceMeasure options ([commit 0997231](https://github.com/googleapis/google-cloud-dotnet/commit/099723106fe192589286ed58ab1ee8af88ce53d1))
+
 ## Version 3.8.0, released 2024-06-24
 
 No API surface changes; just dependency updates.

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/Google.Cloud.Firestore.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/Google.Cloud.Firestore.IntegrationTests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Google.Api.Gax.Testing" VersionOverride="[4.9.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Firestore\Google.Cloud.Firestore.csproj" />
-    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" VersionOverride="[3.9.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" VersionOverride="[3.11.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core.Testing" VersionOverride="[2.46.6, 3.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/Google.Cloud.Firestore.Snippets.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/Google.Cloud.Firestore.Snippets.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Google.Api.Gax.Testing" VersionOverride="[4.9.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Firestore\Google.Cloud.Firestore.csproj" />
-    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" VersionOverride="[3.9.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" VersionOverride="[3.11.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core.Testing" VersionOverride="[2.46.6, 3.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Google.Cloud.Firestore.Tests.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Google.Cloud.Firestore.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Google.Api.Gax.Testing" VersionOverride="[4.9.0, 5.0.0)" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Firestore\Google.Cloud.Firestore.csproj" />
-    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" VersionOverride="[3.9.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" VersionOverride="[3.11.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core.Testing" VersionOverride="[2.46.6, 3.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.8.0</Version>
+    <Version>3.9.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Firestore API.</Description>

--- a/apis/Google.Cloud.Firestore/docs/history.md
+++ b/apis/Google.Cloud.Firestore/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 3.9.0, released 2024-09-26
+
+No API surface changes; just dependency updates.
+
 ## Version 3.8.0, released 2024-06-24
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2465,7 +2465,7 @@
       "productName": "Firestore",
       "productUrl": "https://firebase.google.com/docs/firestore/",
       "listingDescription": "Firestore high-level library",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "type": "other",
       "metadataType": "GAPIC_MANUAL",
       "description": "Recommended Google client library to access the Firestore API.",
@@ -2482,7 +2482,7 @@
       "testDependencies": {
         "Google.Api.Gax.Grpc.Testing": "default",
         "Google.Api.Gax.Testing": "default",
-        "Google.Cloud.Firestore.Admin.V1": "3.9.0",
+        "Google.Cloud.Firestore.Admin.V1": "3.11.0",
         "Grpc.Core.Testing": "2.46.6",
         "System.ValueTuple": "default",
         "Xunit.Combinatorial": "default"
@@ -2496,7 +2496,7 @@
       "productName": "Firestore",
       "productUrl": "https://firebase.google.com",
       "listingDescription": "Firestore low-level API access",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "type": "grpc",
       "description": "Low-level Google client library to access the Firestore API. Users are recommended to use the Google.Cloud.Firestore package instead.",
       "tags": [


### PR DESCRIPTION

Changes in Google.Cloud.Firestore version 3.9.0:

No API surface changes; just dependency updates.

Changes in Google.Cloud.Firestore.V1 version 3.9.0:

### New features

- Expose the `FindNearest.distance_result_field` parameter ([commit 90e89c5](https://github.com/googleapis/google-cloud-dotnet/commit/90e89c54a34ab97ac383fb7fc7ccd308cd9ba189))
- Expose the `FindNearest.distance_threshold` parameter ([commit 90e89c5](https://github.com/googleapis/google-cloud-dotnet/commit/90e89c54a34ab97ac383fb7fc7ccd308cd9ba189))

### Documentation improvements

- Minor documentation clarifications on FindNearest DistanceMeasure options ([commit 0997231](https://github.com/googleapis/google-cloud-dotnet/commit/099723106fe192589286ed58ab1ee8af88ce53d1))

Packages in this release:
- Release Google.Cloud.Firestore version 3.9.0
- Release Google.Cloud.Firestore.V1 version 3.9.0
