### PR TITLE
Release Google.Cloud.Deploy.V1 version 3.1.0

### DIFF
--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Deploy API, which automates delivery of your applications to a series of target environments in a defined sequence.</Description>

--- a/apis/Google.Cloud.Deploy.V1/docs/history.md
+++ b/apis/Google.Cloud.Deploy.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 3.1.0, released 2024-09-30
+
+### New features
+
+- Added support for deploy policies ([commit 4d3c458](https://github.com/googleapis/google-cloud-dotnet/commit/4d3c45859e0e624ac47b37b5fe310e00dca425e6))
+
+### Documentation improvements
+
+- Minor documentation updates ([commit 4d3c458](https://github.com/googleapis/google-cloud-dotnet/commit/4d3c45859e0e624ac47b37b5fe310e00dca425e6))
+- Very minor documentation updates ([commit 24da068](https://github.com/googleapis/google-cloud-dotnet/commit/24da068bcc242ddfc4f45beb3b0baf4931083ec5))
+
 ## Version 3.0.0, released 2024-07-30
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1912,7 +1912,7 @@
     },
     {
       "id": "Google.Cloud.Deploy.V1",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "type": "grpc",
       "productName": "Google Cloud Deploy",
       "productUrl": "https://cloud.google.com/deploy/",


### PR DESCRIPTION

Changes in this release:

### New features

- Added support for deploy policies ([commit 4d3c458](https://github.com/googleapis/google-cloud-dotnet/commit/4d3c45859e0e624ac47b37b5fe310e00dca425e6))

### Documentation improvements

- Minor documentation updates ([commit 4d3c458](https://github.com/googleapis/google-cloud-dotnet/commit/4d3c45859e0e624ac47b37b5fe310e00dca425e6))
- Very minor documentation updates ([commit 24da068](https://github.com/googleapis/google-cloud-dotnet/commit/24da068bcc242ddfc4f45beb3b0baf4931083ec5))
