### PR TITLE
Release Google.Shopping.Merchant.Accounts.V1Beta version 1.0.0-beta03

### DIFF
--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.csproj
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Merchant Accounts API (v1beta) which allows developers to programmatically manage conversion sources.</Description>

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/docs/history.md
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2024-09-30
+
+### New features
+
+- Add 'force' parameter for accounts.delete method ([commit a0d5d82](https://github.com/googleapis/google-cloud-dotnet/commit/a0d5d829b426a3a472c6d47116c200664d743600))
+
+### Documentation improvements
+
+- Updated descriptions for the DeleteAccount and ListAccounts RPCs ([commit a0d5d82](https://github.com/googleapis/google-cloud-dotnet/commit/a0d5d829b426a3a472c6d47116c200664d743600))
+
 ## Version 1.0.0-beta02, released 2024-09-26
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5941,7 +5941,7 @@
     },
     {
       "id": "Google.Shopping.Merchant.Accounts.V1Beta",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "Merchant",
       "productUrl": "https://developers.google.com/merchant/api",


### PR DESCRIPTION

Changes in this release:

### New features

- Add 'force' parameter for accounts.delete method ([commit a0d5d82](https://github.com/googleapis/google-cloud-dotnet/commit/a0d5d829b426a3a472c6d47116c200664d743600))

### Documentation improvements

- Updated descriptions for the DeleteAccount and ListAccounts RPCs ([commit a0d5d82](https://github.com/googleapis/google-cloud-dotnet/commit/a0d5d829b426a3a472c6d47116c200664d743600))
