### PR TITLE
fix: Do not throw if a subscriber is disposed before being started

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClientImpl.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberClientImpl.cs
@@ -184,7 +184,18 @@ public sealed partial class SubscriberClientImpl : SubscriberClient
     }
 
     /// <inheritdoc />
-    public override ValueTask DisposeAsync() => new ValueTask(StopAsync(_disposeTimeout));
+    public override ValueTask DisposeAsync()
+    {
+        lock (_lock)
+        {
+            if (_mainTcs is null)
+            {
+                // No-op. We don't want to throw exceptions if DisposeAsync is called before StartAsync.
+                return new ValueTask(Task.CompletedTask);
+            }
+        }
+        return new ValueTask(StopAsync(_disposeTimeout));
+    }
 
     /// <inheritdoc />
     public override Task StopAsync(CancellationToken hardStopToken)


### PR DESCRIPTION
We preserve the stop behaviour: stop does throw if it's called before start.

Fixes #13647