### PR TITLE
Release Google.Cloud.BigQuery.DataTransfer.V1 version 4.10.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.9.0</Version>
+    <Version>4.10.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Data Transfer API, which transfers data from partner SaaS applications to Google BigQuery on a scheduled, managed basis.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" VersionOverride="[4.9.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.3.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" VersionOverride="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 4.10.0, released 2024-10-07
+
+### New features
+
+- Add scheduleOptionsV2 and Error fields for TransferConfig ([commit 963221d](https://github.com/googleapis/google-cloud-dotnet/commit/963221d3cd8cb6e5252bb59ac3f413a2d703f4bd))
+
+### Documentation improvements
+
+- Add a note to the CreateTransferConfigRequest and UpdateTransferConfigRequest to disable restricting service account usage ([commit e0a36f4](https://github.com/googleapis/google-cloud-dotnet/commit/e0a36f41394c369bd47d7347479bce2ced7d21a0))
+- Deprecate `authorization_code` ([commit e1a80f1](https://github.com/googleapis/google-cloud-dotnet/commit/e1a80f10bd16b85f5805fa95810fb0d68196dc23))
+- Update OAuth links in `CreateTransferConfigRequest` and `UpdateTransferConfigRequest` ([commit 54d1ff9](https://github.com/googleapis/google-cloud-dotnet/commit/54d1ff93df6c51050015bae58e899296ebdb8fcb))
+
 ## Version 4.9.0, released 2024-05-13
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1027,11 +1027,11 @@
       "protoPath": "google/cloud/bigquery/datatransfer/v1",
       "productName": "Google BigQuery Data Transfer",
       "productUrl": "https://cloud.google.com/bigquery/transfer/",
-      "version": "4.9.0",
+      "version": "4.10.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the BigQuery Data Transfer API, which transfers data from partner SaaS applications to Google BigQuery on a scheduled, managed basis.",
       "dependencies": {
-        "Google.Cloud.Location": "2.2.0"
+        "Google.Cloud.Location": "2.3.0"
       },
       "tags": [
         "BigQuery",


### PR DESCRIPTION

Changes in this release:

### New features

- Add scheduleOptionsV2 and Error fields for TransferConfig ([commit 963221d](https://github.com/googleapis/google-cloud-dotnet/commit/963221d3cd8cb6e5252bb59ac3f413a2d703f4bd))

### Documentation improvements

- Add a note to the CreateTransferConfigRequest and UpdateTransferConfigRequest to disable restricting service account usage ([commit e0a36f4](https://github.com/googleapis/google-cloud-dotnet/commit/e0a36f41394c369bd47d7347479bce2ced7d21a0))
- Deprecate `authorization_code` ([commit e1a80f1](https://github.com/googleapis/google-cloud-dotnet/commit/e1a80f10bd16b85f5805fa95810fb0d68196dc23))
- Update OAuth links in `CreateTransferConfigRequest` and `UpdateTransferConfigRequest` ([commit 54d1ff9](https://github.com/googleapis/google-cloud-dotnet/commit/54d1ff93df6c51050015bae58e899296ebdb8fcb))
