### PR TITLE
Release Google.Cloud.Channel.V1 version 2.14.0

### DIFF
--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.csproj
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.13.0</Version>
+    <Version>2.14.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Channel API, which enables Google Cloud resellers and distributors to manage their customers, channel partners, entitlements and reports.</Description>

--- a/apis/Google.Cloud.Channel.V1/docs/history.md
+++ b/apis/Google.Cloud.Channel.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 2.14.0, released 2024-10-07
+
+### New features
+
+- Add support for primary_admin_email as customer_identity for ImportCustomer ([commit 86e0b08](https://github.com/googleapis/google-cloud-dotnet/commit/86e0b08262bd101b4c79a287da12ecae5b063b69))
+- Add support for importing team customer from a different reseller ([commit 86e0b08](https://github.com/googleapis/google-cloud-dotnet/commit/86e0b08262bd101b4c79a287da12ecae5b063b69))
+- Add support to look up team customer Cloud Identity information ([commit 86e0b08](https://github.com/googleapis/google-cloud-dotnet/commit/86e0b08262bd101b4c79a287da12ecae5b063b69))
+
+### Documentation improvements
+
+- Clarify the expected value of the domain field for team type customers ([commit 86e0b08](https://github.com/googleapis/google-cloud-dotnet/commit/86e0b08262bd101b4c79a287da12ecae5b063b69))
+
 ## Version 2.13.0, released 2024-06-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1337,7 +1337,7 @@
     },
     {
       "id": "Google.Cloud.Channel.V1",
-      "version": "2.13.0",
+      "version": "2.14.0",
       "type": "grpc",
       "productName": "Cloud Channel",
       "productUrl": "https://cloud.google.com/channel/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add support for primary_admin_email as customer_identity for ImportCustomer ([commit 86e0b08](https://github.com/googleapis/google-cloud-dotnet/commit/86e0b08262bd101b4c79a287da12ecae5b063b69))
- Add support for importing team customer from a different reseller ([commit 86e0b08](https://github.com/googleapis/google-cloud-dotnet/commit/86e0b08262bd101b4c79a287da12ecae5b063b69))
- Add support to look up team customer Cloud Identity information ([commit 86e0b08](https://github.com/googleapis/google-cloud-dotnet/commit/86e0b08262bd101b4c79a287da12ecae5b063b69))

### Documentation improvements

- Clarify the expected value of the domain field for team type customers ([commit 86e0b08](https://github.com/googleapis/google-cloud-dotnet/commit/86e0b08262bd101b4c79a287da12ecae5b063b69))
