### PR TITLE
Release Google.Cloud.Run.V2 version 2.10.0

### DIFF
--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.9.0</Version>
+    <Version>2.10.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Run Admin API (v2)</Description>

--- a/apis/Google.Cloud.Run.V2/docs/history.md
+++ b/apis/Google.Cloud.Run.V2/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+## Version 2.10.0, released 2024-10-07
+
+### New features
+
+- Add Builds API ([commit b72b1d8](https://github.com/googleapis/google-cloud-dotnet/commit/b72b1d8eae1298344189c98f441989119a1cd0e4))
+- Add Service Mesh configuration to Services ([commit b72b1d8](https://github.com/googleapis/google-cloud-dotnet/commit/b72b1d8eae1298344189c98f441989119a1cd0e4))
+- Add GPU configuration to Services ([commit b72b1d8](https://github.com/googleapis/google-cloud-dotnet/commit/b72b1d8eae1298344189c98f441989119a1cd0e4))
+- Add INGRESS_TRAFFIC_NONE to Services ([commit b72b1d8](https://github.com/googleapis/google-cloud-dotnet/commit/b72b1d8eae1298344189c98f441989119a1cd0e4))
+- Add ServiceScaling to Services ([commit b72b1d8](https://github.com/googleapis/google-cloud-dotnet/commit/b72b1d8eae1298344189c98f441989119a1cd0e4))
+
+### Documentation improvements
+
+- Fixed formatting of some documentation ([commit b72b1d8](https://github.com/googleapis/google-cloud-dotnet/commit/b72b1d8eae1298344189c98f441989119a1cd0e4))
+
 ## Version 2.9.0, released 2024-07-22
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4241,7 +4241,7 @@
     },
     {
       "id": "Google.Cloud.Run.V2",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "type": "grpc",
       "productName": "Cloud Run Admin",
       "productUrl": "https://cloud.google.com/run/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add Builds API ([commit b72b1d8](https://github.com/googleapis/google-cloud-dotnet/commit/b72b1d8eae1298344189c98f441989119a1cd0e4))
- Add Service Mesh configuration to Services ([commit b72b1d8](https://github.com/googleapis/google-cloud-dotnet/commit/b72b1d8eae1298344189c98f441989119a1cd0e4))
- Add GPU configuration to Services ([commit b72b1d8](https://github.com/googleapis/google-cloud-dotnet/commit/b72b1d8eae1298344189c98f441989119a1cd0e4))
- Add INGRESS_TRAFFIC_NONE to Services ([commit b72b1d8](https://github.com/googleapis/google-cloud-dotnet/commit/b72b1d8eae1298344189c98f441989119a1cd0e4))
- Add ServiceScaling to Services ([commit b72b1d8](https://github.com/googleapis/google-cloud-dotnet/commit/b72b1d8eae1298344189c98f441989119a1cd0e4))

### Documentation improvements

- Fixed formatting of some documentation ([commit b72b1d8](https://github.com/googleapis/google-cloud-dotnet/commit/b72b1d8eae1298344189c98f441989119a1cd0e4))
