### PR TITLE
Release Google.Cloud.BigQuery.Storage.V1 version 3.17.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.16.0</Version>
+    <Version>3.17.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Storage API.</Description>

--- a/apis/Google.Cloud.BigQuery.Storage.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.17.0, released 2024-10-14
+
+### New features
+
+- Add experimental ArrowData type and arrow_data field within AppendRowsRequest ([commit f556dca](https://github.com/googleapis/google-cloud-dotnet/commit/f556dca9d15fdbc3d8b93896f101b961f1b7b510))
+
 ## Version 3.16.0, released 2024-09-26
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1125,7 +1125,7 @@
       "protoPath": "google/cloud/bigquery/storage/v1",
       "productName": "Google BigQuery Storage",
       "productUrl": "https://cloud.google.com/bigquery/docs/reference/storage/",
-      "version": "3.16.0",
+      "version": "3.17.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the BigQuery Storage API.",
       "dependencies": {},


### PR DESCRIPTION

Changes in this release:

### New features

- Add experimental ArrowData type and arrow_data field within AppendRowsRequest ([commit f556dca](https://github.com/googleapis/google-cloud-dotnet/commit/f556dca9d15fdbc3d8b93896f101b961f1b7b510))
