### PR TITLE
Release Google.Cloud.BackupDR.V1 version 2.0.0

### DIFF
--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.csproj
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>2.0.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Backup and DR service, which is a powerful, centralized, cloud-first backup and disaster recovery solution for cloud-based and hybrid workloads.</Description>

--- a/apis/Google.Cloud.BackupDR.V1/docs/history.md
+++ b/apis/Google.Cloud.BackupDR.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 2.0.0, released 2024-10-14
+
+### Bug fixes
+
+- **BREAKING CHANGE** Remove visibility of unneeded TestIamPermissions RPC ([commit 553e7b0](https://github.com/googleapis/google-cloud-dotnet/commit/553e7b098875151e4dd7d8afbf20a708064fc645))
+- **BREAKING CHANGE** Remove visibility of unneeded InitiateBackup RPC ([commit 553e7b0](https://github.com/googleapis/google-cloud-dotnet/commit/553e7b098875151e4dd7d8afbf20a708064fc645))
+- **BREAKING CHANGE** Remove visibility of unneeded AbandonBackup RPC ([commit 553e7b0](https://github.com/googleapis/google-cloud-dotnet/commit/553e7b098875151e4dd7d8afbf20a708064fc645))
+- **BREAKING CHANGE** Remove visibility of unneeded FinalizeBackup RPC ([commit 553e7b0](https://github.com/googleapis/google-cloud-dotnet/commit/553e7b098875151e4dd7d8afbf20a708064fc645))
+- **BREAKING CHANGE** Remove visibility of unneeded RemoveDataSource RPC ([commit 553e7b0](https://github.com/googleapis/google-cloud-dotnet/commit/553e7b098875151e4dd7d8afbf20a708064fc645))
+- **BREAKING CHANGE** Remove visibility of unneeded SetInternalStatus RPC ([commit 553e7b0](https://github.com/googleapis/google-cloud-dotnet/commit/553e7b098875151e4dd7d8afbf20a708064fc645))
+
 ## Version 1.2.0, released 2024-09-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -734,7 +734,7 @@
     },
     {
       "id": "Google.Cloud.BackupDR.V1",
-      "version": "1.2.0",
+      "version": "2.0.0",
       "type": "grpc",
       "productName": "Backup and DR Service",
       "productUrl": "https://cloud.google.com/backup-disaster-recovery/docs/concepts/backup-dr",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Remove visibility of unneeded TestIamPermissions RPC ([commit 553e7b0](https://github.com/googleapis/google-cloud-dotnet/commit/553e7b098875151e4dd7d8afbf20a708064fc645))
- **BREAKING CHANGE** Remove visibility of unneeded InitiateBackup RPC ([commit 553e7b0](https://github.com/googleapis/google-cloud-dotnet/commit/553e7b098875151e4dd7d8afbf20a708064fc645))
- **BREAKING CHANGE** Remove visibility of unneeded AbandonBackup RPC ([commit 553e7b0](https://github.com/googleapis/google-cloud-dotnet/commit/553e7b098875151e4dd7d8afbf20a708064fc645))
- **BREAKING CHANGE** Remove visibility of unneeded FinalizeBackup RPC ([commit 553e7b0](https://github.com/googleapis/google-cloud-dotnet/commit/553e7b098875151e4dd7d8afbf20a708064fc645))
- **BREAKING CHANGE** Remove visibility of unneeded RemoveDataSource RPC ([commit 553e7b0](https://github.com/googleapis/google-cloud-dotnet/commit/553e7b098875151e4dd7d8afbf20a708064fc645))
- **BREAKING CHANGE** Remove visibility of unneeded SetInternalStatus RPC ([commit 553e7b0](https://github.com/googleapis/google-cloud-dotnet/commit/553e7b098875151e4dd7d8afbf20a708064fc645))
