### PR TITLE
Release Google.Cloud.Dataproc.V1 version 5.16.0

### DIFF
--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.15.0</Version>
+    <Version>5.16.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataproc API, which manages Hadoop-based clusters and jobs on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Dataproc.V1/docs/history.md
+++ b/apis/Google.Cloud.Dataproc.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 5.16.0, released 2024-10-21
+
+### New features
+
+- Add `ProvisioningModelMix` to support mixing of spot and standard instances for secondary workers ([commit dde1a4f](https://github.com/googleapis/google-cloud-dotnet/commit/dde1a4f656d818f682687266ab7519eb484a0d45))
+- Add support for configuration of bootdisk IOPS and throughput when bootdisk is a hyperdisk ([commit dde1a4f](https://github.com/googleapis/google-cloud-dotnet/commit/dde1a4f656d818f682687266ab7519eb484a0d45))
+
 ## Version 5.15.0, released 2024-09-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1820,7 +1820,7 @@
       "protoPath": "google/cloud/dataproc/v1",
       "productName": "Google Cloud Dataproc",
       "productUrl": "https://cloud.google.com/dataproc/docs/concepts/overview",
-      "version": "5.15.0",
+      "version": "5.16.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Dataproc API, which manages Hadoop-based clusters and jobs on Google Cloud Platform.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Add `ProvisioningModelMix` to support mixing of spot and standard instances for secondary workers ([commit dde1a4f](https://github.com/googleapis/google-cloud-dotnet/commit/dde1a4f656d818f682687266ab7519eb484a0d45))
- Add support for configuration of bootdisk IOPS and throughput when bootdisk is a hyperdisk ([commit dde1a4f](https://github.com/googleapis/google-cloud-dotnet/commit/dde1a4f656d818f682687266ab7519eb484a0d45))
