### PR TITLE
Release Google.Cloud.NetworkManagement.V1 version 2.11.0

### DIFF
--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.csproj
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.10.0</Version>
+    <Version>2.11.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Network Management API, which provides a collection of network performance monitoring and diagnostic capabilities.</Description>
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" VersionOverride="[4.9.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" VersionOverride="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.3.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" VersionOverride="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.NetworkManagement.V1/docs/history.md
+++ b/apis/Google.Cloud.NetworkManagement.V1/docs/history.md
@@ -1,5 +1,25 @@
 # Version history
 
+## Version 2.11.0, released 2024-10-21
+
+### New features
+
+- Add messages and fields related to Redis Instances ([commit 7cef758](https://github.com/googleapis/google-cloud-dotnet/commit/7cef758e38e4dea06b85110575bb6f4e6707be18))
+- Add messages and fields related to Redis Clusters ([commit 7cef758](https://github.com/googleapis/google-cloud-dotnet/commit/7cef758e38e4dea06b85110575bb6f4e6707be18))
+- Add PSC network attachment URI to the InstanceInfo proto ([commit 7cef758](https://github.com/googleapis/google-cloud-dotnet/commit/7cef758e38e4dea06b85110575bb6f4e6707be18))
+- Add subnet URI and region name to the NetworkInfo proto ([commit 7cef758](https://github.com/googleapis/google-cloud-dotnet/commit/7cef758e38e4dea06b85110575bb6f4e6707be18))
+- Add firewall policy URI to the FirewallInfo proto ([commit 7cef758](https://github.com/googleapis/google-cloud-dotnet/commit/7cef758e38e4dea06b85110575bb6f4e6707be18))
+- Add fields related to advertised routes to the RouteInfo proto ([commit 7cef758](https://github.com/googleapis/google-cloud-dotnet/commit/7cef758e38e4dea06b85110575bb6f4e6707be18))
+- Add region name field to the RouteInfo proto ([commit 7cef758](https://github.com/googleapis/google-cloud-dotnet/commit/7cef758e38e4dea06b85110575bb6f4e6707be18))
+- Add region name to the ForwardingRuleInfo proto ([commit 7cef758](https://github.com/googleapis/google-cloud-dotnet/commit/7cef758e38e4dea06b85110575bb6f4e6707be18))
+- Add load balancer name to the ForwardingRuleInfo proto ([commit 7cef758](https://github.com/googleapis/google-cloud-dotnet/commit/7cef758e38e4dea06b85110575bb6f4e6707be18))
+- Add PSC target fields to the ForwardingRuleInfo proto ([commit 7cef758](https://github.com/googleapis/google-cloud-dotnet/commit/7cef758e38e4dea06b85110575bb6f4e6707be18))
+- Add more detailed abort and drop causes to corresponding enums ([commit 7cef758](https://github.com/googleapis/google-cloud-dotnet/commit/7cef758e38e4dea06b85110575bb6f4e6707be18))
+
+### Documentation improvements
+
+- Update outdated comments in the FirewallInfo proto ([commit 7cef758](https://github.com/googleapis/google-cloud-dotnet/commit/7cef758e38e4dea06b85110575bb6f4e6707be18))
+
 ## Version 2.10.0, released 2024-05-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3437,7 +3437,7 @@
     },
     {
       "id": "Google.Cloud.NetworkManagement.V1",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "type": "grpc",
       "productName": "Network Management",
       "productUrl": "https://cloud.google.com/network-intelligence-center/docs/",
@@ -3451,9 +3451,9 @@
         "diagnostics"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.2.0",
-        "Google.Cloud.Location": "2.2.0",
-        "Google.LongRunning": "3.2.0"
+        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Location": "2.3.0",
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/networkmanagement/v1",


### PR DESCRIPTION

Changes in this release:

### New features

- Add messages and fields related to Redis Instances ([commit 7cef758](https://github.com/googleapis/google-cloud-dotnet/commit/7cef758e38e4dea06b85110575bb6f4e6707be18))
- Add messages and fields related to Redis Clusters ([commit 7cef758](https://github.com/googleapis/google-cloud-dotnet/commit/7cef758e38e4dea06b85110575bb6f4e6707be18))
- Add PSC network attachment URI to the InstanceInfo proto ([commit 7cef758](https://github.com/googleapis/google-cloud-dotnet/commit/7cef758e38e4dea06b85110575bb6f4e6707be18))
- Add subnet URI and region name to the NetworkInfo proto ([commit 7cef758](https://github.com/googleapis/google-cloud-dotnet/commit/7cef758e38e4dea06b85110575bb6f4e6707be18))
- Add firewall policy URI to the FirewallInfo proto ([commit 7cef758](https://github.com/googleapis/google-cloud-dotnet/commit/7cef758e38e4dea06b85110575bb6f4e6707be18))
- Add fields related to advertised routes to the RouteInfo proto ([commit 7cef758](https://github.com/googleapis/google-cloud-dotnet/commit/7cef758e38e4dea06b85110575bb6f4e6707be18))
- Add region name field to the RouteInfo proto ([commit 7cef758](https://github.com/googleapis/google-cloud-dotnet/commit/7cef758e38e4dea06b85110575bb6f4e6707be18))
- Add region name to the ForwardingRuleInfo proto ([commit 7cef758](https://github.com/googleapis/google-cloud-dotnet/commit/7cef758e38e4dea06b85110575bb6f4e6707be18))
- Add load balancer name to the ForwardingRuleInfo proto ([commit 7cef758](https://github.com/googleapis/google-cloud-dotnet/commit/7cef758e38e4dea06b85110575bb6f4e6707be18))
- Add PSC target fields to the ForwardingRuleInfo proto ([commit 7cef758](https://github.com/googleapis/google-cloud-dotnet/commit/7cef758e38e4dea06b85110575bb6f4e6707be18))
- Add more detailed abort and drop causes to corresponding enums ([commit 7cef758](https://github.com/googleapis/google-cloud-dotnet/commit/7cef758e38e4dea06b85110575bb6f4e6707be18))

### Documentation improvements

- Update outdated comments in the FirewallInfo proto ([commit 7cef758](https://github.com/googleapis/google-cloud-dotnet/commit/7cef758e38e4dea06b85110575bb6f4e6707be18))
