### PR TITLE
Release Google.Cloud.TextToSpeech.V1Beta1 version 2.0.0-beta10

### DIFF
--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.csproj
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta09</Version>
+    <Version>2.0.0-beta10</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Text-to-Speech API v1beta1, synthesizes natural-sounding speech by applying powerful neural network models.</Description>

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.0.0-beta10, released 2024-10-21
+
+### New features
+
+- Add brand voice lite ([commit 3b4c563](https://github.com/googleapis/google-cloud-dotnet/commit/3b4c563ae7f831f4479bb95f6e841c61f19cb906))
+
 ## Version 2.0.0-beta09, released 2024-10-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5178,7 +5178,7 @@
     },
     {
       "id": "Google.Cloud.TextToSpeech.V1Beta1",
-      "version": "2.0.0-beta09",
+      "version": "2.0.0-beta10",
       "type": "grpc",
       "productName": "Google Cloud Text-to-Speech",
       "productUrl": "https://cloud.google.com/text-to-speech",


### PR DESCRIPTION

Changes in this release:

### New features

- Add brand voice lite ([commit 3b4c563](https://github.com/googleapis/google-cloud-dotnet/commit/3b4c563ae7f831f4479bb95f6e841c61f19cb906))
