### PR TITLE
Release Google.Cloud.PubSub.V1 version 3.19.0

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.18.0</Version>
+    <Version>3.19.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.</Description>

--- a/apis/Google.Cloud.PubSub.V1/docs/history.md
+++ b/apis/Google.Cloud.PubSub.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 3.19.0, released 2024-10-24
+
+### Bug fixes
+
+- Do not throw if a subscriber is disposed before being started ([commit 04b8d8a](https://github.com/googleapis/google-cloud-dotnet/commit/04b8d8abe0da0c5dbd6a6d1ea8a81aa116d1114f))
+
+### New features
+
+- Add IngestionFailureEvent to the external proto ([commit a51bbfd](https://github.com/googleapis/google-cloud-dotnet/commit/a51bbfd7d3c5130b77d0e2a3007e1edb5c27955c))
+- Support connection sharing across gRPC channels ([commit 2e16e74](https://github.com/googleapis/google-cloud-dotnet/commit/2e16e743de7bf60afe462692bdbc444f4dcd9ee8))
+
 ## Version 3.18.0, released 2024-09-26
 
 No API surface changes; just dependency updates.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3984,7 +3984,7 @@
       "protoPath": "google/pubsub/v1",
       "productName": "Cloud Pub/Sub",
       "productUrl": "https://cloud.google.com/pubsub/",
-      "version": "3.18.0",
+      "version": "3.19.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Do not throw if a subscriber is disposed before being started ([commit 04b8d8a](https://github.com/googleapis/google-cloud-dotnet/commit/04b8d8abe0da0c5dbd6a6d1ea8a81aa116d1114f))

### New features

- Add IngestionFailureEvent to the external proto ([commit a51bbfd](https://github.com/googleapis/google-cloud-dotnet/commit/a51bbfd7d3c5130b77d0e2a3007e1edb5c27955c))
- Support connection sharing across gRPC channels ([commit 2e16e74](https://github.com/googleapis/google-cloud-dotnet/commit/2e16e743de7bf60afe462692bdbc444f4dcd9ee8))
