### PR TITLE
docs: Fix broken navigation

### DIFF
--- a/docs/devsite-help/grpc-streaming.md
+++ b/docs/devsite-help/grpc-streaming.md
@@ -21,7 +21,7 @@ Note that this page does not cover client-streaming, as we do not currently
 publish any libraries with client-streaming RPCs. A new section will be added
 if and when we publish such a library.
 
-# Server-streaming RPCs
+## Server-streaming RPCs
 
 A server-streaming RPC starts with a single request, and then the server
 sends responses over time, which are read asynchronously. The server indicates
@@ -53,7 +53,7 @@ as those are API-specific and unrelated to stream usage.
 
 [!code-cs[](../examples/help.Streaming.txt#ServerStreaming)]
 
-# Bidirectional-streaming RPCs
+## Bidirectional-streaming RPCs
 
 A bidirectional-streaming RPC is started without a client-side request, as clients
 can send requests as and when they wish to. Similarly, the server provides a stream

--- a/docs/devsite-help/protobuf.md
+++ b/docs/devsite-help/protobuf.md
@@ -22,7 +22,7 @@ data transfer objects which happen to have well-defined binary and JSON
 formats. The sections below provide more information in areas which have
 previously caused some confusion.
 
-# Repeated fields and map fields
+## Repeated fields and map fields
 
 The generated C# code for protobuf messages makes simple properties
 read/write, but repeated fields and map fields are read-only. That
@@ -93,7 +93,7 @@ Or modify it after other initialization steps:
 
 [!code-cs[](../examples/help.Protobuf.txt#ProtoMap3)]
 
-# JSON parsing and formatting
+## JSON parsing and formatting
 
 Protobuf messages have a JSON format as well as the natural binary wire format.
 The Google.Protobuf library makes it easy to parse JSON into messages using
@@ -112,7 +112,7 @@ Sample parsing code:
 
 [!code-cs[](../examples/help.Protobuf.txt#JsonParsing)]
 
-# Value and Struct
+## Value and Struct
 
 Some APIs use the *well-known types* of `google.protobuf.Value`
 and `google.protobuf.Struct` which are represented by the .NET types


### PR DESCRIPTION
Fixes b/375428438

With the single number symbol these are considered top level titles and are not generated as links nor included on the hand right side navbar.