### PR TITLE
Release Google.Cloud.AIPlatform.V1 version 3.10.0

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.9.0</Version>
+    <Version>3.10.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform API (v1), which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.10.0, released 2024-10-29
+
+### New features
+
+- Add `text` field for Grounding metadata support chunk output ([commit d09eec7](https://github.com/googleapis/google-cloud-dotnet/commit/d09eec728557c8fc8062c7c574367f34e7578b93))
+
 ## Version 3.9.0, released 2024-10-07
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -393,7 +393,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1",
-      "version": "3.9.0",
+      "version": "3.10.0",
       "type": "grpc",
       "productName": "Cloud AI Platform",
       "productUrl": "https://cloud.google.com/ai-platform/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add `text` field for Grounding metadata support chunk output ([commit d09eec7](https://github.com/googleapis/google-cloud-dotnet/commit/d09eec728557c8fc8062c7c574367f34e7578b93))
