### PR TITLE
Release Google.Cloud.ArtifactRegistry.V1 version 2.9.0

### DIFF
--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.csproj
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.8.0</Version>
+    <Version>2.9.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Artifact Registry API v1, which stores and manages build artifacts in a scalable and integrated service built on Google infrastructure.</Description>

--- a/apis/Google.Cloud.ArtifactRegistry.V1/docs/history.md
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/docs/history.md
@@ -1,5 +1,20 @@
 # Version history
 
+## Version 2.9.0, released 2024-10-29
+
+### New features
+
+- Add Artifact Registry attachment API ([commit 04eb4d7](https://github.com/googleapis/google-cloud-dotnet/commit/04eb4d7d1da82e897d63f34b629ccc427ea86e16))
+- Add Artifact Registry custom remote support ([commit 04eb4d7](https://github.com/googleapis/google-cloud-dotnet/commit/04eb4d7d1da82e897d63f34b629ccc427ea86e16))
+- Add Artifact Registry generic repository support ([commit 04eb4d7](https://github.com/googleapis/google-cloud-dotnet/commit/04eb4d7d1da82e897d63f34b629ccc427ea86e16))
+- Add Artifact Registry server side resource filtering and sorting ([commit 04eb4d7](https://github.com/googleapis/google-cloud-dotnet/commit/04eb4d7d1da82e897d63f34b629ccc427ea86e16))
+- Add Artifact Registry rule APIs ([commit 04eb4d7](https://github.com/googleapis/google-cloud-dotnet/commit/04eb4d7d1da82e897d63f34b629ccc427ea86e16))
+- Add Artifact Registry UpdateFile and DeleteFile APIs ([commit 04eb4d7](https://github.com/googleapis/google-cloud-dotnet/commit/04eb4d7d1da82e897d63f34b629ccc427ea86e16))
+
+### Documentation improvements
+
+- Include max page size for all Artifact Registry APIs ([commit 04eb4d7](https://github.com/googleapis/google-cloud-dotnet/commit/04eb4d7d1da82e897d63f34b629ccc427ea86e16))
+
 ## Version 2.8.0, released 2024-06-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -574,7 +574,7 @@
     },
     {
       "id": "Google.Cloud.ArtifactRegistry.V1",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "type": "grpc",
       "productName": "Artifact Registry",
       "productUrl": "https://cloud.google.com/artifact-registry",


### PR DESCRIPTION

Changes in this release:

### New features

- Add Artifact Registry attachment API ([commit 04eb4d7](https://github.com/googleapis/google-cloud-dotnet/commit/04eb4d7d1da82e897d63f34b629ccc427ea86e16))
- Add Artifact Registry custom remote support ([commit 04eb4d7](https://github.com/googleapis/google-cloud-dotnet/commit/04eb4d7d1da82e897d63f34b629ccc427ea86e16))
- Add Artifact Registry generic repository support ([commit 04eb4d7](https://github.com/googleapis/google-cloud-dotnet/commit/04eb4d7d1da82e897d63f34b629ccc427ea86e16))
- Add Artifact Registry server side resource filtering and sorting ([commit 04eb4d7](https://github.com/googleapis/google-cloud-dotnet/commit/04eb4d7d1da82e897d63f34b629ccc427ea86e16))
- Add Artifact Registry rule APIs ([commit 04eb4d7](https://github.com/googleapis/google-cloud-dotnet/commit/04eb4d7d1da82e897d63f34b629ccc427ea86e16))
- Add Artifact Registry UpdateFile and DeleteFile APIs ([commit 04eb4d7](https://github.com/googleapis/google-cloud-dotnet/commit/04eb4d7d1da82e897d63f34b629ccc427ea86e16))

### Documentation improvements

- Include max page size for all Artifact Registry APIs ([commit 04eb4d7](https://github.com/googleapis/google-cloud-dotnet/commit/04eb4d7d1da82e897d63f34b629ccc427ea86e16))
