### PR TITLE
Release Google.Cloud.Bigtable.V2 version 3.15.0

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.14.0</Version>
+    <Version>3.15.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Bigtable API.</Description>

--- a/apis/Google.Cloud.Bigtable.V2/docs/history.md
+++ b/apis/Google.Cloud.Bigtable.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.15.0, released 2024-10-29
+
+### New features
+
+- Add feature flags proto for Direct Access ([commit 70094ae](https://github.com/googleapis/google-cloud-dotnet/commit/70094aea955279d55e675a50ee723b76ff65e4c8))
+
 ## Version 3.14.0, released 2024-07-22
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1181,7 +1181,7 @@
       "protoPath": "google/bigtable/v2",
       "productName": "Google Bigtable",
       "productUrl": "https://cloud.google.com/bigtable/",
-      "version": "3.14.0",
+      "version": "3.15.0",
       "commonResourcesConfig": "apis/Google.Cloud.Bigtable.Common.V2/CommonResourcesConfig.json",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",


### PR DESCRIPTION

Changes in this release:

### New features

- Add feature flags proto for Direct Access ([commit 70094ae](https://github.com/googleapis/google-cloud-dotnet/commit/70094aea955279d55e675a50ee723b76ff65e4c8))
