### PR TITLE
Release Google.Cloud.CloudBuild.V1 version 2.13.0

### DIFF
--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.csproj
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.12.0</Version>
+    <Version>2.13.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Build API v1, which creates and manages builds on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.CloudBuild.V1/docs/history.md
+++ b/apis/Google.Cloud.CloudBuild.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.13.0, released 2024-10-29
+
+### New features
+
+- Add PrivateServiceConnect option to WorkerPool ([commit 59748e6](https://github.com/googleapis/google-cloud-dotnet/commit/59748e60fa58d45650d8f63981db904478308272))
+
 ## Version 2.12.0, released 2024-09-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1359,7 +1359,7 @@
     },
     {
       "id": "Google.Cloud.CloudBuild.V1",
-      "version": "2.12.0",
+      "version": "2.13.0",
       "type": "grpc",
       "productName": "Cloud Build",
       "productUrl": "https://cloud.google.com/cloud-build",


### PR DESCRIPTION

Changes in this release:

### New features

- Add PrivateServiceConnect option to WorkerPool ([commit 59748e6](https://github.com/googleapis/google-cloud-dotnet/commit/59748e60fa58d45650d8f63981db904478308272))
