### PR TITLE
Release Google.Cloud.Deploy.V1 version 3.2.0

### DIFF
--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Deploy API, which automates delivery of your applications to a series of target environments in a defined sequence.</Description>

--- a/apis/Google.Cloud.Deploy.V1/docs/history.md
+++ b/apis/Google.Cloud.Deploy.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 3.2.0, released 2024-10-29
+
+### New features
+
+- Added new fields for the Automation Repair rule ([commit 803ebaa](https://github.com/googleapis/google-cloud-dotnet/commit/803ebaa5bfee8895cd987ec69dcaf0827923198a))
+- Added route destination related fields to Gateway service mesh message ([commit 803ebaa](https://github.com/googleapis/google-cloud-dotnet/commit/803ebaa5bfee8895cd987ec69dcaf0827923198a))
+
 ## Version 3.1.0, released 2024-09-30
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1934,7 +1934,7 @@
     },
     {
       "id": "Google.Cloud.Deploy.V1",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "type": "grpc",
       "productName": "Google Cloud Deploy",
       "productUrl": "https://cloud.google.com/deploy/",


### PR DESCRIPTION

Changes in this release:

### New features

- Added new fields for the Automation Repair rule ([commit 803ebaa](https://github.com/googleapis/google-cloud-dotnet/commit/803ebaa5bfee8895cd987ec69dcaf0827923198a))
- Added route destination related fields to Gateway service mesh message ([commit 803ebaa](https://github.com/googleapis/google-cloud-dotnet/commit/803ebaa5bfee8895cd987ec69dcaf0827923198a))
