### PR TITLE
Release Google.Cloud.Eventarc.V1 version 2.6.0

### DIFF
--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.csproj
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Eventarc API</Description>
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" VersionOverride="[4.9.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" VersionOverride="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.3.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" VersionOverride="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Eventarc.V1/docs/history.md
+++ b/apis/Google.Cloud.Eventarc.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.6.0, released 2024-10-29
+
+### New features
+
+- Publish Eventarc Advanced protos ([commit 5bb7fc6](https://github.com/googleapis/google-cloud-dotnet/commit/5bb7fc6b056a33c2d61a1104d231701f288369d2))
+
+### Documentation improvements
+
+- Clarified multiple comments in Eventarc Standard protos ([commit 5bb7fc6](https://github.com/googleapis/google-cloud-dotnet/commit/5bb7fc6b056a33c2d61a1104d231701f288369d2))
+
 ## Version 2.5.0, released 2024-05-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2415,7 +2415,7 @@
     },
     {
       "id": "Google.Cloud.Eventarc.V1",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "type": "grpc",
       "productName": "Eventarc",
       "productUrl": "https://cloud.google.com/eventarc/docs",
@@ -2425,9 +2425,9 @@
         "cloudevents"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.2.0",
-        "Google.Cloud.Location": "2.2.0",
-        "Google.LongRunning": "3.2.0"
+        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Location": "2.3.0",
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/eventarc/v1",


### PR DESCRIPTION

Changes in this release:

### New features

- Publish Eventarc Advanced protos ([commit 5bb7fc6](https://github.com/googleapis/google-cloud-dotnet/commit/5bb7fc6b056a33c2d61a1104d231701f288369d2))

### Documentation improvements

- Clarified multiple comments in Eventarc Standard protos ([commit 5bb7fc6](https://github.com/googleapis/google-cloud-dotnet/commit/5bb7fc6b056a33c2d61a1104d231701f288369d2))
