### PR TITLE
Release Google.Cloud.GdcHardwareManagement.V1Alpha version 1.0.0-alpha03

### DIFF
--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.csproj
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha02</Version>
+    <Version>1.0.0-alpha03</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Distributed Cloud Hardware Management API (v1alpha)</Description>

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 1.0.0-alpha03, released 2024-10-29
+
+### New features
+
+- Add a DeleteSite method ([commit 546e30b](https://github.com/googleapis/google-cloud-dotnet/commit/546e30b7a257eea06f08b9abcadd62117ad6d304))
+- Add MAC address and disk info to the Hardware resource ([commit 546e30b](https://github.com/googleapis/google-cloud-dotnet/commit/546e30b7a257eea06f08b9abcadd62117ad6d304))
+
+### Documentation improvements
+
+- Annotate rack_location field as required; this was always enforced ([commit 546e30b](https://github.com/googleapis/google-cloud-dotnet/commit/546e30b7a257eea06f08b9abcadd62117ad6d304))
+
 ## Version 1.0.0-alpha02, released 2024-09-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2630,7 +2630,7 @@
     },
     {
       "id": "Google.Cloud.GdcHardwareManagement.V1Alpha",
-      "version": "1.0.0-alpha02",
+      "version": "1.0.0-alpha03",
       "type": "grpc",
       "productName": "GDC Hardware Management",
       "productUrl": "https://cloud.google.com/distributed-cloud/edge/latest/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add a DeleteSite method ([commit 546e30b](https://github.com/googleapis/google-cloud-dotnet/commit/546e30b7a257eea06f08b9abcadd62117ad6d304))
- Add MAC address and disk info to the Hardware resource ([commit 546e30b](https://github.com/googleapis/google-cloud-dotnet/commit/546e30b7a257eea06f08b9abcadd62117ad6d304))

### Documentation improvements

- Annotate rack_location field as required; this was always enforced ([commit 546e30b](https://github.com/googleapis/google-cloud-dotnet/commit/546e30b7a257eea06f08b9abcadd62117ad6d304))
