### PR TITLE
Release Google.Cloud.TextToSpeech.V1 version 3.9.0

### DIFF
--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.csproj
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.8.0</Version>
+    <Version>3.9.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Text-to-Speech API v1, synthesizes natural-sounding speech by applying powerful neural network models.</Description>

--- a/apis/Google.Cloud.TextToSpeech.V1/docs/history.md
+++ b/apis/Google.Cloud.TextToSpeech.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 3.9.0, released 2024-10-29
+
+### New features
+
+- Add multi-speaker markup, which allows generating dialogue between multiple speakers ([commit 94c353c](https://github.com/googleapis/google-cloud-dotnet/commit/94c353c51b23301309aacbcf055b147a085612e8))
+- Add brand voice lite, which lets you clone a voice with just 10 seconds of audio ([commit 6635e62](https://github.com/googleapis/google-cloud-dotnet/commit/6635e6209450b1005ca0c15495c0724c90a955a5))
+
 ## Version 3.8.0, released 2024-10-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5183,7 +5183,7 @@
       "protoPath": "google/cloud/texttospeech/v1",
       "productName": "Google Cloud Text-to-Speech",
       "productUrl": "https://cloud.google.com/text-to-speech",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Text-to-Speech API v1, synthesizes natural-sounding speech by applying powerful neural network models.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add multi-speaker markup, which allows generating dialogue between multiple speakers ([commit 94c353c](https://github.com/googleapis/google-cloud-dotnet/commit/94c353c51b23301309aacbcf055b147a085612e8))
- Add brand voice lite, which lets you clone a voice with just 10 seconds of audio ([commit 6635e62](https://github.com/googleapis/google-cloud-dotnet/commit/6635e6209450b1005ca0c15495c0724c90a955a5))
