### PR TITLE
Release Google.Cloud.TextToSpeech.V1Beta1 version 2.0.0-beta11

### DIFF
--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.csproj
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta10</Version>
+    <Version>2.0.0-beta11</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Text-to-Speech API v1beta1, synthesizes natural-sounding speech by applying powerful neural network models.</Description>

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.0.0-beta11, released 2024-10-29
+
+### New features
+
+- Add multi-speaker markup, which allows generating dialogue between multiple speakers ([commit 9c3527e](https://github.com/googleapis/google-cloud-dotnet/commit/9c3527ec81408e73c6f3542b9e9dfeb18c3675b0))
+
 ## Version 2.0.0-beta10, released 2024-10-21
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5201,7 +5201,7 @@
     },
     {
       "id": "Google.Cloud.TextToSpeech.V1Beta1",
-      "version": "2.0.0-beta10",
+      "version": "2.0.0-beta11",
       "type": "grpc",
       "productName": "Google Cloud Text-to-Speech",
       "productUrl": "https://cloud.google.com/text-to-speech",


### PR DESCRIPTION

Changes in this release:

### New features

- Add multi-speaker markup, which allows generating dialogue between multiple speakers ([commit 9c3527e](https://github.com/googleapis/google-cloud-dotnet/commit/9c3527ec81408e73c6f3542b9e9dfeb18c3675b0))
