### PR TITLE
Release Google.Shopping.Css.V1 version 1.0.0-beta05

### DIFF
--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/Google.Shopping.Css.V1.csproj
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/Google.Shopping.Css.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta04</Version>
+    <Version>1.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Shopping CSS API, which allows you to programmatically manage your Comparison Shopping Service (CSS) account data at scale.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" VersionOverride="[4.9.0, 5.0.0)" />
-    <PackageReference Include="Google.Shopping.Type" VersionOverride="[1.0.0-beta05, 2.0.0)" />
+    <PackageReference Include="Google.Shopping.Type" VersionOverride="[1.0.0-beta06, 2.0.0)" />
     <PackageReference Include="Grpc.Core" VersionOverride="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Shopping.Css.V1/docs/history.md
+++ b/apis/Google.Shopping.Css.V1/docs/history.md
@@ -1,5 +1,20 @@
 # Version history
 
+## Version 1.0.0-beta05, released 2024-10-29
+
+### New features
+
+- A new field `headline_offer_installment` is added to message `.google.shopping.css.v1.Attributes` ([commit 24d5896](https://github.com/googleapis/google-cloud-dotnet/commit/24d5896684e471248ecbdf09b29409260e1fba49))
+- A new field `headline_offer_subscription_cost` is added to message `.google.shopping.css.v1.Attributes` ([commit 24d5896](https://github.com/googleapis/google-cloud-dotnet/commit/24d5896684e471248ecbdf09b29409260e1fba49))
+- A new message `HeadlineOfferSubscriptionCost` is added ([commit 24d5896](https://github.com/googleapis/google-cloud-dotnet/commit/24d5896684e471248ecbdf09b29409260e1fba49))
+- A new message `HeadlineOfferInstallment` is added ([commit 24d5896](https://github.com/googleapis/google-cloud-dotnet/commit/24d5896684e471248ecbdf09b29409260e1fba49))
+- A new enum `SubscriptionPeriod` is added ([commit 24d5896](https://github.com/googleapis/google-cloud-dotnet/commit/24d5896684e471248ecbdf09b29409260e1fba49))
+
+### Documentation improvements
+
+- Update `Certification` field descriptions ([commit d53568a](https://github.com/googleapis/google-cloud-dotnet/commit/d53568a61cd098cd82443a9063263a51e8a94f80))
+- Remove "in Google Shopping" from documentation comments ([commit ed8f693](https://github.com/googleapis/google-cloud-dotnet/commit/ed8f6939daaf50f6cffc8e911c7d03440da5a570))
+
 ## Version 1.0.0-beta04, released 2024-05-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5991,7 +5991,7 @@
     },
     {
       "id": "Google.Shopping.Css.V1",
-      "version": "1.0.0-beta04",
+      "version": "1.0.0-beta05",
       "type": "grpc",
       "productName": "CSS",
       "productUrl": "https://developers.google.com/comparison-shopping-services/api",
@@ -6001,7 +6001,7 @@
         "comparison"
       ],
       "dependencies": {
-        "Google.Shopping.Type": "1.0.0-beta05"
+        "Google.Shopping.Type": "1.0.0-beta06"
       },
       "generator": "micro",
       "protoPath": "google/shopping/css/v1",


### PR DESCRIPTION

Changes in this release:

### New features

- A new field `headline_offer_installment` is added to message `.google.shopping.css.v1.Attributes` ([commit 24d5896](https://github.com/googleapis/google-cloud-dotnet/commit/24d5896684e471248ecbdf09b29409260e1fba49))
- A new field `headline_offer_subscription_cost` is added to message `.google.shopping.css.v1.Attributes` ([commit 24d5896](https://github.com/googleapis/google-cloud-dotnet/commit/24d5896684e471248ecbdf09b29409260e1fba49))
- A new message `HeadlineOfferSubscriptionCost` is added ([commit 24d5896](https://github.com/googleapis/google-cloud-dotnet/commit/24d5896684e471248ecbdf09b29409260e1fba49))
- A new message `HeadlineOfferInstallment` is added ([commit 24d5896](https://github.com/googleapis/google-cloud-dotnet/commit/24d5896684e471248ecbdf09b29409260e1fba49))
- A new enum `SubscriptionPeriod` is added ([commit 24d5896](https://github.com/googleapis/google-cloud-dotnet/commit/24d5896684e471248ecbdf09b29409260e1fba49))

### Documentation improvements

- Update `Certification` field descriptions ([commit d53568a](https://github.com/googleapis/google-cloud-dotnet/commit/d53568a61cd098cd82443a9063263a51e8a94f80))
- Remove "in Google Shopping" from documentation comments ([commit ed8f693](https://github.com/googleapis/google-cloud-dotnet/commit/ed8f6939daaf50f6cffc8e911c7d03440da5a570))
