### PR TITLE
Release Google.Cloud.AIPlatform.V1Beta1 version 1.0.0-beta09

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta08</Version>
+    <Version>1.0.0-beta09</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform API (v1beta), which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta09, released 2024-10-30
+
+### New features
+
+- Add UpdateEndpointLongRunning API in v1beta1 version ([commit 42c90e3](https://github.com/googleapis/google-cloud-dotnet/commit/42c90e3a092a9757a6e1af1a44d9f049bb580c86))
+
 ## Version 1.0.0-beta08, released 2024-10-29
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -370,7 +370,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1Beta1",
-      "version": "1.0.0-beta08",
+      "version": "1.0.0-beta09",
       "type": "grpc",
       "productName": "Cloud AI Platform",
       "productUrl": "https://cloud.google.com/ai-platform/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add UpdateEndpointLongRunning API in v1beta1 version ([commit 42c90e3](https://github.com/googleapis/google-cloud-dotnet/commit/42c90e3a092a9757a6e1af1a44d9f049bb580c86))
