### PR TITLE
Release Google.Cloud.Eventarc.Publishing.V1 version 2.0.0-beta07

### DIFF
--- a/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.csproj
+++ b/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta06</Version>
+    <Version>2.0.0-beta07</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Eventarc Publishing API</Description>

--- a/apis/Google.Cloud.Eventarc.Publishing.V1/docs/history.md
+++ b/apis/Google.Cloud.Eventarc.Publishing.V1/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+## Version 2.0.0-beta07, released 2024-10-30
+
+### New features
+
+- Add Eventarc Advanced Publishing features, allowing publishing events to a Message Bus ([commit 60f4d3e](https://github.com/googleapis/google-cloud-dotnet/commit/60f4d3efe7d79ccd6d66e1c04be6a95a3aa12a38))
 ## Version 2.0.0-beta06, released 2024-05-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2395,7 +2395,7 @@
     },
     {
       "id": "Google.Cloud.Eventarc.Publishing.V1",
-      "version": "2.0.0-beta06",
+      "version": "2.0.0-beta07",
       "type": "grpc",
       "productName": "Eventarc Publishing",
       "productUrl": "https://cloud.google.com/eventarc/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add Eventarc Advanced Publishing features, allowing publishing events to a Message Bus ([commit 60f4d3e](https://github.com/googleapis/google-cloud-dotnet/commit/60f4d3efe7d79ccd6d66e1c04be6a95a3aa12a38))
