### PR TITLE
Release Spanner libraries version 5.0.0-beta05

### DIFF
--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.0.0-beta04</Version>
+    <Version>5.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Spanner Database Admin API.</Description>

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.0.0-beta04</Version>
+    <Version>5.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Spanner Instance Admin API.</Description>

--- a/apis/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.0.0-beta04</Version>
+    <Version>5.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Common resource names used by all Spanner V1 APIs</Description>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.0.0-beta04</Version>
+    <Version>5.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google ADO.NET Provider for Google Cloud Spanner.</Description>

--- a/apis/Google.Cloud.Spanner.Data/docs/history.md
+++ b/apis/Google.Cloud.Spanner.Data/docs/history.md
@@ -1,5 +1,20 @@
 # Version history
 
+## Version 5.0.0-beta05, released 2024-11-07
+
+### New features
+
+- Add support for Cloud Spanner Default Backup Schedules ([commit a456d8c](https://github.com/googleapis/google-cloud-dotnet/commit/a456d8cb3888c61360e3361bec4568c95807e312))
+- Define ReplicaComputeCapacity and AsymmetricAutoscalingOption ([commit 905160d](https://github.com/googleapis/google-cloud-dotnet/commit/905160d71ca8d4eeaabd5373ec2600efcd64a108))
+- Add new QueryMode enum values (WITH_STATS, WITH_PLAN_AND_STATS) ([commit 16d3bbb](https://github.com/googleapis/google-cloud-dotnet/commit/16d3bbbdce35809697b8e47338cbd3369b5f8865))
+- Add INTERVAL API ([commit 9f9efe6](https://github.com/googleapis/google-cloud-dotnet/commit/9f9efe6dc4ff1ec59ac506585e26c0a40ce75552))
+
+### Documentation improvements
+
+- A comment for field `node_count` in message `spanner.admin.instance.v1.Instance` is changed ([commit 905160d](https://github.com/googleapis/google-cloud-dotnet/commit/905160d71ca8d4eeaabd5373ec2600efcd64a108))
+- A comment for field `processing_units` in message `spanner.admin.instance.v1.Instance` is changed ([commit 905160d](https://github.com/googleapis/google-cloud-dotnet/commit/905160d71ca8d4eeaabd5373ec2600efcd64a108))
+- Update comment for PROFILE QueryMode ([commit 16d3bbb](https://github.com/googleapis/google-cloud-dotnet/commit/16d3bbbdce35809697b8e47338cbd3369b5f8865))
+
 ## Version 5.0.0-beta04, released 2024-08-13
 
 ### Bug fixes

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.csproj
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.0.0-beta04</Version>
+    <Version>5.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Low-level Google client library to access the Google Cloud Spanner API. The ADO.NET provider (Google.Cloud.Spanner.Data) which depends on this package is generally preferred for Spanner access.</Description>

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4746,7 +4746,7 @@
       "protoPath": "google/spanner/admin/database/v1",
       "productName": "Google Cloud Spanner Database Administration",
       "productUrl": "https://cloud.google.com/spanner/",
-      "version": "5.0.0-beta04",
+      "version": "5.0.0-beta05",
       "commonResourcesConfig": "apis/Google.Cloud.Spanner.Common.V1/CommonResourcesConfig.json",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Spanner Database Admin API.",
@@ -4771,7 +4771,7 @@
       "protoPath": "google/spanner/admin/instance/v1",
       "productName": "Google Cloud Spanner Instance Administration",
       "productUrl": "https://cloud.google.com/spanner/",
-      "version": "5.0.0-beta04",
+      "version": "5.0.0-beta05",
       "commonResourcesConfig": "apis/Google.Cloud.Spanner.Common.V1/CommonResourcesConfig.json",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Spanner Instance Admin API.",
@@ -4793,7 +4793,7 @@
     {
       "id": "Google.Cloud.Spanner.Data",
       "targetFrameworks": "netstandard2.1;net462",
-      "version": "5.0.0-beta04",
+      "version": "5.0.0-beta05",
       "type": "other",
       "metadataType": "INTEGRATION",
       "description": "Google ADO.NET Provider for Google Cloud Spanner.",
@@ -4822,7 +4822,7 @@
     {
       "id": "Google.Cloud.Spanner.Common.V1",
       "type": "other",
-      "version": "5.0.0-beta04",
+      "version": "5.0.0-beta05",
       "description": "Common resource names used by all Spanner V1 APIs",
       "tags": [
         "Spanner"
@@ -4838,7 +4838,7 @@
       "protoPath": "google/spanner/v1",
       "productName": "Google Cloud Spanner",
       "productUrl": "https://cloud.google.com/spanner/",
-      "version": "5.0.0-beta04",
+      "version": "5.0.0-beta05",
       "commonResourcesConfig": "apis/Google.Cloud.Spanner.Common.V1/CommonResourcesConfig.json",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",


### PR DESCRIPTION

Changes in Google.Cloud.Spanner.Data version 5.0.0-beta05:

### New features

- Add support for Cloud Spanner Default Backup Schedules ([commit a456d8c](https://github.com/googleapis/google-cloud-dotnet/commit/a456d8cb3888c61360e3361bec4568c95807e312))
- Define ReplicaComputeCapacity and AsymmetricAutoscalingOption ([commit 905160d](https://github.com/googleapis/google-cloud-dotnet/commit/905160d71ca8d4eeaabd5373ec2600efcd64a108))
- Add new QueryMode enum values (WITH_STATS, WITH_PLAN_AND_STATS) ([commit 16d3bbb](https://github.com/googleapis/google-cloud-dotnet/commit/16d3bbbdce35809697b8e47338cbd3369b5f8865))
- Add INTERVAL API ([commit 9f9efe6](https://github.com/googleapis/google-cloud-dotnet/commit/9f9efe6dc4ff1ec59ac506585e26c0a40ce75552))

### Documentation improvements

- A comment for field `node_count` in message `spanner.admin.instance.v1.Instance` is changed ([commit 905160d](https://github.com/googleapis/google-cloud-dotnet/commit/905160d71ca8d4eeaabd5373ec2600efcd64a108))
- A comment for field `processing_units` in message `spanner.admin.instance.v1.Instance` is changed ([commit 905160d](https://github.com/googleapis/google-cloud-dotnet/commit/905160d71ca8d4eeaabd5373ec2600efcd64a108))
- Update comment for PROFILE QueryMode ([commit 16d3bbb](https://github.com/googleapis/google-cloud-dotnet/commit/16d3bbbdce35809697b8e47338cbd3369b5f8865))

Packages in this release:
- Release Google.Cloud.Spanner.Admin.Database.V1 version 5.0.0-beta05
- Release Google.Cloud.Spanner.Admin.Instance.V1 version 5.0.0-beta05
- Release Google.Cloud.Spanner.Common.V1 version 5.0.0-beta05
- Release Google.Cloud.Spanner.Data version 5.0.0-beta05
- Release Google.Cloud.Spanner.V1 version 5.0.0-beta05
