### PR TITLE
Release Google.Cloud.Compute.V1 version 3.0.0

### DIFF
--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.17.0</Version>
+    <Version>3.0.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Compute Engine API.</Description>

--- a/apis/Google.Cloud.Compute.V1/docs/history.md
+++ b/apis/Google.Cloud.Compute.V1/docs/history.md
@@ -1,5 +1,21 @@
 # Version history
 
+## Version 3.0.0, released 2024-11-07
+
+### New features
+
+- Update Compute Engine API to revision 20241015 ([commit dd73c65](https://github.com/googleapis/google-cloud-dotnet/commit/dd73c65b8bb7aa8a5927b5e5f7bb8d5e8372f881))
+
+### Breaking changes
+
+This release removes some IAM-related client library types. These
+already had no effect on the service, but due to the wide-ranging
+nature of the removal, it's *possible* that customers may have been
+relying on the types. We do not expect these types to reappear in
+the library; if this removal breaks your code, please check
+carefully for what you expected it to do, and raise an issue in
+GitHub if you have concerns.
+
 ## Version 2.17.0, released 2024-07-25
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1520,7 +1520,7 @@
     },
     {
       "id": "Google.Cloud.Compute.V1",
-      "version": "2.17.0",
+      "version": "3.0.0",
       "type": "regapic",
       "productName": "Compute Engine",
       "productUrl": "https://cloud.google.com/compute",


### PR DESCRIPTION

Changes in this release:

### New features

- Update Compute Engine API to revision 20241015 ([commit dd73c65](https://github.com/googleapis/google-cloud-dotnet/commit/dd73c65b8bb7aa8a5927b5e5f7bb8d5e8372f881))

### Breaking changes

This release removes some IAM-related client library types. These already had no effect on the service, but due to the wide-ranging nature of the removal, it's *possible* that customers may have been relying on the types. We do not expect these types to reappear in the library; if this removal breaks your code, please check carefully for what you expected it to do, and raise an issue in GitHub if you have concerns.
