### PR TITLE
Release Google.Cloud.AlloyDb.V1Alpha version 1.0.0-alpha10

### DIFF
--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.csproj
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha09</Version>
+    <Version>1.0.0-alpha10</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AlloyDB API (v1alpha). AlloyDB for PostgreSQL is an open source-compatible database service that provides a powerful option for migrating, modernizing, or building commercial-grade applications.</Description>

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/docs/history.md
@@ -1,5 +1,30 @@
 # Version history
 
+## Version 1.0.0-alpha10, released 2024-11-18
+
+### Bug fixes
+
+- **BREAKING CHANGE** Deprecated various PSC instance configuration fields ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))
+
+### New features
+
+- Add new PSC instance configuration setting and output the PSC DNS name ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))
+- Add new API to upgrade a cluster ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))
+- Add new API to execute SQL statements ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))
+- Add new cluster and instance level configurations to interact with Gemini ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))
+- Add support for Free Trials ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))
+- Add support to schedule maintenance ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))
+- Additional field to set tags on a backup or cluster ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))
+- Add more observability options on the Instance level ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))
+- Add new API to perform a promotion or switchover on secondary instances ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))
+- Add new CloudSQL backup resource ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))
+- Support for obtaining the public ip addresses of an instance and enabling outbound public ip ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))
+- Add optional field to keep extra roles on a user if it already exists ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))
+
+### Documentation improvements
+
+- Various typo fixes, correcting the formatting, and clarifications on the request_id and validate_only fields in API requests and on the page_size when listing the database ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))
+
 ## Version 1.0.0-alpha09, released 2024-06-04
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -300,7 +300,7 @@
     },
     {
       "id": "Google.Cloud.AlloyDb.V1Alpha",
-      "version": "1.0.0-alpha09",
+      "version": "1.0.0-alpha10",
       "type": "grpc",
       "productName": "AlloyDB",
       "productUrl": "https://cloud.google.com/alloydb/docs",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Deprecated various PSC instance configuration fields ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))

### New features

- Add new PSC instance configuration setting and output the PSC DNS name ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))
- Add new API to upgrade a cluster ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))
- Add new API to execute SQL statements ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))
- Add new cluster and instance level configurations to interact with Gemini ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))
- Add support for Free Trials ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))
- Add support to schedule maintenance ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))
- Additional field to set tags on a backup or cluster ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))
- Add more observability options on the Instance level ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))
- Add new API to perform a promotion or switchover on secondary instances ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))
- Add new CloudSQL backup resource ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))
- Support for obtaining the public ip addresses of an instance and enabling outbound public ip ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))
- Add optional field to keep extra roles on a user if it already exists ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))

### Documentation improvements

- Various typo fixes, correcting the formatting, and clarifications on the request_id and validate_only fields in API requests and on the page_size when listing the database ([commit dcf6b0d](https://github.com/googleapis/google-cloud-dotnet/commit/dcf6b0d4a8d7fcf440e0e44c84d5d4bed8a26d1f))
