### PR TITLE
Release Google.Cloud.AlloyDb.V1Beta version 1.0.0-beta09

### DIFF
--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.csproj
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta08</Version>
+    <Version>1.0.0-beta09</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AlloyDB API (v1beta). AlloyDB for PostgreSQL is an open source-compatible database service that provides a powerful option for migrating, modernizing, or building commercial-grade applications.</Description>

--- a/apis/Google.Cloud.AlloyDb.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/docs/history.md
@@ -1,5 +1,30 @@
 # Version history
 
+## Version 1.0.0-beta09, released 2024-11-18
+
+### Bug fixes
+
+- **BREAKING CHANGE** Deprecated various PSC instance configuration fields ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))
+
+### New features
+
+- Add new PSC instance configuration setting and output the PSC DNS name ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))
+- Add new API to upgrade a cluster ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))
+- Add new API to execute SQL statements ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))
+- Add new cluster and instance level configurations to interact with Gemini ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))
+- Add support for Free Trials ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))
+- Add support to schedule maintenance ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))
+- Additional field to set tags on a backup or cluster ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))
+- Add more observability options on the Instance level ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))
+- Add new API to perform a promotion or switchover on secondary instances ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))
+- Add new CloudSQL backup resource ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))
+- Support for obtaining the public ip addresses of an instance and enabling outbound public ip ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))
+- Add optional field to keep extra roles on a user if it already exists ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))
+
+### Documentation improvements
+
+- Various typo fixes, correcting the formatting, and clarifications on the request_id and validate_only fields in API requests and on the page_size when listing the database ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))
+
 ## Version 1.0.0-beta08, released 2024-09-09
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -324,7 +324,7 @@
     },
     {
       "id": "Google.Cloud.AlloyDb.V1Beta",
-      "version": "1.0.0-beta08",
+      "version": "1.0.0-beta09",
       "type": "grpc",
       "productName": "AlloyDB",
       "productUrl": "https://cloud.google.com/alloydb/docs",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Deprecated various PSC instance configuration fields ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))

### New features

- Add new PSC instance configuration setting and output the PSC DNS name ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))
- Add new API to upgrade a cluster ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))
- Add new API to execute SQL statements ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))
- Add new cluster and instance level configurations to interact with Gemini ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))
- Add support for Free Trials ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))
- Add support to schedule maintenance ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))
- Additional field to set tags on a backup or cluster ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))
- Add more observability options on the Instance level ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))
- Add new API to perform a promotion or switchover on secondary instances ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))
- Add new CloudSQL backup resource ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))
- Support for obtaining the public ip addresses of an instance and enabling outbound public ip ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))
- Add optional field to keep extra roles on a user if it already exists ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))

### Documentation improvements

- Various typo fixes, correcting the formatting, and clarifications on the request_id and validate_only fields in API requests and on the page_size when listing the database ([commit 8af4d47](https://github.com/googleapis/google-cloud-dotnet/commit/8af4d47005f38b2859c35889e4c4066d5f3546ef))
