### PR TITLE
Release Google.Cloud.CloudQuotas.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.csproj
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Quotas API, which provides GCP service consumers with management and observability for resource usage, quotas, and restrictions of the services they consume.</Description>

--- a/apis/Google.Cloud.CloudQuotas.V1/docs/history.md
+++ b/apis/Google.Cloud.CloudQuotas.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 1.1.0, released 2024-11-18
+
+### New features
+
+- A new value `NOT_SUPPORTED` is added to enum `IneligibilityReason` ([commit 84c20bc](https://github.com/googleapis/google-cloud-dotnet/commit/84c20bc934998a46adec407c26d58734391cf8d0))
+- A new value `NOT_ENOUGH_USAGE_HISTORY` is added to enum `IneligibilityReason` ([commit 84c20bc](https://github.com/googleapis/google-cloud-dotnet/commit/84c20bc934998a46adec407c26d58734391cf8d0))
+
 ## Version 1.0.0, released 2024-05-24
 
 No API surface changes; just dependency updates and promotion to GA.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1468,7 +1468,7 @@
     },
     {
       "id": "Google.Cloud.CloudQuotas.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Cloud Quotas",
       "productUrl": "https://cloud.google.com/docs/quotas/api-overview",


### PR DESCRIPTION

Changes in this release:

### New features

- A new value `NOT_SUPPORTED` is added to enum `IneligibilityReason` ([commit 84c20bc](https://github.com/googleapis/google-cloud-dotnet/commit/84c20bc934998a46adec407c26d58734391cf8d0))
- A new value `NOT_ENOUGH_USAGE_HISTORY` is added to enum `IneligibilityReason` ([commit 84c20bc](https://github.com/googleapis/google-cloud-dotnet/commit/84c20bc934998a46adec407c26d58734391cf8d0))
