### PR TITLE
Release Google.Cloud.Compute.V1 version 3.1.0

### DIFF
--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Compute Engine API.</Description>

--- a/apis/Google.Cloud.Compute.V1/docs/history.md
+++ b/apis/Google.Cloud.Compute.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.1.0, released 2024-11-18
+
+### New features
+
+- Update Compute Engine API to revision 20241105 ([issue 954](https://github.com/googleapis/google-cloud-dotnet/issues/954)) ([commit 8577e3f](https://github.com/googleapis/google-cloud-dotnet/commit/8577e3fd9f22769db8d740a44efc03dbc07689d8))
+
 ## Version 3.0.0, released 2024-11-07
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1520,7 +1520,7 @@
     },
     {
       "id": "Google.Cloud.Compute.V1",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "type": "regapic",
       "productName": "Compute Engine",
       "productUrl": "https://cloud.google.com/compute",


### PR DESCRIPTION

Changes in this release:

### New features

- Update Compute Engine API to revision 20241105 ([issue 954](https://github.com/googleapis/google-cloud-dotnet/issues/954)) ([commit 8577e3f](https://github.com/googleapis/google-cloud-dotnet/commit/8577e3fd9f22769db8d740a44efc03dbc07689d8))
