### PR TITLE
Release Google.Cloud.ContactCenterInsights.V1 version 2.18.0

### DIFF
--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.csproj
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.17.0</Version>
+    <Version>2.18.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Contact Center AI Insights API, which helps users detect and visualize patterns in their contact center data. Understanding conversational data drives business value, improves operational efficiency, and provides a voice for customer feedback.</Description>

--- a/apis/Google.Cloud.ContactCenterInsights.V1/docs/history.md
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/docs/history.md
@@ -1,5 +1,25 @@
 # Version history
 
+## Version 2.18.0, released 2024-11-18
+
+### New features
+
+- Add FeedbackLabel resource and APIs ([commit fc735ad](https://github.com/googleapis/google-cloud-dotnet/commit/fc735add3c94e539818b5adfcf1137750e682099))
+- Add QueryMetrics API ([commit fc735ad](https://github.com/googleapis/google-cloud-dotnet/commit/fc735add3c94e539818b5adfcf1137750e682099))
+- Add Quality AI resources and APIs ([commit fc735ad](https://github.com/googleapis/google-cloud-dotnet/commit/fc735add3c94e539818b5adfcf1137750e682099))
+- Add AnalysisRules resource and APIs ([commit fc735ad](https://github.com/googleapis/google-cloud-dotnet/commit/fc735add3c94e539818b5adfcf1137750e682099))
+
+### Documentation improvements
+
+- A comment for method `InitializeEncryptionSpec` in service `ContactCenterInsights` is changed ([commit fc735ad](https://github.com/googleapis/google-cloud-dotnet/commit/fc735add3c94e539818b5adfcf1137750e682099))
+- A comment for field `custom_metadata_keys` in message `.google.cloud.contactcenterinsights.v1.IngestConversationsRequest` is changed ([commit fc735ad](https://github.com/googleapis/google-cloud-dotnet/commit/fc735add3c94e539818b5adfcf1137750e682099))
+- A comment for field `encryption_spec` in message `.google.cloud.contactcenterinsights.v1.InitializeEncryptionSpecRequest` is changed ([commit fc735ad](https://github.com/googleapis/google-cloud-dotnet/commit/fc735add3c94e539818b5adfcf1137750e682099))
+- A comment for field `partial_errors` in message `.google.cloud.contactcenterinsights.v1.InitializeEncryptionSpecMetadata` is changed ([commit fc735ad](https://github.com/googleapis/google-cloud-dotnet/commit/fc735add3c94e539818b5adfcf1137750e682099))
+- A comment for field `labels` in message `.google.cloud.contactcenterinsights.v1.Conversation` is changed ([commit fc735ad](https://github.com/googleapis/google-cloud-dotnet/commit/fc735add3c94e539818b5adfcf1137750e682099))
+- A comment for field `metadata_json` in message `.google.cloud.contactcenterinsights.v1.Conversation` is changed ([commit fc735ad](https://github.com/googleapis/google-cloud-dotnet/commit/fc735add3c94e539818b5adfcf1137750e682099))
+- A comment for message `EncryptionSpec` is changed ([commit fc735ad](https://github.com/googleapis/google-cloud-dotnet/commit/fc735add3c94e539818b5adfcf1137750e682099))
+- A comment for field `kms_key` in message `.google.cloud.contactcenterinsights.v1.EncryptionSpec` is changed ([commit fc735ad](https://github.com/googleapis/google-cloud-dotnet/commit/fc735add3c94e539818b5adfcf1137750e682099))
+
 ## Version 2.17.0, released 2024-10-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1638,7 +1638,7 @@
     },
     {
       "id": "Google.Cloud.ContactCenterInsights.V1",
-      "version": "2.17.0",
+      "version": "2.18.0",
       "type": "grpc",
       "productName": "Contact Center AI Insights",
       "productUrl": "https://cloud.google.com/contact-center/insights/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add FeedbackLabel resource and APIs ([commit fc735ad](https://github.com/googleapis/google-cloud-dotnet/commit/fc735add3c94e539818b5adfcf1137750e682099))
- Add QueryMetrics API ([commit fc735ad](https://github.com/googleapis/google-cloud-dotnet/commit/fc735add3c94e539818b5adfcf1137750e682099))
- Add Quality AI resources and APIs ([commit fc735ad](https://github.com/googleapis/google-cloud-dotnet/commit/fc735add3c94e539818b5adfcf1137750e682099))
- Add AnalysisRules resource and APIs ([commit fc735ad](https://github.com/googleapis/google-cloud-dotnet/commit/fc735add3c94e539818b5adfcf1137750e682099))

### Documentation improvements

- A comment for method `InitializeEncryptionSpec` in service `ContactCenterInsights` is changed ([commit fc735ad](https://github.com/googleapis/google-cloud-dotnet/commit/fc735add3c94e539818b5adfcf1137750e682099))
- A comment for field `custom_metadata_keys` in message `.google.cloud.contactcenterinsights.v1.IngestConversationsRequest` is changed ([commit fc735ad](https://github.com/googleapis/google-cloud-dotnet/commit/fc735add3c94e539818b5adfcf1137750e682099))
- A comment for field `encryption_spec` in message `.google.cloud.contactcenterinsights.v1.InitializeEncryptionSpecRequest` is changed ([commit fc735ad](https://github.com/googleapis/google-cloud-dotnet/commit/fc735add3c94e539818b5adfcf1137750e682099))
- A comment for field `partial_errors` in message `.google.cloud.contactcenterinsights.v1.InitializeEncryptionSpecMetadata` is changed ([commit fc735ad](https://github.com/googleapis/google-cloud-dotnet/commit/fc735add3c94e539818b5adfcf1137750e682099))
- A comment for field `labels` in message `.google.cloud.contactcenterinsights.v1.Conversation` is changed ([commit fc735ad](https://github.com/googleapis/google-cloud-dotnet/commit/fc735add3c94e539818b5adfcf1137750e682099))
- A comment for field `metadata_json` in message `.google.cloud.contactcenterinsights.v1.Conversation` is changed ([commit fc735ad](https://github.com/googleapis/google-cloud-dotnet/commit/fc735add3c94e539818b5adfcf1137750e682099))
- A comment for message `EncryptionSpec` is changed ([commit fc735ad](https://github.com/googleapis/google-cloud-dotnet/commit/fc735add3c94e539818b5adfcf1137750e682099))
- A comment for field `kms_key` in message `.google.cloud.contactcenterinsights.v1.EncryptionSpec` is changed ([commit fc735ad](https://github.com/googleapis/google-cloud-dotnet/commit/fc735add3c94e539818b5adfcf1137750e682099))
