### PR TITLE
Release Google.Cloud.Container.V1 version 3.33.0

### DIFF
--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/Google.Cloud.Container.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.32.0</Version>
+    <Version>3.33.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.</Description>

--- a/apis/Google.Cloud.Container.V1/docs/history.md
+++ b/apis/Google.Cloud.Container.V1/docs/history.md
@@ -1,5 +1,20 @@
 # Version history
 
+## Version 3.33.0, released 2024-11-18
+
+### New features
+
+- Add LocalSsdEncryptionMode in NodeConfig ([commit c51e9ee](https://github.com/googleapis/google-cloud-dotnet/commit/c51e9eef33ccad6b436c839c85ba2d9e220f6ce0))
+- Add LinuxNodeConfig in NodePoolAutoConfig ([commit c51e9ee](https://github.com/googleapis/google-cloud-dotnet/commit/c51e9eef33ccad6b436c839c85ba2d9e220f6ce0))
+- Add DesiredEnterpriseConfig proto message ([commit c51e9ee](https://github.com/googleapis/google-cloud-dotnet/commit/c51e9eef33ccad6b436c839c85ba2d9e220f6ce0))
+- Add desired_enterprise_config,desired_node_pool_auto_config_linux_node_config to ClusterUpdate. ([commit c51e9ee](https://github.com/googleapis/google-cloud-dotnet/commit/c51e9eef33ccad6b436c839c85ba2d9e220f6ce0))
+- Add UpgradeInfoEvent proto message ([commit c51e9ee](https://github.com/googleapis/google-cloud-dotnet/commit/c51e9eef33ccad6b436c839c85ba2d9e220f6ce0))
+- Add desired_tier to EnterpriseConfig. ([commit c51e9ee](https://github.com/googleapis/google-cloud-dotnet/commit/c51e9eef33ccad6b436c839c85ba2d9e220f6ce0))
+
+### Documentation improvements
+
+- Minor documentation updates ([commit c51e9ee](https://github.com/googleapis/google-cloud-dotnet/commit/c51e9eef33ccad6b436c839c85ba2d9e220f6ce0))
+
 ## Version 3.32.0, released 2024-10-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1666,7 +1666,7 @@
       "protoPath": "google/container/v1",
       "productName": "Google Kubernetes Engine",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/reference/rest/",
-      "version": "3.32.0",
+      "version": "3.33.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Kubernetes Engine API, used for building and managing container based applications, powered by the open source Kubernetes technology.",
       "dependencies": {},


### PR DESCRIPTION

Changes in this release:

### New features

- Add LocalSsdEncryptionMode in NodeConfig ([commit c51e9ee](https://github.com/googleapis/google-cloud-dotnet/commit/c51e9eef33ccad6b436c839c85ba2d9e220f6ce0))
- Add LinuxNodeConfig in NodePoolAutoConfig ([commit c51e9ee](https://github.com/googleapis/google-cloud-dotnet/commit/c51e9eef33ccad6b436c839c85ba2d9e220f6ce0))
- Add DesiredEnterpriseConfig proto message ([commit c51e9ee](https://github.com/googleapis/google-cloud-dotnet/commit/c51e9eef33ccad6b436c839c85ba2d9e220f6ce0))
- Add desired_enterprise_config,desired_node_pool_auto_config_linux_node_config to ClusterUpdate. ([commit c51e9ee](https://github.com/googleapis/google-cloud-dotnet/commit/c51e9eef33ccad6b436c839c85ba2d9e220f6ce0))
- Add UpgradeInfoEvent proto message ([commit c51e9ee](https://github.com/googleapis/google-cloud-dotnet/commit/c51e9eef33ccad6b436c839c85ba2d9e220f6ce0))
- Add desired_tier to EnterpriseConfig. ([commit c51e9ee](https://github.com/googleapis/google-cloud-dotnet/commit/c51e9eef33ccad6b436c839c85ba2d9e220f6ce0))

### Documentation improvements

- Minor documentation updates ([commit c51e9ee](https://github.com/googleapis/google-cloud-dotnet/commit/c51e9eef33ccad6b436c839c85ba2d9e220f6ce0))
