### PR TITLE
Release Google.Cloud.DataCatalog.V1 version 2.13.0

### DIFF
--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.12.0</Version>
+    <Version>2.13.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Data Catalog API. Data Catalog is a fully managed and highly scalable data discovery and metadata management service.</Description>
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" VersionOverride="[4.9.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.LongRunning" VersionOverride="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" VersionOverride="[2.46.6, 3.0.0)" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.DataCatalog.V1/docs/history.md
+++ b/apis/Google.Cloud.DataCatalog.V1/docs/history.md
@@ -1,5 +1,28 @@
 # Version history
 
+## Version 2.13.0, released 2024-11-18
+
+### New features
+
+- A new field `feature_online_store_spec` is added to message `.google.cloud.datacatalog.v1.Entry` ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
+- A new value `GENIE` is added to enum `ModelSourceType` ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
+- A new value `CUSTOM_TEXT_EMBEDDING` is added to enum `ModelSourceType` ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
+- A new value `MARKETPLACE` is added to enum `ModelSourceType` ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
+- A new message `FeatureOnlineStoreSpec` is added ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
+- A new value `FEATURE_ONLINE_STORE` is added to enum `EntryType` ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
+- A new value `FEATURE_VIEW` is added to enum `EntryType` ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
+- A new value `FEATURE_GROUP` is added to enum `EntryType` ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
+- A new enum `DataplexTransferStatus` is added ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
+- A new field `dataplex_transfer_status` is added to message `.google.cloud.datacatalog.v1.TagTemplate` ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
+
+### Documentation improvements
+
+- A comment for field `name` in message `.google.cloud.datacatalog.v1.Entry` is changed ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
+- A comment for field `name` in message `.google.cloud.datacatalog.v1.EntryGroup` is changed ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
+- A comment for field `name` in message `.google.cloud.datacatalog.v1.Tag` is changed ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
+- A comment for field `name` in message `.google.cloud.datacatalog.v1.TagTemplate` is changed ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
+- A comment for field `name` in message `.google.cloud.datacatalog.v1.TagTemplateField` is changed ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
+
 ## Version 2.12.0, released 2024-05-13
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1708,7 +1708,7 @@
       "protoPath": "google/cloud/datacatalog/v1",
       "productName": "Data Catalog",
       "productUrl": "https://cloud.google.com/data-catalog/docs",
-      "version": "2.12.0",
+      "version": "2.13.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Data Catalog API. Data Catalog is a fully managed and highly scalable data discovery and metadata management service.",
       "tags": [
@@ -1716,8 +1716,8 @@
         "metadata"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.2.0",
-        "Google.LongRunning": "3.2.0"
+        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.LongRunning": "3.3.0"
       },
       "shortName": "datacatalog",
       "serviceConfigFile": "datacatalog_v1.yaml",


### PR DESCRIPTION

Changes in this release:

### New features

- A new field `feature_online_store_spec` is added to message `.google.cloud.datacatalog.v1.Entry` ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
- A new value `GENIE` is added to enum `ModelSourceType` ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
- A new value `CUSTOM_TEXT_EMBEDDING` is added to enum `ModelSourceType` ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
- A new value `MARKETPLACE` is added to enum `ModelSourceType` ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
- A new message `FeatureOnlineStoreSpec` is added ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
- A new value `FEATURE_ONLINE_STORE` is added to enum `EntryType` ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
- A new value `FEATURE_VIEW` is added to enum `EntryType` ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
- A new value `FEATURE_GROUP` is added to enum `EntryType` ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
- A new enum `DataplexTransferStatus` is added ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
- A new field `dataplex_transfer_status` is added to message `.google.cloud.datacatalog.v1.TagTemplate` ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))

### Documentation improvements

- A comment for field `name` in message `.google.cloud.datacatalog.v1.Entry` is changed ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
- A comment for field `name` in message `.google.cloud.datacatalog.v1.EntryGroup` is changed ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
- A comment for field `name` in message `.google.cloud.datacatalog.v1.Tag` is changed ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
- A comment for field `name` in message `.google.cloud.datacatalog.v1.TagTemplate` is changed ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
- A comment for field `name` in message `.google.cloud.datacatalog.v1.TagTemplateField` is changed ([commit 7df11e5](https://github.com/googleapis/google-cloud-dotnet/commit/7df11e5255541ed1d824b768452ce634cac5b81f))
