### PR TITLE
Release Google.Cloud.Deploy.V1 version 3.3.0

### DIFF
--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.2.0</Version>
+    <Version>3.3.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Deploy API, which automates delivery of your applications to a series of target environments in a defined sequence.</Description>

--- a/apis/Google.Cloud.Deploy.V1/docs/history.md
+++ b/apis/Google.Cloud.Deploy.V1/docs/history.md
@@ -1,5 +1,20 @@
 # Version history
 
+## Version 3.3.0, released 2024-11-18
+
+### New features
+
+- A new field `timed_promote_release_rule` is added to message `.google.cloud.deploy.v1.AutomationRule` ([commit 3b31b09](https://github.com/googleapis/google-cloud-dotnet/commit/3b31b09fdd5ce3e59804634386339e282cf6d2d6))
+- A new message `TimedPromoteReleaseRule` is added ([commit 3b31b09](https://github.com/googleapis/google-cloud-dotnet/commit/3b31b09fdd5ce3e59804634386339e282cf6d2d6))
+- A new field `timed_promote_release_condition` is added to message `.google.cloud.deploy.v1.AutomationRuleCondition` ([commit 3b31b09](https://github.com/googleapis/google-cloud-dotnet/commit/3b31b09fdd5ce3e59804634386339e282cf6d2d6))
+- A new message `TimedPromoteReleaseCondition` is added ([commit 3b31b09](https://github.com/googleapis/google-cloud-dotnet/commit/3b31b09fdd5ce3e59804634386339e282cf6d2d6))
+- A new field `timed_promote_release_operation` is added to message `.google.cloud.deploy.v1.AutomationRun` ([commit 3b31b09](https://github.com/googleapis/google-cloud-dotnet/commit/3b31b09fdd5ce3e59804634386339e282cf6d2d6))
+- A new message `TimedPromoteReleaseOperation` is added ([commit 3b31b09](https://github.com/googleapis/google-cloud-dotnet/commit/3b31b09fdd5ce3e59804634386339e282cf6d2d6))
+
+### Documentation improvements
+
+- A comment for field `target_id` in message `.google.cloud.deploy.v1.AutomationRun` is changed ([commit 3b31b09](https://github.com/googleapis/google-cloud-dotnet/commit/3b31b09fdd5ce3e59804634386339e282cf6d2d6))
+
 ## Version 3.2.0, released 2024-10-29
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1935,7 +1935,7 @@
     },
     {
       "id": "Google.Cloud.Deploy.V1",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "type": "grpc",
       "productName": "Google Cloud Deploy",
       "productUrl": "https://cloud.google.com/deploy/",


### PR DESCRIPTION

Changes in this release:

### New features

- A new field `timed_promote_release_rule` is added to message `.google.cloud.deploy.v1.AutomationRule` ([commit 3b31b09](https://github.com/googleapis/google-cloud-dotnet/commit/3b31b09fdd5ce3e59804634386339e282cf6d2d6))
- A new message `TimedPromoteReleaseRule` is added ([commit 3b31b09](https://github.com/googleapis/google-cloud-dotnet/commit/3b31b09fdd5ce3e59804634386339e282cf6d2d6))
- A new field `timed_promote_release_condition` is added to message `.google.cloud.deploy.v1.AutomationRuleCondition` ([commit 3b31b09](https://github.com/googleapis/google-cloud-dotnet/commit/3b31b09fdd5ce3e59804634386339e282cf6d2d6))
- A new message `TimedPromoteReleaseCondition` is added ([commit 3b31b09](https://github.com/googleapis/google-cloud-dotnet/commit/3b31b09fdd5ce3e59804634386339e282cf6d2d6))
- A new field `timed_promote_release_operation` is added to message `.google.cloud.deploy.v1.AutomationRun` ([commit 3b31b09](https://github.com/googleapis/google-cloud-dotnet/commit/3b31b09fdd5ce3e59804634386339e282cf6d2d6))
- A new message `TimedPromoteReleaseOperation` is added ([commit 3b31b09](https://github.com/googleapis/google-cloud-dotnet/commit/3b31b09fdd5ce3e59804634386339e282cf6d2d6))

### Documentation improvements

- A comment for field `target_id` in message `.google.cloud.deploy.v1.AutomationRun` is changed ([commit 3b31b09](https://github.com/googleapis/google-cloud-dotnet/commit/3b31b09fdd5ce3e59804634386339e282cf6d2d6))
