### PR TITLE
Release Google.Cloud.Dialogflow.Cx.V3 version 2.21.0

### DIFF
--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.20.0</Version>
+    <Version>2.21.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Builds conversational interfaces (for example, chatbots, and voice-powered apps and devices).</Description>

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.21.0, released 2024-11-18
+
+### New features
+
+- Add options of client_certificate_settings, bigquery_export_settings, bearer_token_config and boost_control_spec; add support of ALAW encoding ([commit 5f708d8](https://github.com/googleapis/google-cloud-dotnet/commit/5f708d833e320527b225017042e40f8e129a2ce4))
+
 ## Version 2.20.0, released 2024-07-29
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2076,7 +2076,7 @@
     },
     {
       "id": "Google.Cloud.Dialogflow.Cx.V3",
-      "version": "2.20.0",
+      "version": "2.21.0",
       "type": "grpc",
       "productName": "Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow/cx/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add options of client_certificate_settings, bigquery_export_settings, bearer_token_config and boost_control_spec; add support of ALAW encoding ([commit 5f708d8](https://github.com/googleapis/google-cloud-dotnet/commit/5f708d833e320527b225017042e40f8e129a2ce4))
