### PR TITLE
Release Google.Cloud.GdcHardwareManagement.V1Alpha version 1.0.0-alpha04

### DIFF
--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.csproj
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha03</Version>
+    <Version>1.0.0-alpha04</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Distributed Cloud Hardware Management API (v1alpha)</Description>

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 1.0.0-alpha04, released 2024-11-18
+
+### New features
+
+- Add DNS address, Kubernetes primary VLAN ID, and provisioning state to the Zone resource ([commit 9180676](https://github.com/googleapis/google-cloud-dotnet/commit/918067697f16a57916593566858e5bac33709c10))
+- Add MAC address-associated IP address to the Hardware resource ([commit 9180676](https://github.com/googleapis/google-cloud-dotnet/commit/918067697f16a57916593566858e5bac33709c10))
+- Add provisioning_state_signal field in SignalZoneState method request ([commit 9180676](https://github.com/googleapis/google-cloud-dotnet/commit/918067697f16a57916593566858e5bac33709c10))
+
+### Documentation improvements
+
+- Change state_signal field in SignalZoneState method request as optional ([commit 9180676](https://github.com/googleapis/google-cloud-dotnet/commit/918067697f16a57916593566858e5bac33709c10))
+
 ## Version 1.0.0-alpha03, released 2024-10-29
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2631,7 +2631,7 @@
     },
     {
       "id": "Google.Cloud.GdcHardwareManagement.V1Alpha",
-      "version": "1.0.0-alpha03",
+      "version": "1.0.0-alpha04",
       "type": "grpc",
       "productName": "GDC Hardware Management",
       "productUrl": "https://cloud.google.com/distributed-cloud/edge/latest/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add DNS address, Kubernetes primary VLAN ID, and provisioning state to the Zone resource ([commit 9180676](https://github.com/googleapis/google-cloud-dotnet/commit/918067697f16a57916593566858e5bac33709c10))
- Add MAC address-associated IP address to the Hardware resource ([commit 9180676](https://github.com/googleapis/google-cloud-dotnet/commit/918067697f16a57916593566858e5bac33709c10))
- Add provisioning_state_signal field in SignalZoneState method request ([commit 9180676](https://github.com/googleapis/google-cloud-dotnet/commit/918067697f16a57916593566858e5bac33709c10))

### Documentation improvements

- Change state_signal field in SignalZoneState method request as optional ([commit 9180676](https://github.com/googleapis/google-cloud-dotnet/commit/918067697f16a57916593566858e5bac33709c10))
