### PR TITLE
Release Google.Cloud.GkeConnect.Gateway.V1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.GkeConnect.Gateway.V1/Google.Cloud.GkeConnect.Gateway.V1/Google.Cloud.GkeConnect.Gateway.V1.csproj
+++ b/apis/Google.Cloud.GkeConnect.Gateway.V1/Google.Cloud.GkeConnect.Gateway.V1/Google.Cloud.GkeConnect.Gateway.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the GKE Connect Gateway API, which allows connectivity from external parties to connected Kubernetes clusters.</Description>

--- a/apis/Google.Cloud.GkeConnect.Gateway.V1/docs/history.md
+++ b/apis/Google.Cloud.GkeConnect.Gateway.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2024-11-18
+
+### New features
+
+- **BREAKING CHANGE** Update default transport type for Connect Gateway v1 client to "rest" ([commit 1bbe7a8](https://github.com/googleapis/google-cloud-dotnet/commit/1bbe7a88327709392b7fa0bb8a7abeea9b5f13d9))
+
+### Breaking changes
+
+- GRPC support is being removed in favor of HTTP support, as gRPC is not currently supported by Connect Gateway. ([commit 1bbe7a8](https://github.com/googleapis/google-cloud-dotnet/commit/1bbe7a88327709392b7fa0bb8a7abeea9b5f13d9))
+
 ## Version 1.0.0-beta01, released 2024-09-04
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2679,7 +2679,7 @@
     },
     {
       "id": "Google.Cloud.GkeConnect.Gateway.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Connect Gateway",
       "productUrl": "https://cloud.google.com/kubernetes-engine/enterprise/multicluster-management/gateway",


### PR DESCRIPTION

Changes in this release:

### New features

- **BREAKING CHANGE** Update default transport type for Connect Gateway v1 client to "rest" ([commit 1bbe7a8](https://github.com/googleapis/google-cloud-dotnet/commit/1bbe7a88327709392b7fa0bb8a7abeea9b5f13d9))

### Breaking changes

- GRPC support is being removed in favor of HTTP support, as gRPC is not currently supported by Connect Gateway. ([commit 1bbe7a8](https://github.com/googleapis/google-cloud-dotnet/commit/1bbe7a88327709392b7fa0bb8a7abeea9b5f13d9))
