### PR TITLE
Release Google.Cloud.NetworkManagement.V1 version 2.12.0

### DIFF
--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.csproj
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.11.0</Version>
+    <Version>2.12.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Network Management API, which provides a collection of network performance monitoring and diagnostic capabilities.</Description>

--- a/apis/Google.Cloud.NetworkManagement.V1/docs/history.md
+++ b/apis/Google.Cloud.NetworkManagement.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 2.12.0, released 2024-11-18
+
+### New features
+
+- Add round-trip mode ([commit 7f285c1](https://github.com/googleapis/google-cloud-dotnet/commit/7f285c165cb943640033385786f9e8f02476e2a9))
+- Add DNS endpoint of Google Kubernetes Engine cluster control plane ([commit 14d1507](https://github.com/googleapis/google-cloud-dotnet/commit/14d150726ba94347602efaa9db115f1da1228aa2))
+- Add more detailed drop causes to corresponding enum ([commit 14d1507](https://github.com/googleapis/google-cloud-dotnet/commit/14d150726ba94347602efaa9db115f1da1228aa2))
+
+### Documentation improvements
+
+- Update outdated comments ([commit 14d1507](https://github.com/googleapis/google-cloud-dotnet/commit/14d150726ba94347602efaa9db115f1da1228aa2))
+
 ## Version 2.11.0, released 2024-10-21
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3438,7 +3438,7 @@
     },
     {
       "id": "Google.Cloud.NetworkManagement.V1",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "type": "grpc",
       "productName": "Network Management",
       "productUrl": "https://cloud.google.com/network-intelligence-center/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add round-trip mode ([commit 7f285c1](https://github.com/googleapis/google-cloud-dotnet/commit/7f285c165cb943640033385786f9e8f02476e2a9))
- Add DNS endpoint of Google Kubernetes Engine cluster control plane ([commit 14d1507](https://github.com/googleapis/google-cloud-dotnet/commit/14d150726ba94347602efaa9db115f1da1228aa2))
- Add more detailed drop causes to corresponding enum ([commit 14d1507](https://github.com/googleapis/google-cloud-dotnet/commit/14d150726ba94347602efaa9db115f1da1228aa2))

### Documentation improvements

- Update outdated comments ([commit 14d1507](https://github.com/googleapis/google-cloud-dotnet/commit/14d150726ba94347602efaa9db115f1da1228aa2))
