### PR TITLE
Release Google.Cloud.RecaptchaEnterprise.V1 version 2.17.0

### DIFF
--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.csproj
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.16.0</Version>
+    <Version>2.17.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud reCAPTCHA for Enterprise API v1.</Description>

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/docs/history.md
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 2.17.0, released 2024-11-18
+
+### New features
+
+- A new enum `Challenge` is added ([commit 3080dfc](https://github.com/googleapis/google-cloud-dotnet/commit/3080dfc1247a9714a9d5b4fbc1c4a4a3db0f444b))
+- A new field `challenge` is added to message `.google.cloud.recaptchaenterprise.v1.RiskAnalysis` ([commit 3080dfc](https://github.com/googleapis/google-cloud-dotnet/commit/3080dfc1247a9714a9d5b4fbc1c4a4a3db0f444b))
+
 ## Version 2.16.0, released 2024-10-30
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4059,7 +4059,7 @@
       "protoPath": "google/cloud/recaptchaenterprise/v1",
       "productName": "Google Cloud reCAPTCHA Enterprise",
       "productUrl": "https://cloud.google.com/recaptcha-enterprise/",
-      "version": "2.16.0",
+      "version": "2.17.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud reCAPTCHA for Enterprise API v1.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- A new enum `Challenge` is added ([commit 3080dfc](https://github.com/googleapis/google-cloud-dotnet/commit/3080dfc1247a9714a9d5b4fbc1c4a4a3db0f444b))
- A new field `challenge` is added to message `.google.cloud.recaptchaenterprise.v1.RiskAnalysis` ([commit 3080dfc](https://github.com/googleapis/google-cloud-dotnet/commit/3080dfc1247a9714a9d5b4fbc1c4a4a3db0f444b))
