### PR TITLE
Release Google.Cloud.Run.V2 version 2.11.0

### DIFF
--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.10.0</Version>
+    <Version>2.11.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Run Admin API (v2)</Description>

--- a/apis/Google.Cloud.Run.V2/docs/history.md
+++ b/apis/Google.Cloud.Run.V2/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+## Version 2.11.0, released 2024-11-18
+
+### New features
+
+- Add EncryptionKeyRevocationAction and shutdown duration configuration to Services ([commit 6963dfd](https://github.com/googleapis/google-cloud-dotnet/commit/6963dfdb09d8947ff414d6cb15b33c5edc049a50))
+- Support advanced configurations options for cloud storage volumes by setting mount_options in the GCSVolumeSource configuration ([commit f8a46b8](https://github.com/googleapis/google-cloud-dotnet/commit/f8a46b8760b14817434b7da6734a3208c2751a0b))
+
+### Documentation improvements
+
+- Fixed formatting of some documentation ([commit 6963dfd](https://github.com/googleapis/google-cloud-dotnet/commit/6963dfdb09d8947ff414d6cb15b33c5edc049a50))
+- Update docs for field `value` in message `.google.cloud.run.v2.EnvVar` to reflect Cloud Run product capabilities ([commit f8a46b8](https://github.com/googleapis/google-cloud-dotnet/commit/f8a46b8760b14817434b7da6734a3208c2751a0b))
+- A comment for field `max_instance_request_concurrency` in message `.google.cloud.run.v2.RevisionTemplate` is changed ([commit f8a46b8](https://github.com/googleapis/google-cloud-dotnet/commit/f8a46b8760b14817434b7da6734a3208c2751a0b))
+- For field `invoker_iam_disabled` in message `.google.cloud.run.v2.Service`, clarify that feature is available by invitation only ([commit f8a46b8](https://github.com/googleapis/google-cloud-dotnet/commit/f8a46b8760b14817434b7da6734a3208c2751a0b))
+
 ## Version 2.10.0, released 2024-10-07
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4265,7 +4265,7 @@
     },
     {
       "id": "Google.Cloud.Run.V2",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "type": "grpc",
       "productName": "Cloud Run Admin",
       "productUrl": "https://cloud.google.com/run/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add EncryptionKeyRevocationAction and shutdown duration configuration to Services ([commit 6963dfd](https://github.com/googleapis/google-cloud-dotnet/commit/6963dfdb09d8947ff414d6cb15b33c5edc049a50))
- Support advanced configurations options for cloud storage volumes by setting mount_options in the GCSVolumeSource configuration ([commit f8a46b8](https://github.com/googleapis/google-cloud-dotnet/commit/f8a46b8760b14817434b7da6734a3208c2751a0b))

### Documentation improvements

- Fixed formatting of some documentation ([commit 6963dfd](https://github.com/googleapis/google-cloud-dotnet/commit/6963dfdb09d8947ff414d6cb15b33c5edc049a50))
- Update docs for field `value` in message `.google.cloud.run.v2.EnvVar` to reflect Cloud Run product capabilities ([commit f8a46b8](https://github.com/googleapis/google-cloud-dotnet/commit/f8a46b8760b14817434b7da6734a3208c2751a0b))
- A comment for field `max_instance_request_concurrency` in message `.google.cloud.run.v2.RevisionTemplate` is changed ([commit f8a46b8](https://github.com/googleapis/google-cloud-dotnet/commit/f8a46b8760b14817434b7da6734a3208c2751a0b))
- For field `invoker_iam_disabled` in message `.google.cloud.run.v2.Service`, clarify that feature is available by invitation only ([commit f8a46b8](https://github.com/googleapis/google-cloud-dotnet/commit/f8a46b8760b14817434b7da6734a3208c2751a0b))
