### PR TITLE
tools: Add a --unconfigured option for API generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ build_timing_log.txt
 
 # Temporary local GAX
 gax-dotnet
+
+# Generated code for "unconfigured" APIs (generateapis.sh --unconfigured)
+unconfigured-generation

--- a/tools/Google.Cloud.Tools.ReleaseManager/AddCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/AddCommand.cs
@@ -155,7 +155,10 @@ namespace Google.Cloud.Tools.ReleaseManager
             return 0;
         }
 
-        private static Api.Service ParseServiceConfigYaml(string path)
+        // This is internal so that it's available to GenerateApisCommand, for unconfigured
+        // APIs. This is somewhat experimental - if we want this long-term, we should probably
+        // move it elsewhere.
+        internal static Api.Service ParseServiceConfigYaml(string path)
         {
             if (path is null)
             {


### PR DESCRIPTION
This allows generation (at least for most APIs) of code without an API being part of the API catalog. This is *not* code that's ready to ship - various things may be wrong - but can still be useful as part of an API producer's workflow. Running `./generateapis.sh --unconfigured` will generate every API it can find under googleapis - or APIs can be specified as *directories* (e.g. google/cloud/functions/v2) instead of as the .NET package name.