### PR TITLE
Release Google.Analytics.Data.V1Beta version 2.0.0-beta09

### DIFF
--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.csproj
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta08</Version>
+    <Version>2.0.0-beta09</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Data API (v1beta)</Description>

--- a/apis/Google.Analytics.Data.V1Beta/docs/history.md
+++ b/apis/Google.Analytics.Data.V1Beta/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 2.0.0-beta09, released 2024-12-05
+
+### New features
+
+- Add `EmptyFilter` type to the Data API v1beta ([commit 1f4a8b3](https://github.com/googleapis/google-cloud-dotnet/commit/1f4a8b3dd4bc8fd91be21f5a270e88af1a1c6c5d))
+- Add the `empty_filter` field to the `Filter` type ([commit 1f4a8b3](https://github.com/googleapis/google-cloud-dotnet/commit/1f4a8b3dd4bc8fd91be21f5a270e88af1a1c6c5d))
+
+### Documentation improvements
+
+- Update documentation for the`RunReport` method ([commit 1f4a8b3](https://github.com/googleapis/google-cloud-dotnet/commit/1f4a8b3dd4bc8fd91be21f5a270e88af1a1c6c5d))
+- Remove all references to 'GA4' in documentation ([commit 1f4a8b3](https://github.com/googleapis/google-cloud-dotnet/commit/1f4a8b3dd4bc8fd91be21f5a270e88af1a1c6c5d))
+
 ## Version 2.0.0-beta08, released 2024-08-05
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -84,7 +84,7 @@
     },
     {
       "id": "Google.Analytics.Data.V1Beta",
-      "version": "2.0.0-beta08",
+      "version": "2.0.0-beta09",
       "type": "grpc",
       "productName": "Google Analytics Data",
       "productUrl": "https://developers.google.com/analytics",


### PR DESCRIPTION

Changes in this release:

### New features

- Add `EmptyFilter` type to the Data API v1beta ([commit 1f4a8b3](https://github.com/googleapis/google-cloud-dotnet/commit/1f4a8b3dd4bc8fd91be21f5a270e88af1a1c6c5d))
- Add the `empty_filter` field to the `Filter` type ([commit 1f4a8b3](https://github.com/googleapis/google-cloud-dotnet/commit/1f4a8b3dd4bc8fd91be21f5a270e88af1a1c6c5d))

### Documentation improvements

- Update documentation for the`RunReport` method ([commit 1f4a8b3](https://github.com/googleapis/google-cloud-dotnet/commit/1f4a8b3dd4bc8fd91be21f5a270e88af1a1c6c5d))
- Remove all references to 'GA4' in documentation ([commit 1f4a8b3](https://github.com/googleapis/google-cloud-dotnet/commit/1f4a8b3dd4bc8fd91be21f5a270e88af1a1c6c5d))
