### PR TITLE
Release Google.Cloud.ApiHub.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.ApiHub.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.ApiHub.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.ApiHub.V1",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.ApiHub.V1/latest",
   "library_type": "GAPIC_AUTO",
   "language": "dotnet",

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.csproj
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Apigee API hub API, which lets you consolidate and organize information about all of the APIs of interest to your organization.</Description>

--- a/apis/Google.Cloud.ApiHub.V1/docs/history.md
+++ b/apis/Google.Cloud.ApiHub.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2024-12-05
+
+No API surface changes; just dependency updates and promotion to GA.
+
 ## Version 1.0.0-beta02, released 2024-09-04
 
 ### Bug fixes

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -421,7 +421,7 @@
     },
     {
       "id": "Google.Cloud.ApiHub.V1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "API hub",
       "productUrl": "https://cloud.google.com/apigee/docs/apihub/what-is-api-hub",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to GA.
