### PR TITLE
Release Google.Cloud.AppHub.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.AppHub.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.AppHub.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.AppHub.V1",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.AppHub.V1/latest",
   "library_type": "GAPIC_AUTO",
   "language": "dotnet",

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.csproj
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the App Hub API, which simplifies the process of building, running, and managing applications on Google Cloud.</Description>
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" VersionOverride="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.3.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.AppHub.V1/docs/history.md
+++ b/apis/Google.Cloud.AppHub.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2024-12-05
+
+No API surface changes; just dependency updates and promotion to GA.
+
 ## Version 1.0.0-beta03, released 2024-05-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -555,7 +555,7 @@
     },
     {
       "id": "Google.Cloud.AppHub.V1",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "App Hub",
       "productUrl": "https://cloud.google.com/app-hub/docs/overview",
@@ -565,9 +565,9 @@
         "management"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.2.0",
-        "Google.Cloud.Location": "2.2.0",
-        "Google.LongRunning": "3.2.0"
+        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Location": "2.3.0",
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/apphub/v1",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to GA.
