### PR TITLE
Release Google.Cloud.GkeConnect.Gateway.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.GkeConnect.Gateway.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.GkeConnect.Gateway.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.GkeConnect.Gateway.V1",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.GkeConnect.Gateway.V1/latest",
   "library_type": "GAPIC_AUTO",
   "language": "dotnet",

--- a/apis/Google.Cloud.GkeConnect.Gateway.V1/Google.Cloud.GkeConnect.Gateway.V1/Google.Cloud.GkeConnect.Gateway.V1.csproj
+++ b/apis/Google.Cloud.GkeConnect.Gateway.V1/Google.Cloud.GkeConnect.Gateway.V1/Google.Cloud.GkeConnect.Gateway.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the GKE Connect Gateway API, which allows connectivity from external parties to connected Kubernetes clusters.</Description>

--- a/apis/Google.Cloud.GkeConnect.Gateway.V1/docs/history.md
+++ b/apis/Google.Cloud.GkeConnect.Gateway.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2024-12-05
+
+No API surface changes; just dependency updates and promotion to GA.
+
 ## Version 1.0.0-beta02, released 2024-11-18
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2686,7 +2686,7 @@
     },
     {
       "id": "Google.Cloud.GkeConnect.Gateway.V1",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Connect Gateway",
       "productUrl": "https://cloud.google.com/kubernetes-engine/enterprise/multicluster-management/gateway",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to GA.
