### PR TITLE
Release Google.Cloud.NetworkServices.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.NetworkServices.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.NetworkServices.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.NetworkServices.V1",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.NetworkServices.V1/latest",
   "library_type": "GAPIC_AUTO",
   "language": "dotnet",

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.csproj
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Network Services API, which allows you to manage Network Services resources.</Description>

--- a/apis/Google.Cloud.NetworkServices.V1/docs/history.md
+++ b/apis/Google.Cloud.NetworkServices.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2024-12-05
+
+No API surface changes; just dependency updates and promotion to GA.
+
 ## Version 1.0.0-beta01, released 2024-06-19
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3502,7 +3502,7 @@
     },
     {
       "id": "Google.Cloud.NetworkServices.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Network Services",
       "productUrl": "https://cloud.google.com/products/networking",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to GA.
