### PR TITLE
Release Google.Cloud.Parallelstore.V1 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.Parallelstore.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.Parallelstore.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.Parallelstore.V1",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Parallelstore.V1/latest",
   "library_type": "GAPIC_AUTO",
   "language": "dotnet",

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.csproj
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library for Parallelstore: a fully managed, low-latency distributed file system designed to meet the demands of high performance computing (HPC) and data-intensive applications.</Description>

--- a/apis/Google.Cloud.Parallelstore.V1/docs/history.md
+++ b/apis/Google.Cloud.Parallelstore.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2024-12-05
+
+No API surface changes; just dependency updates and promotion to GA.
+
 ## Version 1.0.0-beta01, released 2024-10-25
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3813,7 +3813,7 @@
     },
     {
       "id": "Google.Cloud.Parallelstore.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Parallelstore",
       "productUrl": "https://cloud.google.com/parallelstore?hl=en",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to GA.
