### PR TITLE
Release Google.Cloud.SecurityCenter.V2 version 1.0.0

### DIFF
--- a/apis/Google.Cloud.SecurityCenter.V2/.repo-metadata.json
+++ b/apis/Google.Cloud.SecurityCenter.V2/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Cloud.SecurityCenter.V2",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.SecurityCenter.V2/latest",
   "library_type": "GAPIC_AUTO",
   "language": "dotnet",

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.csproj
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta05</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Security Command Center API (v2), which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.</Description>

--- a/apis/Google.Cloud.SecurityCenter.V2/docs/history.md
+++ b/apis/Google.Cloud.SecurityCenter.V2/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2024-12-05
+
+No API surface changes; just dependency updates and promotion to GA.
+
 ## Version 1.0.0-beta05, released 2024-08-05
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4550,7 +4550,7 @@
     },
     {
       "id": "Google.Cloud.SecurityCenter.V2",
-      "version": "1.0.0-beta05",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Security Command Center",
       "productUrl": "https://cloud.google.com/security-command-center/docs/reference/rest",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just dependency updates and promotion to GA.
