### PR TITLE
Release Google.Apps.Chat.V1 version 1.0.0-beta09

### DIFF
--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/Google.Apps.Chat.V1.csproj
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/Google.Apps.Chat.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta08</Version>
+    <Version>1.0.0-beta09</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Chat API, which lets you build Chat apps to integrate your services with Google Chat and manage Chat resources such as spaces, members, and messages.</Description>

--- a/apis/Google.Apps.Chat.V1/docs/history.md
+++ b/apis/Google.Apps.Chat.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.0.0-beta09, released 2024-12-06
+
+### New features
+
+- Chat Apps can now retrieve the import mode expire time information to know when to complete the import mode properly ([commit 84cf136](https://github.com/googleapis/google-cloud-dotnet/commit/84cf1362823ea53928baf9fef663c439b07b93e9))
+
+### Documentation improvements
+
+- Update reference documentation to include import_mode_expire_time field ([commit 84cf136](https://github.com/googleapis/google-cloud-dotnet/commit/84cf1362823ea53928baf9fef663c439b07b93e9))
+
 ## Version 1.0.0-beta08, released 2024-10-07
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -119,7 +119,7 @@
     },
     {
       "id": "Google.Apps.Chat.V1",
-      "version": "1.0.0-beta08",
+      "version": "1.0.0-beta09",
       "type": "grpc",
       "productName": "Google Chat",
       "productUrl": "https://developers.google.com/chat/concepts",


### PR DESCRIPTION

Changes in this release:

### New features

- Chat Apps can now retrieve the import mode expire time information to know when to complete the import mode properly ([commit 84cf136](https://github.com/googleapis/google-cloud-dotnet/commit/84cf1362823ea53928baf9fef663c439b07b93e9))

### Documentation improvements

- Update reference documentation to include import_mode_expire_time field ([commit 84cf136](https://github.com/googleapis/google-cloud-dotnet/commit/84cf1362823ea53928baf9fef663c439b07b93e9))
