### PR TITLE
Release Google.Cloud.AIPlatform.V1 version 3.12.0

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.11.0</Version>
+    <Version>3.12.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform API (v1), which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1/docs/history.md
@@ -1,5 +1,20 @@
 # Version history
 
+## Version 3.12.0, released 2024-12-06
+
+### New features
+
+- Add workbench_runtime and kernel_name to NotebookExecutionJob ([commit 5835c7c](https://github.com/googleapis/google-cloud-dotnet/commit/5835c7cc3e9ed46f05a7c9d19a69de19c4aaf334))
+- Add new `Status` field to DeployedModel in Endpoint ([commit 4226ced](https://github.com/googleapis/google-cloud-dotnet/commit/4226ced8c84e3f401404225b46a0708cb34250f6))
+- Add new `RequiredReplicaCount` field to DedicatedResources in MachineResources ([commit 4226ced](https://github.com/googleapis/google-cloud-dotnet/commit/4226ced8c84e3f401404225b46a0708cb34250f6))
+- Add Vertex RAG service proto to v1 ([commit ebf9b3f](https://github.com/googleapis/google-cloud-dotnet/commit/ebf9b3fb51cfe13b68fd35c467c57125523c1ddf))
+- Add a v1 UpdateEndpointLongRunning API ([commit 69c07c0](https://github.com/googleapis/google-cloud-dotnet/commit/69c07c0d7ae57a1e045affd11300246b81108e6e))
+- Add CustomEnvironmentSpec to NotebookExecutionJob ([commit 39afa50](https://github.com/googleapis/google-cloud-dotnet/commit/39afa501f82de87c2b2149f2e9d6d3d6703272b3))
+
+### Documentation improvements
+
+- A comment for field `encryption_spec` in message `.google.cloud.aiplatform.v1.NotebookExecutionJob` is changed ([commit 5835c7c](https://github.com/googleapis/google-cloud-dotnet/commit/5835c7cc3e9ed46f05a7c9d19a69de19c4aaf334))
+
 ## Version 3.11.0, released 2024-11-18
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -397,7 +397,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1",
-      "version": "3.11.0",
+      "version": "3.12.0",
       "type": "grpc",
       "productName": "Cloud AI Platform",
       "productUrl": "https://cloud.google.com/ai-platform/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add workbench_runtime and kernel_name to NotebookExecutionJob ([commit 5835c7c](https://github.com/googleapis/google-cloud-dotnet/commit/5835c7cc3e9ed46f05a7c9d19a69de19c4aaf334))
- Add new `Status` field to DeployedModel in Endpoint ([commit 4226ced](https://github.com/googleapis/google-cloud-dotnet/commit/4226ced8c84e3f401404225b46a0708cb34250f6))
- Add new `RequiredReplicaCount` field to DedicatedResources in MachineResources ([commit 4226ced](https://github.com/googleapis/google-cloud-dotnet/commit/4226ced8c84e3f401404225b46a0708cb34250f6))
- Add Vertex RAG service proto to v1 ([commit ebf9b3f](https://github.com/googleapis/google-cloud-dotnet/commit/ebf9b3fb51cfe13b68fd35c467c57125523c1ddf))
- Add a v1 UpdateEndpointLongRunning API ([commit 69c07c0](https://github.com/googleapis/google-cloud-dotnet/commit/69c07c0d7ae57a1e045affd11300246b81108e6e))
- Add CustomEnvironmentSpec to NotebookExecutionJob ([commit 39afa50](https://github.com/googleapis/google-cloud-dotnet/commit/39afa501f82de87c2b2149f2e9d6d3d6703272b3))

### Documentation improvements

- A comment for field `encryption_spec` in message `.google.cloud.aiplatform.v1.NotebookExecutionJob` is changed ([commit 5835c7c](https://github.com/googleapis/google-cloud-dotnet/commit/5835c7cc3e9ed46f05a7c9d19a69de19c4aaf334))
