### PR TITLE
Release Google.Cloud.BigQuery.Reservation.V1 version 2.6.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Reservation API, which allows you to modify your BigQuery flat-rate reservations.</Description>

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 2.6.0, released 2024-12-06
+
+### New features
+
+- Add the managed disaster recovery API(https://cloud.google.com/bigquery/docs/managed-disaster-recovery) ([commit 54897cb](https://github.com/googleapis/google-cloud-dotnet/commit/54897cbd2d99c298ee5f2e7b58b85b042e64e296))
+- Add a new field `is_flat_rate` to `.google.cloud.bigquery.reservation.v1.CapacityCommitment` to distinguish between flat rate and edition commitments ([commit 54897cb](https://github.com/googleapis/google-cloud-dotnet/commit/54897cbd2d99c298ee5f2e7b58b85b042e64e296))
+
+### Documentation improvements
+
+- Clarify that `Autoscale.current_slots` in message `.google.cloud.bigquery.reservation.v1.Reservation` can temporarily be larger than `Autoscale.max_slots` if users reduce `Autoscale.max_slots` ([commit 54897cb](https://github.com/googleapis/google-cloud-dotnet/commit/54897cbd2d99c298ee5f2e7b58b85b042e64e296))
+- Update comment for `slot_capacity` in message `.google.cloud.bigquery.reservation.v1.Reservation` to provide more clarity about reservation baselines, committed slots and autoscaler SKU charges when the baseline exceeds committed slots ([commit 54897cb](https://github.com/googleapis/google-cloud-dotnet/commit/54897cbd2d99c298ee5f2e7b58b85b042e64e296))
+- Update comments for `commitment_start_time` and `commitment_end_time` in message `.google.cloud.bigquery.reservation.v1.CapacityCommitment` to provide details on how these values are affected by commitment renewal ([commit 54897cb](https://github.com/googleapis/google-cloud-dotnet/commit/54897cbd2d99c298ee5f2e7b58b85b042e64e296))
+
 ## Version 2.5.0, released 2024-05-13
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1087,7 +1087,7 @@
     },
     {
       "id": "Google.Cloud.BigQuery.Reservation.V1",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "type": "grpc",
       "productName": "BigQuery Reservation",
       "productUrl": "https://cloud.google.com/bigquery/docs/reference/reservations",


### PR DESCRIPTION

Changes in this release:

### New features

- Add the managed disaster recovery API(https://cloud.google.com/bigquery/docs/managed-disaster-recovery) ([commit 54897cb](https://github.com/googleapis/google-cloud-dotnet/commit/54897cbd2d99c298ee5f2e7b58b85b042e64e296))
- Add a new field `is_flat_rate` to `.google.cloud.bigquery.reservation.v1.CapacityCommitment` to distinguish between flat rate and edition commitments ([commit 54897cb](https://github.com/googleapis/google-cloud-dotnet/commit/54897cbd2d99c298ee5f2e7b58b85b042e64e296))

### Documentation improvements

- Clarify that `Autoscale.current_slots` in message `.google.cloud.bigquery.reservation.v1.Reservation` can temporarily be larger than `Autoscale.max_slots` if users reduce `Autoscale.max_slots` ([commit 54897cb](https://github.com/googleapis/google-cloud-dotnet/commit/54897cbd2d99c298ee5f2e7b58b85b042e64e296))
- Update comment for `slot_capacity` in message `.google.cloud.bigquery.reservation.v1.Reservation` to provide more clarity about reservation baselines, committed slots and autoscaler SKU charges when the baseline exceeds committed slots ([commit 54897cb](https://github.com/googleapis/google-cloud-dotnet/commit/54897cbd2d99c298ee5f2e7b58b85b042e64e296))
- Update comments for `commitment_start_time` and `commitment_end_time` in message `.google.cloud.bigquery.reservation.v1.CapacityCommitment` to provide details on how these values are affected by commitment renewal ([commit 54897cb](https://github.com/googleapis/google-cloud-dotnet/commit/54897cbd2d99c298ee5f2e7b58b85b042e64e296))
