### PR TITLE
Release Google.Cloud.ConfidentialComputing.V1 version 1.7.0

### DIFF
--- a/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.csproj
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.6.0</Version>
+    <Version>1.7.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Confidential Computing API (v1)</Description>

--- a/apis/Google.Cloud.ConfidentialComputing.V1/docs/history.md
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.7.0, released 2024-12-06
+
+### New features
+
+- Add a token_type options proto to allow for customization of specific token types. Added the first token type option to hold principal tag token options ([commit 4bf271b](https://github.com/googleapis/google-cloud-dotnet/commit/4bf271b8ae073fb8915a01e4f58be3647a20a49a))
+
 ## Version 1.6.0, released 2024-07-22
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1547,7 +1547,7 @@
     },
     {
       "id": "Google.Cloud.ConfidentialComputing.V1",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "type": "grpc",
       "productName": "Confidential Computing",
       "productUrl": "https://cloud.google.com/confidential-computing",


### PR DESCRIPTION

Changes in this release:

### New features

- Add a token_type options proto to allow for customization of specific token types. Added the first token type option to hold principal tag token options ([commit 4bf271b](https://github.com/googleapis/google-cloud-dotnet/commit/4bf271b8ae073fb8915a01e4f58be3647a20a49a))
