### PR TITLE
Release Google.Cloud.DataCatalog.V1 version 2.14.0

### DIFF
--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.13.0</Version>
+    <Version>2.14.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Data Catalog API. Data Catalog is a fully managed and highly scalable data discovery and metadata management service.</Description>

--- a/apis/Google.Cloud.DataCatalog.V1/docs/history.md
+++ b/apis/Google.Cloud.DataCatalog.V1/docs/history.md
@@ -1,5 +1,27 @@
 # Version history
 
+## Version 2.14.0, released 2024-12-06
+
+### New features
+
+- A new method `SetConfig` is added to service `DataCatalog` ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))
+- A new method `RetrieveConfig` is added to service `DataCatalog` ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))
+- A new method `RetrieveEffectiveConfig` is added to service `DataCatalog` ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))
+- A new field `transferred_to_dataplex` is added to message `.google.cloud.datacatalog.v1.EntryGroup` ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))
+- A new message `SetConfigRequest` is added ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))
+- A new message `RetrieveConfigRequest` is added ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))
+- A new message `RetrieveEffectiveConfigRequest` is added ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))
+- A new enum `TagTemplateMigration` is added ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))
+- A new enum `CatalogUIExperience` is added ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))
+- A new message `OrganizationConfig` is added ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))
+- A new message `MigrationConfig` is added ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))
+- A new field `dataplex_transfer_status` is added to message `.google.cloud.datacatalog.v1.Tag` ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))
+- A new value `TRANSFERRED` is added to enum `DataplexTransferStatus` ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))
+
+### Documentation improvements
+
+- A comment for message `EntryGroup` is changed ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))
+
 ## Version 2.13.0, released 2024-11-18
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1715,7 +1715,7 @@
       "protoPath": "google/cloud/datacatalog/v1",
       "productName": "Data Catalog",
       "productUrl": "https://cloud.google.com/data-catalog/docs",
-      "version": "2.13.0",
+      "version": "2.14.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Data Catalog API. Data Catalog is a fully managed and highly scalable data discovery and metadata management service.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- A new method `SetConfig` is added to service `DataCatalog` ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))
- A new method `RetrieveConfig` is added to service `DataCatalog` ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))
- A new method `RetrieveEffectiveConfig` is added to service `DataCatalog` ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))
- A new field `transferred_to_dataplex` is added to message `.google.cloud.datacatalog.v1.EntryGroup` ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))
- A new message `SetConfigRequest` is added ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))
- A new message `RetrieveConfigRequest` is added ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))
- A new message `RetrieveEffectiveConfigRequest` is added ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))
- A new enum `TagTemplateMigration` is added ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))
- A new enum `CatalogUIExperience` is added ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))
- A new message `OrganizationConfig` is added ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))
- A new message `MigrationConfig` is added ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))
- A new field `dataplex_transfer_status` is added to message `.google.cloud.datacatalog.v1.Tag` ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))
- A new value `TRANSFERRED` is added to enum `DataplexTransferStatus` ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))

### Documentation improvements

- A comment for message `EntryGroup` is changed ([commit 18d632f](https://github.com/googleapis/google-cloud-dotnet/commit/18d632f1b2f5619693af0e37bda54769c6eb4913))
