### PR TITLE
Release Google.Cloud.Deploy.V1 version 3.4.0

### DIFF
--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.3.0</Version>
+    <Version>3.4.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Deploy API, which automates delivery of your applications to a series of target environments in a defined sequence.</Description>

--- a/apis/Google.Cloud.Deploy.V1/docs/history.md
+++ b/apis/Google.Cloud.Deploy.V1/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+## Version 3.4.0, released 2024-12-06
+
+### New features
+
+- A new field `dns_endpoint` is added to message `.google.cloud.deploy.v1.GkeCluster` ([commit c6f4346](https://github.com/googleapis/google-cloud-dotnet/commit/c6f4346c72e659d51c1e906283cd173d60048dcf))
+
+### Documentation improvements
+
+- A comment for field `internal_ip` in message `.google.cloud.deploy.v1.GkeCluster` is changed ([commit c6f4346](https://github.com/googleapis/google-cloud-dotnet/commit/c6f4346c72e659d51c1e906283cd173d60048dcf))
+- A comment for field `skaffold_version` in message `.google.cloud.deploy.v1.Release` is changed ([commit c6f4346](https://github.com/googleapis/google-cloud-dotnet/commit/c6f4346c72e659d51c1e906283cd173d60048dcf))
+- A comment for field `requested_cancellation` in message `.google.cloud.deploy.v1.OperationMetadata` is changed ([commit c6f4346](https://github.com/googleapis/google-cloud-dotnet/commit/c6f4346c72e659d51c1e906283cd173d60048dcf))
+- Documentation improvements. `skaffold_version` field is no longer explicitly marked as optional ([commit 5671fb8](https://github.com/googleapis/google-cloud-dotnet/commit/5671fb8301dc3e79894b949bf95f719b5b6bb129))
+- Minor documentation updates ([commit efd4894](https://github.com/googleapis/google-cloud-dotnet/commit/efd4894b04409faa2bf3a49ece329315a11afb7a))
+
 ## Version 3.3.0, released 2024-11-18
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -1942,7 +1942,7 @@
     },
     {
       "id": "Google.Cloud.Deploy.V1",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "type": "grpc",
       "productName": "Google Cloud Deploy",
       "productUrl": "https://cloud.google.com/deploy/",


### PR DESCRIPTION

Changes in this release:

### New features

- A new field `dns_endpoint` is added to message `.google.cloud.deploy.v1.GkeCluster` ([commit c6f4346](https://github.com/googleapis/google-cloud-dotnet/commit/c6f4346c72e659d51c1e906283cd173d60048dcf))

### Documentation improvements

- A comment for field `internal_ip` in message `.google.cloud.deploy.v1.GkeCluster` is changed ([commit c6f4346](https://github.com/googleapis/google-cloud-dotnet/commit/c6f4346c72e659d51c1e906283cd173d60048dcf))
- A comment for field `skaffold_version` in message `.google.cloud.deploy.v1.Release` is changed ([commit c6f4346](https://github.com/googleapis/google-cloud-dotnet/commit/c6f4346c72e659d51c1e906283cd173d60048dcf))
- A comment for field `requested_cancellation` in message `.google.cloud.deploy.v1.OperationMetadata` is changed ([commit c6f4346](https://github.com/googleapis/google-cloud-dotnet/commit/c6f4346c72e659d51c1e906283cd173d60048dcf))
- Documentation improvements. `skaffold_version` field is no longer explicitly marked as optional ([commit 5671fb8](https://github.com/googleapis/google-cloud-dotnet/commit/5671fb8301dc3e79894b949bf95f719b5b6bb129))
- Minor documentation updates ([commit efd4894](https://github.com/googleapis/google-cloud-dotnet/commit/efd4894b04409faa2bf3a49ece329315a11afb7a))
