### PR TITLE
Release Google.Cloud.Dialogflow.V2 version 4.24.0

### DIFF
--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.23.0</Version>
+    <Version>4.24.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Dialogflow API (v2).</Description>

--- a/apis/Google.Cloud.Dialogflow.V2/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.V2/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 4.24.0, released 2024-12-06
+
+### New features
+
+- Properly mark TrainingPhrase name field output-only ([commit d336935](https://github.com/googleapis/google-cloud-dotnet/commit/d336935d53910959377f0437f88cee1f1577ebf9))
+
+### Documentation improvements
+
+- Fixed the references to proto method / fields ([commit d336935](https://github.com/googleapis/google-cloud-dotnet/commit/d336935d53910959377f0437f88cee1f1577ebf9))
+
 ## Version 4.23.0, released 2024-11-18
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2111,7 +2111,7 @@
       "protoPath": "google/cloud/dialogflow/v2",
       "productName": "Google Cloud Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow-enterprise/",
-      "version": "4.23.0",
+      "version": "4.24.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Dialogflow API (v2).",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Properly mark TrainingPhrase name field output-only ([commit d336935](https://github.com/googleapis/google-cloud-dotnet/commit/d336935d53910959377f0437f88cee1f1577ebf9))

### Documentation improvements

- Fixed the references to proto method / fields ([commit d336935](https://github.com/googleapis/google-cloud-dotnet/commit/d336935d53910959377f0437f88cee1f1577ebf9))
