### PR TITLE
Release Google.Cloud.Dialogflow.V2Beta1 version 1.0.0-beta20

### DIFF
--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta19</Version>
+    <Version>1.0.0-beta20</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Dialogflow API (v2beta1).</Description>

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta20, released 2024-12-06
+
+### New features
+
+- Make TrainingPhrase name field output-only ([commit 0436b0d](https://github.com/googleapis/google-cloud-dotnet/commit/0436b0df581bee719f71512c5913c1f38026d47b))
+
 ## Version 1.0.0-beta19, released 2024-11-18
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -2133,7 +2133,7 @@
     },
     {
       "id": "Google.Cloud.Dialogflow.V2Beta1",
-      "version": "1.0.0-beta19",
+      "version": "1.0.0-beta20",
       "type": "grpc",
       "productName": "Google Cloud Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow-enterprise/",


### PR DESCRIPTION

Changes in this release:

### New features

- Make TrainingPhrase name field output-only ([commit 0436b0d](https://github.com/googleapis/google-cloud-dotnet/commit/0436b0df581bee719f71512c5913c1f38026d47b))
