### PR TITLE
Release Google.Cloud.ManagedKafka.V1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.csproj
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Managed Service for Apache Kafka API, which lets you ingest Kafka streams directly into Google Cloud.</Description>

--- a/apis/Google.Cloud.ManagedKafka.V1/docs/history.md
+++ b/apis/Google.Cloud.ManagedKafka.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2024-12-06
+
+### New features
+
+- A new field `satisfies_pzi` is added to message `.google.cloud.managedkafka.v1.Cluster` ([commit bc68dca](https://github.com/googleapis/google-cloud-dotnet/commit/bc68dcac588b1123d9326d57b3baa2b0916c5cbc))
+- A new field `satisfies_pzs` is added to message `.google.cloud.managedkafka.v1.Cluster` ([commit bc68dca](https://github.com/googleapis/google-cloud-dotnet/commit/bc68dcac588b1123d9326d57b3baa2b0916c5cbc))
+
 ## Version 1.0.0-beta01, released 2024-11-19
 
 Initial release.

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3171,7 +3171,7 @@
     },
     {
       "id": "Google.Cloud.ManagedKafka.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Managed Service for Apache Kafka API",
       "productUrl": "https://cloud.google.com/managed-kafka",


### PR DESCRIPTION

Changes in this release:

### New features

- A new field `satisfies_pzi` is added to message `.google.cloud.managedkafka.v1.Cluster` ([commit bc68dca](https://github.com/googleapis/google-cloud-dotnet/commit/bc68dcac588b1123d9326d57b3baa2b0916c5cbc))
- A new field `satisfies_pzs` is added to message `.google.cloud.managedkafka.v1.Cluster` ([commit bc68dca](https://github.com/googleapis/google-cloud-dotnet/commit/bc68dcac588b1123d9326d57b3baa2b0916c5cbc))
