### PR TITLE
Release Google.Cloud.NetworkConnectivity.V1 version 2.9.0

### DIFF
--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.csproj
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.8.0</Version>
+    <Version>2.9.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Network Connectivity API, which provides access to Network Connectivity Center.</Description>
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" VersionOverride="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.3.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.NetworkConnectivity.V1/docs/history.md
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/docs/history.md
@@ -1,5 +1,22 @@
 # Version history
 
+## Version 2.9.0, released 2024-12-06
+
+### New features
+
+- Add Network Connectivity Center APIs for PSC connection propagation through NCC ([commit 8c58bae](https://github.com/googleapis/google-cloud-dotnet/commit/8c58bae15c531aee2eca291d27e713d0dd92c58c))
+- Add Network Connectivity Center APIs for star topology ([commit 8c58bae](https://github.com/googleapis/google-cloud-dotnet/commit/8c58bae15c531aee2eca291d27e713d0dd92c58c))
+- Add Network Connectivity Center APIs for producer VPC spokes ([commit 8c58bae](https://github.com/googleapis/google-cloud-dotnet/commit/8c58bae15c531aee2eca291d27e713d0dd92c58c))
+- Add Network Connectivity Center APIs for dynamic route exchange ([commit 8c58bae](https://github.com/googleapis/google-cloud-dotnet/commit/8c58bae15c531aee2eca291d27e713d0dd92c58c))
+- Add Network Connectivity Center APIs for include export filters ([commit 8c58bae](https://github.com/googleapis/google-cloud-dotnet/commit/8c58bae15c531aee2eca291d27e713d0dd92c58c))
+- Add Network Connectivity Center APIs for include import ranges on hybrid spokes ([commit 8c58bae](https://github.com/googleapis/google-cloud-dotnet/commit/8c58bae15c531aee2eca291d27e713d0dd92c58c))
+
+### Documentation improvements
+
+- Update comment for `ListRoutes` method in service `HubService` to clarify that it lists routes in a route table ([commit 8c58bae](https://github.com/googleapis/google-cloud-dotnet/commit/8c58bae15c531aee2eca291d27e713d0dd92c58c))
+- Update comment for `ListRouteTables` method in service `HubService` to clarify that it lists route tables in a hub ([commit 8c58bae](https://github.com/googleapis/google-cloud-dotnet/commit/8c58bae15c531aee2eca291d27e713d0dd92c58c))
+- Update comment for field `location` in message `.google.cloud.networkconnectivity.v1.Route` to clarify that it's the origin location ([commit 8c58bae](https://github.com/googleapis/google-cloud-dotnet/commit/8c58bae15c531aee2eca291d27e713d0dd92c58c))
+
 ## Version 2.8.0, released 2024-05-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3399,7 +3399,7 @@
     },
     {
       "id": "Google.Cloud.NetworkConnectivity.V1",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "type": "grpc",
       "productName": "Network Connectivity",
       "productUrl": "https://cloud.google.com/network-connectivity/docs/",
@@ -3410,9 +3410,9 @@
         "vpc"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.2.0",
-        "Google.Cloud.Location": "2.2.0",
-        "Google.LongRunning": "3.2.0"
+        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Location": "2.3.0",
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/networkconnectivity/v1",


### PR DESCRIPTION

Changes in this release:

### New features

- Add Network Connectivity Center APIs for PSC connection propagation through NCC ([commit 8c58bae](https://github.com/googleapis/google-cloud-dotnet/commit/8c58bae15c531aee2eca291d27e713d0dd92c58c))
- Add Network Connectivity Center APIs for star topology ([commit 8c58bae](https://github.com/googleapis/google-cloud-dotnet/commit/8c58bae15c531aee2eca291d27e713d0dd92c58c))
- Add Network Connectivity Center APIs for producer VPC spokes ([commit 8c58bae](https://github.com/googleapis/google-cloud-dotnet/commit/8c58bae15c531aee2eca291d27e713d0dd92c58c))
- Add Network Connectivity Center APIs for dynamic route exchange ([commit 8c58bae](https://github.com/googleapis/google-cloud-dotnet/commit/8c58bae15c531aee2eca291d27e713d0dd92c58c))
- Add Network Connectivity Center APIs for include export filters ([commit 8c58bae](https://github.com/googleapis/google-cloud-dotnet/commit/8c58bae15c531aee2eca291d27e713d0dd92c58c))
- Add Network Connectivity Center APIs for include import ranges on hybrid spokes ([commit 8c58bae](https://github.com/googleapis/google-cloud-dotnet/commit/8c58bae15c531aee2eca291d27e713d0dd92c58c))

### Documentation improvements

- Update comment for `ListRoutes` method in service `HubService` to clarify that it lists routes in a route table ([commit 8c58bae](https://github.com/googleapis/google-cloud-dotnet/commit/8c58bae15c531aee2eca291d27e713d0dd92c58c))
- Update comment for `ListRouteTables` method in service `HubService` to clarify that it lists route tables in a hub ([commit 8c58bae](https://github.com/googleapis/google-cloud-dotnet/commit/8c58bae15c531aee2eca291d27e713d0dd92c58c))
- Update comment for field `location` in message `.google.cloud.networkconnectivity.v1.Route` to clarify that it's the origin location ([commit 8c58bae](https://github.com/googleapis/google-cloud-dotnet/commit/8c58bae15c531aee2eca291d27e713d0dd92c58c))
