### PR TITLE
Release Google.Cloud.Parallelstore.V1Beta version 1.0.0-beta07

### DIFF
--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.csproj
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta06</Version>
+    <Version>1.0.0-beta07</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to manage the Parallelstore high performance, managed parallel file service.</Description>

--- a/apis/Google.Cloud.Parallelstore.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 1.0.0-beta07, released 2024-12-06
+
+### New features
+
+- A new enum `DeploymentType` is added ([commit f4bafc0](https://github.com/googleapis/google-cloud-dotnet/commit/f4bafc09b48c55492edbccd21defeb11eac7f7b4))
+- A new field `deployment_type` is added to message `.google.cloud.parallelstore.v1beta.Instance` ([commit f4bafc0](https://github.com/googleapis/google-cloud-dotnet/commit/f4bafc09b48c55492edbccd21defeb11eac7f7b4))
+
+### Documentation improvements
+
+- Minor documentation formatting fix for Parallelstore ([commit d348b3a](https://github.com/googleapis/google-cloud-dotnet/commit/d348b3a29f3139e176c8323d5c79a18aa0a9903a))
+- Minor documentation formatting fix for Parallelstore ([commit ff699f3](https://github.com/googleapis/google-cloud-dotnet/commit/ff699f3eed396ca7f80c1c3646ebbb47021b5a8e))
+
 ## Version 1.0.0-beta06, released 2024-09-26
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -3836,7 +3836,7 @@
     },
     {
       "id": "Google.Cloud.Parallelstore.V1Beta",
-      "version": "1.0.0-beta06",
+      "version": "1.0.0-beta07",
       "type": "grpc",
       "productName": "Parallelstore",
       "productUrl": "http://cloud/parallelstore?hl=en",


### PR DESCRIPTION

Changes in this release:

### New features

- A new enum `DeploymentType` is added ([commit f4bafc0](https://github.com/googleapis/google-cloud-dotnet/commit/f4bafc09b48c55492edbccd21defeb11eac7f7b4))
- A new field `deployment_type` is added to message `.google.cloud.parallelstore.v1beta.Instance` ([commit f4bafc0](https://github.com/googleapis/google-cloud-dotnet/commit/f4bafc09b48c55492edbccd21defeb11eac7f7b4))

### Documentation improvements

- Minor documentation formatting fix for Parallelstore ([commit d348b3a](https://github.com/googleapis/google-cloud-dotnet/commit/d348b3a29f3139e176c8323d5c79a18aa0a9903a))
- Minor documentation formatting fix for Parallelstore ([commit ff699f3](https://github.com/googleapis/google-cloud-dotnet/commit/ff699f3eed396ca7f80c1c3646ebbb47021b5a8e))
