### PR TITLE
Release Google.Cloud.Run.V2 version 2.12.0

### DIFF
--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.11.0</Version>
+    <Version>2.12.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Run Admin API (v2)</Description>

--- a/apis/Google.Cloud.Run.V2/docs/history.md
+++ b/apis/Google.Cloud.Run.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.12.0, released 2024-12-06
+
+### New features
+
+- Support manual instance count in Cloud Run for manual scaling feature ([commit aa9150c](https://github.com/googleapis/google-cloud-dotnet/commit/aa9150cacc8005f1c2923220561c9c0c9b9c58f9))
+
 ## Version 2.11.0, released 2024-11-18
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4271,7 +4271,7 @@
     },
     {
       "id": "Google.Cloud.Run.V2",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "type": "grpc",
       "productName": "Cloud Run Admin",
       "productUrl": "https://cloud.google.com/run/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Support manual instance count in Cloud Run for manual scaling feature ([commit aa9150c](https://github.com/googleapis/google-cloud-dotnet/commit/aa9150cacc8005f1c2923220561c9c0c9b9c58f9))
