### PR TITLE
Release Google.Cloud.ServiceDirectory.V1 version 2.6.0

### DIFF
--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.csproj
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Service Directory API version v1, which provides a platform for discovering, publishing, and connecting services.</Description>
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.3.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ServiceDirectory.V1/docs/history.md
+++ b/apis/Google.Cloud.ServiceDirectory.V1/docs/history.md
@@ -1,5 +1,8 @@
 # Version history
 
+## Version 2.6.0, released 2024-12-06
+
+No API changes, just dependency updates.
 ## Version 2.5.0, released 2024-05-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4618,7 +4618,7 @@
     },
     {
       "id": "Google.Cloud.ServiceDirectory.V1",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "type": "grpc",
       "productName": "Service Directory",
       "productUrl": "https://cloud.google.com/service-directory/",
@@ -4627,8 +4627,8 @@
         "services"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.2.0",
-        "Google.Cloud.Location": "2.2.0"
+        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Location": "2.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/servicedirectory/v1",


### PR DESCRIPTION

Changes in this release:

No API changes, just dependency updates.
