### PR TITLE
Release Google.Cloud.ServiceHealth.V1 version 1.3.0

### DIFF
--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.csproj
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Service Health API, which helps you gain visibility into disruptive events impacting Google Cloud products.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.3.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.ServiceHealth.V1/docs/history.md
+++ b/apis/Google.Cloud.ServiceHealth.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.3.0, released 2024-12-06
+
+### New features
+
+- A new field `id` is added to message `.google.cloud.servicehealth.v1.Product` ([commit 301a0ac](https://github.com/googleapis/google-cloud-dotnet/commit/301a0ac27f7ae2344669304defd742e6cf972ace))
+
+### Documentation improvements
+
+- Add missing doc comments ([commit 50a2121](https://github.com/googleapis/google-cloud-dotnet/commit/50a212138886f95eccbe68beb8aa6a0ca462dc48))
+
 ## Version 1.2.0, released 2024-05-14
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -4662,7 +4662,7 @@
     },
     {
       "id": "Google.Cloud.ServiceHealth.V1",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "type": "grpc",
       "productName": "Service Health",
       "productUrl": "https://cloud.google.com/service-health/docs/overview",
@@ -4671,7 +4671,7 @@
         "monitoring"
       ],
       "dependencies": {
-        "Google.Cloud.Location": "2.2.0"
+        "Google.Cloud.Location": "2.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/servicehealth/v1",


### PR DESCRIPTION

Changes in this release:

### New features

- A new field `id` is added to message `.google.cloud.servicehealth.v1.Product` ([commit 301a0ac](https://github.com/googleapis/google-cloud-dotnet/commit/301a0ac27f7ae2344669304defd742e6cf972ace))

### Documentation improvements

- Add missing doc comments ([commit 50a2121](https://github.com/googleapis/google-cloud-dotnet/commit/50a212138886f95eccbe68beb8aa6a0ca462dc48))
