### PR TITLE
Release Google.Maps.Routing.V2 version 1.0.0-beta15

### DIFF
--- a/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2/Google.Maps.Routing.V2.csproj
+++ b/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2/Google.Maps.Routing.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta14</Version>
+    <Version>1.0.0-beta15</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Routes Preferred API.</Description>

--- a/apis/Google.Maps.Routing.V2/docs/history.md
+++ b/apis/Google.Maps.Routing.V2/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 1.0.0-beta15, released 2024-12-06
+
+### New features
+
+- Add API for experimental flyover and narrow road polyline details ([commit bfd5a3b](https://github.com/googleapis/google-cloud-dotnet/commit/bfd5a3b5d8ae03239a0148b356035905b6a0506b))
+- Add API for shorter distance reference routes ([commit be57837](https://github.com/googleapis/google-cloud-dotnet/commit/be578371af3db0375bc2dc6991033d6b93c8b911))
+
 ## Version 1.0.0-beta14, released 2024-05-08
 
 ### New features

--- a/apis/apis.json
+++ b/apis/apis.json
@@ -5975,7 +5975,7 @@
     },
     {
       "id": "Google.Maps.Routing.V2",
-      "version": "1.0.0-beta14",
+      "version": "1.0.0-beta15",
       "type": "grpc",
       "productName": "Maps Routing",
       "productUrl": "https://developers.google.com/maps/documentation/routes_preferred",


### PR DESCRIPTION

Changes in this release:

### New features

- Add API for experimental flyover and narrow road polyline details ([commit bfd5a3b](https://github.com/googleapis/google-cloud-dotnet/commit/bfd5a3b5d8ae03239a0148b356035905b6a0506b))
- Add API for shorter distance reference routes ([commit be57837](https://github.com/googleapis/google-cloud-dotnet/commit/be578371af3db0375bc2dc6991033d6b93c8b911))
