### PR TITLE
Release Google.Apps.Chat.V1 version 1.0.0-beta10

### DIFF
--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/Google.Apps.Chat.V1.csproj
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/Google.Apps.Chat.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta09</Version>
+    <Version>1.0.0-beta10</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Chat API, which lets you build Chat apps to integrate your services with Google Chat and manage Chat resources such as spaces, members, and messages.</Description>

--- a/apis/Google.Apps.Chat.V1/docs/history.md
+++ b/apis/Google.Apps.Chat.V1/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+## Version 1.0.0-beta10, released 2024-12-12
+
+### Bug fixes
+
+- **BREAKING CHANGE** Changed field behavior for an existing field `update_mask` and `emoji` ([commit ec46bf2](https://github.com/googleapis/google-cloud-dotnet/commit/ec46bf2c127a0367e182b8e90874911d2a3f5635))
+
+### New features
+
+- Add missing field annotations in space.proto, message.proto, reaction.proto, space_event.proto, membership.proto, attachment.proto ([commit ec46bf2](https://github.com/googleapis/google-cloud-dotnet/commit/ec46bf2c127a0367e182b8e90874911d2a3f5635))
+
+### Documentation improvements
+
+- Update field annotations in space.proto, message.proto, reaction.proto, space_event.proto, membership.proto, attachment.proto ([commit ec46bf2](https://github.com/googleapis/google-cloud-dotnet/commit/ec46bf2c127a0367e182b8e90874911d2a3f5635))
+
 ## Version 1.0.0-beta09, released 2024-12-06
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -119,7 +119,7 @@
     },
     {
       "id": "Google.Apps.Chat.V1",
-      "version": "1.0.0-beta09",
+      "version": "1.0.0-beta10",
       "type": "grpc",
       "productName": "Google Chat",
       "productUrl": "https://developers.google.com/chat/concepts",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Changed field behavior for an existing field `update_mask` and `emoji` ([commit ec46bf2](https://github.com/googleapis/google-cloud-dotnet/commit/ec46bf2c127a0367e182b8e90874911d2a3f5635))

### New features

- Add missing field annotations in space.proto, message.proto, reaction.proto, space_event.proto, membership.proto, attachment.proto ([commit ec46bf2](https://github.com/googleapis/google-cloud-dotnet/commit/ec46bf2c127a0367e182b8e90874911d2a3f5635))

### Documentation improvements

- Update field annotations in space.proto, message.proto, reaction.proto, space_event.proto, membership.proto, attachment.proto ([commit ec46bf2](https://github.com/googleapis/google-cloud-dotnet/commit/ec46bf2c127a0367e182b8e90874911d2a3f5635))
