### PR TITLE
Release Google.Cloud.AIPlatform.V1Beta1 version 1.0.0-beta12

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta11</Version>
+    <Version>1.0.0-beta12</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform API (v1beta), which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.3.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 1.0.0-beta12, released 2024-12-12
+
+### New features
+
+- Add LLM parser proto to API ([commit 239b1c1](https://github.com/googleapis/google-cloud-dotnet/commit/239b1c14269962f5813649a2e34c77808fdaceaf))
+- Add Tool.GoogleSearch ([commit ec1d79d](https://github.com/googleapis/google-cloud-dotnet/commit/ec1d79d7d0a431eae959ffb5e25b641ab6ff08e1))
+- Add GenerationConfig.Modality ([commit ec1d79d](https://github.com/googleapis/google-cloud-dotnet/commit/ec1d79d7d0a431eae959ffb5e25b641ab6ff08e1))
+- Add GenerationConfig.SpeechConfig ([commit ec1d79d](https://github.com/googleapis/google-cloud-dotnet/commit/ec1d79d7d0a431eae959ffb5e25b641ab6ff08e1))
+- Add GenerationConfig.MediaResolution ([commit ec1d79d](https://github.com/googleapis/google-cloud-dotnet/commit/ec1d79d7d0a431eae959ffb5e25b641ab6ff08e1))
+- Enable FeatureGroup Service Account and IAM methods ([commit 6ee5a6b](https://github.com/googleapis/google-cloud-dotnet/commit/6ee5a6b34a6ab2f578644575d1de804dfa7eabc0))
+- A new value `NVIDIA_H100_MEGA_80GB` is added to enum `AcceleratorType` ([commit 0ced559](https://github.com/googleapis/google-cloud-dotnet/commit/0ced559c9981dfe9edee669f822ecf476480fcdb))
+- A new field `list_all_versions` to `ListPublisherModelsRequest` ([commit afd7734](https://github.com/googleapis/google-cloud-dotnet/commit/afd7734b115d6cad9ca3f094e60f08cc261c4134))
+
 ## Version 1.0.0-beta11, released 2024-12-06
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -373,7 +373,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1Beta1",
-      "version": "1.0.0-beta11",
+      "version": "1.0.0-beta12",
       "type": "grpc",
       "productName": "Cloud AI Platform",
       "productUrl": "https://cloud.google.com/ai-platform/docs/",
@@ -383,7 +383,7 @@
         "ml"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Iam.V1": "3.4.0",
         "Google.Cloud.Location": "2.3.0",
         "Google.LongRunning": "3.3.0"
       },


### PR DESCRIPTION

Changes in this release:

### New features

- Add LLM parser proto to API ([commit 239b1c1](https://github.com/googleapis/google-cloud-dotnet/commit/239b1c14269962f5813649a2e34c77808fdaceaf))
- Add Tool.GoogleSearch ([commit ec1d79d](https://github.com/googleapis/google-cloud-dotnet/commit/ec1d79d7d0a431eae959ffb5e25b641ab6ff08e1))
- Add GenerationConfig.Modality ([commit ec1d79d](https://github.com/googleapis/google-cloud-dotnet/commit/ec1d79d7d0a431eae959ffb5e25b641ab6ff08e1))
- Add GenerationConfig.SpeechConfig ([commit ec1d79d](https://github.com/googleapis/google-cloud-dotnet/commit/ec1d79d7d0a431eae959ffb5e25b641ab6ff08e1))
- Add GenerationConfig.MediaResolution ([commit ec1d79d](https://github.com/googleapis/google-cloud-dotnet/commit/ec1d79d7d0a431eae959ffb5e25b641ab6ff08e1))
- Enable FeatureGroup Service Account and IAM methods ([commit 6ee5a6b](https://github.com/googleapis/google-cloud-dotnet/commit/6ee5a6b34a6ab2f578644575d1de804dfa7eabc0))
- A new value `NVIDIA_H100_MEGA_80GB` is added to enum `AcceleratorType` ([commit 0ced559](https://github.com/googleapis/google-cloud-dotnet/commit/0ced559c9981dfe9edee669f822ecf476480fcdb))
- A new field `list_all_versions` to `ListPublisherModelsRequest` ([commit afd7734](https://github.com/googleapis/google-cloud-dotnet/commit/afd7734b115d6cad9ca3f094e60f08cc261c4134))
