### PR TITLE
Release Google.Cloud.Config.V1 version 1.6.0

### DIFF
--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1/Google.Cloud.Config.V1.csproj
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1/Google.Cloud.Config.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.5.0</Version>
+    <Version>1.6.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Infrastructure Manager API, which creates and manages Google Cloud Platform resources and infrastructure.</Description>
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" VersionOverride="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.3.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Config.V1/docs/history.md
+++ b/apis/Google.Cloud.Config.V1/docs/history.md
@@ -1,5 +1,20 @@
 # Version history
 
+## Version 1.6.0, released 2024-12-12
+
+### Bug fixes
+
+- Changed field behavior for an existing field `service_account` in message `.google.cloud.config.v1.Deployment` ([commit 57c3817](https://github.com/googleapis/google-cloud-dotnet/commit/57c3817524f12a40c5756fa6820df75c5a92a90f))
+- Changed field behavior for an existing field `service_account` in message `.google.cloud.config.v1.Preview` ([commit 57c3817](https://github.com/googleapis/google-cloud-dotnet/commit/57c3817524f12a40c5756fa6820df75c5a92a90f))
+
+### New features
+
+- Added annotations ([commit 57c3817](https://github.com/googleapis/google-cloud-dotnet/commit/57c3817524f12a40c5756fa6820df75c5a92a90f))
+
+### Documentation improvements
+
+- Service Account is a required field ([commit 57c3817](https://github.com/googleapis/google-cloud-dotnet/commit/57c3817524f12a40c5756fa6820df75c5a92a90f))
+
 ## Version 1.5.0, released 2024-04-29
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -1618,7 +1618,7 @@
     },
     {
       "id": "Google.Cloud.Config.V1",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "type": "grpc",
       "productName": "Infrastructure Manager",
       "productUrl": "https://cloud.google.com/infrastructure-manager/docs/overview",
@@ -1629,9 +1629,9 @@
         "resources"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.2.0",
-        "Google.Cloud.Location": "2.2.0",
-        "Google.LongRunning": "3.2.0"
+        "Google.Cloud.Iam.V1": "3.4.0",
+        "Google.Cloud.Location": "2.3.0",
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/config/v1",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Changed field behavior for an existing field `service_account` in message `.google.cloud.config.v1.Deployment` ([commit 57c3817](https://github.com/googleapis/google-cloud-dotnet/commit/57c3817524f12a40c5756fa6820df75c5a92a90f))
- Changed field behavior for an existing field `service_account` in message `.google.cloud.config.v1.Preview` ([commit 57c3817](https://github.com/googleapis/google-cloud-dotnet/commit/57c3817524f12a40c5756fa6820df75c5a92a90f))

### New features

- Added annotations ([commit 57c3817](https://github.com/googleapis/google-cloud-dotnet/commit/57c3817524f12a40c5756fa6820df75c5a92a90f))

### Documentation improvements

- Service Account is a required field ([commit 57c3817](https://github.com/googleapis/google-cloud-dotnet/commit/57c3817524f12a40c5756fa6820df75c5a92a90f))
