### PR TITLE
Release Google.Shopping.Merchant.Products.V1Beta version 1.0.0-beta02

### DIFF
--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.csproj
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Merchant Products API (v1beta) which allows you to programmatically manage your Merchant Center accounts.</Description>

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/docs/history.md
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/docs/history.md
@@ -1,5 +1,33 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2024-12-12
+
+### Bug fixes
+
+- **BREAKING CHANGE** Changed repeated flag of an existing field `gtin` in message `.google.shopping.merchant.products.v1beta.Attributes` ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
+- **BREAKING CHANGE** An existing field `gtin` is moved out of oneof in message `.google.shopping.merchant.products.v1beta.Attributes` ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
+
+### New features
+
+- A new field `member_price_effective_date` is added to message `.google.shopping.merchant.products.v1beta.LoyaltyProgram` ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
+- A new field `shipping_label` is added to message `.google.shopping.merchant.products.v1beta.LoyaltyProgram` ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
+
+### Documentation improvements
+
+- A comment for message `ProductInput` is changed ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
+- A comment for field `name` in message `.google.shopping.merchant.products.v1beta.ProductInput` is changed ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
+- A comment for field `name` in message `.google.shopping.merchant.products.v1beta.DeleteProductInputRequest` is changed ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
+- A comment for message `Product` is changed ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
+- A comment for field `name` in message `.google.shopping.merchant.products.v1beta.Product` is changed ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
+- A comment for field `name` in message `.google.shopping.merchant.products.v1beta.GetProductRequest` is changed ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
+- A comment for field `page_size` in message `.google.shopping.merchant.products.v1beta.ListProductsRequest` is changed ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
+- A comment for field `gtin` in message `.google.shopping.merchant.products.v1beta.Attributes` is changed ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
+- A comment for field `tax_category` in message `.google.shopping.merchant.products.v1beta.Attributes` is changed ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
+- A comment for field `min_handling_time` in message `.google.shopping.merchant.products.v1beta.Shipping` is changed ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
+- A comment for field `max_handling_time` in message `.google.shopping.merchant.products.v1beta.Shipping` is changed ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
+- A comment for field `min_transit_time` in message `.google.shopping.merchant.products.v1beta.Shipping` is changed ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
+- A comment for field `max_transit_time` in message `.google.shopping.merchant.products.v1beta.Shipping` is changed ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
+
 ## Version 1.0.0-beta01, released 2024-06-13
 
 Initial release.

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -6280,7 +6280,7 @@
     },
     {
       "id": "Google.Shopping.Merchant.Products.V1Beta",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Merchant",
       "productUrl": "https://developers.google.com/merchant/api",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Changed repeated flag of an existing field `gtin` in message `.google.shopping.merchant.products.v1beta.Attributes` ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
- **BREAKING CHANGE** An existing field `gtin` is moved out of oneof in message `.google.shopping.merchant.products.v1beta.Attributes` ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))

### New features

- A new field `member_price_effective_date` is added to message `.google.shopping.merchant.products.v1beta.LoyaltyProgram` ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
- A new field `shipping_label` is added to message `.google.shopping.merchant.products.v1beta.LoyaltyProgram` ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))

### Documentation improvements

- A comment for message `ProductInput` is changed ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
- A comment for field `name` in message `.google.shopping.merchant.products.v1beta.ProductInput` is changed ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
- A comment for field `name` in message `.google.shopping.merchant.products.v1beta.DeleteProductInputRequest` is changed ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
- A comment for message `Product` is changed ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
- A comment for field `name` in message `.google.shopping.merchant.products.v1beta.Product` is changed ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
- A comment for field `name` in message `.google.shopping.merchant.products.v1beta.GetProductRequest` is changed ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
- A comment for field `page_size` in message `.google.shopping.merchant.products.v1beta.ListProductsRequest` is changed ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
- A comment for field `gtin` in message `.google.shopping.merchant.products.v1beta.Attributes` is changed ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
- A comment for field `tax_category` in message `.google.shopping.merchant.products.v1beta.Attributes` is changed ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
- A comment for field `min_handling_time` in message `.google.shopping.merchant.products.v1beta.Shipping` is changed ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
- A comment for field `max_handling_time` in message `.google.shopping.merchant.products.v1beta.Shipping` is changed ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
- A comment for field `min_transit_time` in message `.google.shopping.merchant.products.v1beta.Shipping` is changed ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
- A comment for field `max_transit_time` in message `.google.shopping.merchant.products.v1beta.Shipping` is changed ([commit da4a57a](https://github.com/googleapis/google-cloud-dotnet/commit/da4a57a076cee8e9534ace58e65a6c159df3c02d))
