### PR TITLE
chore: Add a CloudBuild configuration file for the generator container

### DIFF
--- a/cloudbuild-generator.yaml
+++ b/cloudbuild-generator.yaml
@@ -1,0 +1,32 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+timeout: 21600s  # 6 hours
+options:
+ logging: CLOUD_LOGGING_ONLY
+steps:
+- id: 'build'
+  name: gcr.io/cloud-builders/docker
+  waitFor: ['-']
+  args: [
+    'build', 
+    '-t', 
+    'us-central1-docker.pkg.dev/$PROJECT_ID/pipeline-images/google-cloud-dotnet-generator',
+    '-f',
+    'Dockerfile.generator',
+    '.'
+  ]
+
+images:
+  - us-central1-docker.pkg.dev/$PROJECT_ID/pipeline-images/google-cloud-dotnet-generator


### PR DESCRIPTION
Note that this doesn't build the main repo - just the generator container.