### PR TITLE
Release Google.Cloud.Dialogflow.V2 version 4.25.0

### DIFF
--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.24.0</Version>
+    <Version>4.25.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Dialogflow API (v2).</Description>

--- a/apis/Google.Cloud.Dialogflow.V2/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 4.25.0, released 2024-12-16
+
+### New features
+
+- Add new fields for delivering intermediate transcriptions through PubSub ([commit b94ea2a](https://github.com/googleapis/google-cloud-dotnet/commit/b94ea2a6f6ca0d2551c7471c018da65ee381f65c))
+
 ## Version 4.24.0, released 2024-12-06
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -2151,7 +2151,7 @@
       "protoPath": "google/cloud/dialogflow/v2",
       "productName": "Google Cloud Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow-enterprise/",
-      "version": "4.24.0",
+      "version": "4.25.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Dialogflow API (v2).",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Add new fields for delivering intermediate transcriptions through PubSub ([commit b94ea2a](https://github.com/googleapis/google-cloud-dotnet/commit/b94ea2a6f6ca0d2551c7471c018da65ee381f65c))
