### PR TITLE
Release Google.Cloud.Dialogflow.V2Beta1 version 1.0.0-beta21

### DIFF
--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta20</Version>
+    <Version>1.0.0-beta21</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Dialogflow API (v2beta1).</Description>

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta21, released 2024-12-16
+
+### New features
+
+- Add new fields for delivering intermediate transcriptions through PubSub ([commit 82c1063](https://github.com/googleapis/google-cloud-dotnet/commit/82c10635d9faad47a724e503f4e8658c25e2b486))
+
 ## Version 1.0.0-beta20, released 2024-12-06
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -2173,7 +2173,7 @@
     },
     {
       "id": "Google.Cloud.Dialogflow.V2Beta1",
-      "version": "1.0.0-beta20",
+      "version": "1.0.0-beta21",
       "type": "grpc",
       "productName": "Google Cloud Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow-enterprise/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add new fields for delivering intermediate transcriptions through PubSub ([commit 82c1063](https://github.com/googleapis/google-cloud-dotnet/commit/82c10635d9faad47a724e503f4e8658c25e2b486))
