### PR TITLE
Release Google.Cloud.Monitoring.V3 version 3.13.0

### DIFF
--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.12.0</Version>
+    <Version>3.13.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Monitoring API, which manages your Google Cloud Monitoring data and configurations.</Description>

--- a/apis/Google.Cloud.Monitoring.V3/docs/history.md
+++ b/apis/Google.Cloud.Monitoring.V3/docs/history.md
@@ -1,5 +1,20 @@
 # Version history
 
+## Version 3.13.0, released 2024-12-16
+
+### New features
+
+- Added SqlCondition in AlertPolicy ([commit 7468d5b](https://github.com/googleapis/google-cloud-dotnet/commit/7468d5befb4869909881424998f3be0a12467abe))
+- Added PrometheusQueryLanguageCondition.disable_metric_validation ([commit 7468d5b](https://github.com/googleapis/google-cloud-dotnet/commit/7468d5befb4869909881424998f3be0a12467abe))
+- Deprecated QueryTimeSeries (MQL query endpoint) ([commit 7468d5b](https://github.com/googleapis/google-cloud-dotnet/commit/7468d5befb4869909881424998f3be0a12467abe))
+- Added TimeSeries.description for input only ([commit 7468d5b](https://github.com/googleapis/google-cloud-dotnet/commit/7468d5befb4869909881424998f3be0a12467abe))
+
+### Documentation improvements
+
+- TimeSeries.unit allows limited updating by CreateTimeSeries ([commit 7468d5b](https://github.com/googleapis/google-cloud-dotnet/commit/7468d5befb4869909881424998f3be0a12467abe))
+- ServiceLevelObjective.goal must be <= 0.9999 ([commit 7468d5b](https://github.com/googleapis/google-cloud-dotnet/commit/7468d5befb4869909881424998f3be0a12467abe))
+- ServiceAgentAuthentication supports generating an OAuth token ([commit 7468d5b](https://github.com/googleapis/google-cloud-dotnet/commit/7468d5befb4869909881424998f3be0a12467abe))
+
 ## Version 3.12.0, released 2024-12-06
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -3428,7 +3428,7 @@
       "protoPath": "google/monitoring/v3",
       "productName": "Google Cloud Monitoring",
       "productUrl": "https://cloud.google.com/monitoring/api/v3/",
-      "version": "3.12.0",
+      "version": "3.13.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Monitoring API, which manages your Google Cloud Monitoring data and configurations.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Added SqlCondition in AlertPolicy ([commit 7468d5b](https://github.com/googleapis/google-cloud-dotnet/commit/7468d5befb4869909881424998f3be0a12467abe))
- Added PrometheusQueryLanguageCondition.disable_metric_validation ([commit 7468d5b](https://github.com/googleapis/google-cloud-dotnet/commit/7468d5befb4869909881424998f3be0a12467abe))
- Deprecated QueryTimeSeries (MQL query endpoint) ([commit 7468d5b](https://github.com/googleapis/google-cloud-dotnet/commit/7468d5befb4869909881424998f3be0a12467abe))
- Added TimeSeries.description for input only ([commit 7468d5b](https://github.com/googleapis/google-cloud-dotnet/commit/7468d5befb4869909881424998f3be0a12467abe))

### Documentation improvements

- TimeSeries.unit allows limited updating by CreateTimeSeries ([commit 7468d5b](https://github.com/googleapis/google-cloud-dotnet/commit/7468d5befb4869909881424998f3be0a12467abe))
- ServiceLevelObjective.goal must be <= 0.9999 ([commit 7468d5b](https://github.com/googleapis/google-cloud-dotnet/commit/7468d5befb4869909881424998f3be0a12467abe))
- ServiceAgentAuthentication supports generating an OAuth token ([commit 7468d5b](https://github.com/googleapis/google-cloud-dotnet/commit/7468d5befb4869909881424998f3be0a12467abe))
