### PR TITLE
fix: Set environment variables used by pre/postgeneration scripts

### DIFF
--- a/tools/Google.Cloud.Tools.ReleaseManager/ContainerCommands/GenerateCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/ContainerCommands/GenerateCommand.cs
@@ -56,6 +56,11 @@ internal class GenerateCommand : IContainerCommand
         }
         else
         {
+            // Set environment variables used by scripts invoked by GenerateApisCommand.
+            Environment.SetEnvironmentVariable(GenerateApisCommand.GeneratorInputDirectoryEnvironmentVariable, rootLayout.GeneratorInput);
+            Environment.SetEnvironmentVariable(GenerateApisCommand.GeneratorOutputDirectoryEnvironmentVariable, rootLayout.GeneratorOutput);
+            Environment.SetEnvironmentVariable(GenerateApisCommand.GoogleApisDirectoryEnvironmentVariable, rootLayout.Googleapis);
+
             if (apiPath is not null)
             {
                 var catalog = ApiCatalog.Load(rootLayout);


### PR DESCRIPTION
These were removed when refactoring GenerateApisCommand, as that no longer picks the values up from the environment when provided with a root layout - but we still want to be able to refer to them from the scripts.