### PR TITLE
Release Google.Cloud.AIPlatform.V1Beta1 version 1.0.0-beta13

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta12</Version>
+    <Version>1.0.0-beta13</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform API (v1beta), which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 1.0.0-beta13, released 2025-01-06
+
+### New features
+
+- Add Model Garden deploy API ([commit bc4928d](https://github.com/googleapis/google-cloud-dotnet/commit/bc4928dd78560d2cf7854bc37cb9f4f63f269cef))
+- Add a new thought field in content proto ([commit f267357](https://github.com/googleapis/google-cloud-dotnet/commit/f26735783a4d532cc78c933b05a1c552ce2f6c9b))
+
+### Documentation improvements
+
+- A comment for field `labels` in message `.google.cloud.aiplatform.v1beta1.PublisherModel` is changed ([commit bc4928d](https://github.com/googleapis/google-cloud-dotnet/commit/bc4928dd78560d2cf7854bc37cb9f4f63f269cef))
+
 ## Version 1.0.0-beta12, released 2024-12-12
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -373,7 +373,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1Beta1",
-      "version": "1.0.0-beta12",
+      "version": "1.0.0-beta13",
       "type": "grpc",
       "productName": "Cloud AI Platform",
       "productUrl": "https://cloud.google.com/ai-platform/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add Model Garden deploy API ([commit bc4928d](https://github.com/googleapis/google-cloud-dotnet/commit/bc4928dd78560d2cf7854bc37cb9f4f63f269cef))
- Add a new thought field in content proto ([commit f267357](https://github.com/googleapis/google-cloud-dotnet/commit/f26735783a4d532cc78c933b05a1c552ce2f6c9b))

### Documentation improvements

- A comment for field `labels` in message `.google.cloud.aiplatform.v1beta1.PublisherModel` is changed ([commit bc4928d](https://github.com/googleapis/google-cloud-dotnet/commit/bc4928dd78560d2cf7854bc37cb9f4f63f269cef))
