### PR TITLE
Release Google.Cloud.Dataplex.V1 version 3.5.0

### DIFF
--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.csproj
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.4.0</Version>
+    <Version>3.5.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataplex API, which is used to manage the lifecycle of data lakes.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.3.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />

--- a/apis/Google.Cloud.Dataplex.V1/docs/history.md
+++ b/apis/Google.Cloud.Dataplex.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.5.0, released 2025-01-06
+
+### New features
+
+- A new field `force` is added to message `.google.cloud.dataplex.v1.DeleteDataScanRequest` ([commit cd7c4a2](https://github.com/googleapis/google-cloud-dotnet/commit/cd7c4a21176ae7da80669defa9da0550c7bf5470))
+
+### Documentation improvements
+
+- Miscellaneous doc updates ([commit cd7c4a2](https://github.com/googleapis/google-cloud-dotnet/commit/cd7c4a21176ae7da80669defa9da0550c7bf5470))
+
 ## Version 3.4.0, released 2024-11-18
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -1823,7 +1823,7 @@
     },
     {
       "id": "Google.Cloud.Dataplex.V1",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "type": "grpc",
       "productName": "Cloud Dataplex",
       "productUrl": "https://cloud.google.com/dataplex/docs",
@@ -1833,7 +1833,7 @@
         "dataplex"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Iam.V1": "3.4.0",
         "Google.Cloud.Location": "2.3.0",
         "Google.LongRunning": "3.3.0"
       },


### PR DESCRIPTION

Changes in this release:

### New features

- A new field `force` is added to message `.google.cloud.dataplex.v1.DeleteDataScanRequest` ([commit cd7c4a2](https://github.com/googleapis/google-cloud-dotnet/commit/cd7c4a21176ae7da80669defa9da0550c7bf5470))

### Documentation improvements

- Miscellaneous doc updates ([commit cd7c4a2](https://github.com/googleapis/google-cloud-dotnet/commit/cd7c4a21176ae7da80669defa9da0550c7bf5470))
