### PR TITLE
Release Google.Cloud.GkeMultiCloud.V1 version 2.8.0

### DIFF
--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.csproj
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.7.0</Version>
+    <Version>2.8.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Anthos Multi-Cloud API, which provides a way to manage Kubernetes clusters that run on AWS and Azure infrastructure using the Anthos Multi-Cloud API. Combined with Connect, you can manage Kubernetes clusters on Google Cloud, AWS, and Azure from the Google Cloud Console.  When you create a cluster with Anthos Multi-Cloud, Google creates the resources needed and brings up a cluster on your behalf. You can deploy workloads with the Anthos Multi-Cloud API or the gcloud and kubectl command-line tools.</Description>

--- a/apis/Google.Cloud.GkeMultiCloud.V1/docs/history.md
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 2.8.0, released 2025-01-06
+
+### New features
+
+- Added support for optionally disabling built-in GKE metrics ([commit 3170840](https://github.com/googleapis/google-cloud-dotnet/commit/317084009432ca7040b2a6cf1bf1f77efeaee353))
+- Added tag bindings support for Attached Clusters ([commit 3170840](https://github.com/googleapis/google-cloud-dotnet/commit/317084009432ca7040b2a6cf1bf1f77efeaee353))
+
+### Documentation improvements
+
+- Updated comments of existing fields ([commit 3170840](https://github.com/googleapis/google-cloud-dotnet/commit/317084009432ca7040b2a6cf1bf1f77efeaee353))
+
 ## Version 2.7.0, released 2024-09-16
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -2807,7 +2807,7 @@
     },
     {
       "id": "Google.Cloud.GkeMultiCloud.V1",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "type": "grpc",
       "productName": "Anthos Multi-Cloud",
       "productUrl": "https://cloud.google.com/anthos/clusters/docs/multi-cloud",


### PR DESCRIPTION

Changes in this release:

### New features

- Added support for optionally disabling built-in GKE metrics ([commit 3170840](https://github.com/googleapis/google-cloud-dotnet/commit/317084009432ca7040b2a6cf1bf1f77efeaee353))
- Added tag bindings support for Attached Clusters ([commit 3170840](https://github.com/googleapis/google-cloud-dotnet/commit/317084009432ca7040b2a6cf1bf1f77efeaee353))

### Documentation improvements

- Updated comments of existing fields ([commit 3170840](https://github.com/googleapis/google-cloud-dotnet/commit/317084009432ca7040b2a6cf1bf1f77efeaee353))
