### PR TITLE
Release Google.Cloud.StorageTransfer.V1 version 2.8.0

### DIFF
--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.csproj
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.7.0</Version>
+    <Version>2.8.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Transfers data from external data sources to a Google Cloud Storage bucket or between Google Cloud Storage buckets.</Description>

--- a/apis/Google.Cloud.StorageTransfer.V1/docs/history.md
+++ b/apis/Google.Cloud.StorageTransfer.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.8.0, released 2025-01-06
+
+### New features
+
+- Support cross-bucket replication ([commit 7dea52d](https://github.com/googleapis/google-cloud-dotnet/commit/7dea52d9add3fe9892ae97524d1033b8aac145d2))
+
 ## Version 2.7.0, released 2024-09-09
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -5139,7 +5139,7 @@
     },
     {
       "id": "Google.Cloud.StorageTransfer.V1",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "type": "grpc",
       "productName": "Storage Transfer",
       "productUrl": "https://cloud.google.com/storage-transfer-service",


### PR DESCRIPTION

Changes in this release:

### New features

- Support cross-bucket replication ([commit 7dea52d](https://github.com/googleapis/google-cloud-dotnet/commit/7dea52d9add3fe9892ae97524d1033b8aac145d2))
