### PR TITLE
Release Google.Cloud.Talent.V4 version 2.7.0

### DIFF
--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.csproj
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Talent solution API (v4) which provides the capability to create, read, update, and delete job postings, as well as search jobs based on keywords and filters.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.LongRunning" VersionOverride="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Talent.V4/docs/history.md
+++ b/apis/Google.Cloud.Talent.V4/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 2.7.0, released 2025-01-06
+
+### New features
+
+- A new enum `RelevanceThreshold` is added ([commit 45971fe](https://github.com/googleapis/google-cloud-dotnet/commit/45971fe3f5dc4f09ebfa57ea979253085bd78d1a))
+- A new field `relevance_threshold` is added to message `.google.cloud.talent.v4.SearchJobsRequest` ([commit 45971fe](https://github.com/googleapis/google-cloud-dotnet/commit/45971fe3f5dc4f09ebfa57ea979253085bd78d1a))
+
+### Documentation improvements
+
+- Multiple fixes for links in documentation ([commit 45971fe](https://github.com/googleapis/google-cloud-dotnet/commit/45971fe3f5dc4f09ebfa57ea979253085bd78d1a))
+
 ## Version 2.6.0, released 2024-05-14
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -5181,7 +5181,7 @@
     },
     {
       "id": "Google.Cloud.Talent.V4",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "type": "grpc",
       "productName": "Google Cloud Talent Solution",
       "productUrl": "https://cloud.google.com/talent-solution/",
@@ -5191,7 +5191,7 @@
         "Jobs"
       ],
       "dependencies": {
-        "Google.LongRunning": "3.2.0"
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/talent/v4",


### PR DESCRIPTION

Changes in this release:

### New features

- A new enum `RelevanceThreshold` is added ([commit 45971fe](https://github.com/googleapis/google-cloud-dotnet/commit/45971fe3f5dc4f09ebfa57ea979253085bd78d1a))
- A new field `relevance_threshold` is added to message `.google.cloud.talent.v4.SearchJobsRequest` ([commit 45971fe](https://github.com/googleapis/google-cloud-dotnet/commit/45971fe3f5dc4f09ebfa57ea979253085bd78d1a))

### Documentation improvements

- Multiple fixes for links in documentation ([commit 45971fe](https://github.com/googleapis/google-cloud-dotnet/commit/45971fe3f5dc4f09ebfa57ea979253085bd78d1a))
