### PR TITLE
Release Google.Cloud.Talent.V4Beta1 version 3.0.0-beta06

### DIFF
--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.csproj
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-beta05</Version>
+    <Version>3.0.0-beta06</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Talent solution API (v4 beta1) which provides the capability to create, read, update, and delete job postings, as well as search jobs based on keywords and filters.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.LongRunning" VersionOverride="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Talent.V4Beta1/docs/history.md
+++ b/apis/Google.Cloud.Talent.V4Beta1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 3.0.0-beta06, released 2025-01-06
+
+### New features
+
+- A new enum `RelevanceThreshold` is added ([commit d704518](https://github.com/googleapis/google-cloud-dotnet/commit/d70451883734a3c0675a9d646074011da7b0bf5f))
+- A new field `relevance_threshold` is added to message `.google.cloud.talent.v4beta1.SearchJobsRequest` ([commit d704518](https://github.com/googleapis/google-cloud-dotnet/commit/d70451883734a3c0675a9d646074011da7b0bf5f))
+
 ## Version 3.0.0-beta05, released 2024-05-08
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -5207,7 +5207,7 @@
       "protoPath": "google/cloud/talent/v4beta1",
       "productName": "Google Cloud Talent Solution",
       "productUrl": "https://cloud.google.com/talent-solution/",
-      "version": "3.0.0-beta05",
+      "version": "3.0.0-beta06",
       "releaseLevelOverride": "preview",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Talent solution API (v4 beta1) which provides the capability to create, read, update, and delete job postings, as well as search jobs based on keywords and filters.",
@@ -5216,7 +5216,7 @@
         "Jobs"
       ],
       "dependencies": {
-        "Google.LongRunning": "3.2.0"
+        "Google.LongRunning": "3.3.0"
       },
       "shortName": "jobs",
       "serviceConfigFile": "jobs_v4beta1.yaml",


### PR DESCRIPTION

Changes in this release:

### New features

- A new enum `RelevanceThreshold` is added ([commit d704518](https://github.com/googleapis/google-cloud-dotnet/commit/d70451883734a3c0675a9d646074011da7b0bf5f))
- A new field `relevance_threshold` is added to message `.google.cloud.talent.v4beta1.SearchJobsRequest` ([commit d704518](https://github.com/googleapis/google-cloud-dotnet/commit/d70451883734a3c0675a9d646074011da7b0bf5f))
