### PR TITLE
Release Google.Cloud.TextToSpeech.V1Beta1 version 2.0.0-beta12

### DIFF
--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.csproj
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta11</Version>
+    <Version>2.0.0-beta12</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Text-to-Speech API v1beta1, synthesizes natural-sounding speech by applying powerful neural network models.</Description>

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.0.0-beta12, released 2025-01-06
+
+### New features
+
+- StreamingSynthesize now supports opus ([commit f36434a](https://github.com/googleapis/google-cloud-dotnet/commit/f36434ad1f7b73f07e0cd3fa9f4da20c2a6a04aa))
+
 ## Version 2.0.0-beta11, released 2024-10-29
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -5320,7 +5320,7 @@
     },
     {
       "id": "Google.Cloud.TextToSpeech.V1Beta1",
-      "version": "2.0.0-beta11",
+      "version": "2.0.0-beta12",
       "type": "grpc",
       "productName": "Google Cloud Text-to-Speech",
       "productUrl": "https://cloud.google.com/text-to-speech",


### PR DESCRIPTION

Changes in this release:

### New features

- StreamingSynthesize now supports opus ([commit f36434a](https://github.com/googleapis/google-cloud-dotnet/commit/f36434ad1f7b73f07e0cd3fa9f4da20c2a6a04aa))
