### PR TITLE
Prototype of Firestore query explain functionality

### DIFF
--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/AggregateQueryTest.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/AggregateQueryTest.cs
@@ -87,6 +87,32 @@ public class AggregateQueryTest
     }
 
     [Fact]
+    public async Task Sum_Explain()
+    {
+        CollectionReference collection = _fixture.StudentCollection;
+        var plan = await collection
+            .Aggregate(AggregateField.Sum("Level", "Sum_Of_Levels"), AggregateField.Sum("MathScore"), AggregateField.Sum("EnglishScore"), AggregateField.Sum("Name"))
+            .ExplainAsync();
+        Assert.NotNull(plan);
+    }
+
+    [Fact]
+    public async Task Sum_ExplainAnalyze()
+    {
+        CollectionReference collection = _fixture.StudentCollection;
+        var queryProfileInfo = await collection.Aggregate(AggregateField.Sum("Level", "Sum_Of_Levels"), AggregateField.Sum("MathScore"), AggregateField.Sum("EnglishScore"), AggregateField.Sum("Name"))
+            .ExplainAnalyzeAsync();
+        var plan = queryProfileInfo.Plan;
+        var stats = queryProfileInfo.Stats;
+        Assert.NotNull(plan);
+        Assert.NotNull(stats);
+        var snapshot = queryProfileInfo.Snapshot;
+        Assert.Equal(Student.Data.Sum(c => c.Level), snapshot.GetValue<long>("Sum_Of_Levels")); // Long value, Alias check 
+        Assert.Equal(Student.Data.Sum(c => c.MathScore), snapshot.GetValue<double>("Sum_MathScore")); // Double value check
+        Assert.Equal(double.NaN, snapshot.GetValue<double>("Sum_EnglishScore"));  // NaN value check
+    }
+
+    [Fact]
     public async Task Avg()
     {
         CollectionReference collection = _fixture.StudentCollection;

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.sln
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.sln
@@ -3,59 +3,65 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.2.32516.85
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Firestore", "Google.Cloud.Firestore\Google.Cloud.Firestore.csproj", "{23BB3FFF-DC4C-F978-04B5-C5E146893E68}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Firestore", "Google.Cloud.Firestore\Google.Cloud.Firestore.csproj", "{23BB3FFF-DC4C-F978-04B5-C5E146893E68}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Firestore.Benchmarks", "Google.Cloud.Firestore.Benchmarks\Google.Cloud.Firestore.Benchmarks.csproj", "{3B576042-1EF8-EA8B-2554-C5FF11CB3F48}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Firestore.Benchmarks", "Google.Cloud.Firestore.Benchmarks\Google.Cloud.Firestore.Benchmarks.csproj", "{3B576042-1EF8-EA8B-2554-C5FF11CB3F48}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Firestore.CleanTestData", "Google.Cloud.Firestore.CleanTestData\Google.Cloud.Firestore.CleanTestData.csproj", "{1A7F1C0F-72C8-8983-9906-1EA379969C43}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Firestore.CleanTestData", "Google.Cloud.Firestore.CleanTestData\Google.Cloud.Firestore.CleanTestData.csproj", "{1A7F1C0F-72C8-8983-9906-1EA379969C43}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Firestore.IntegrationTests", "Google.Cloud.Firestore.IntegrationTests\Google.Cloud.Firestore.IntegrationTests.csproj", "{ECA6C703-9C4B-5DB6-610C-37217893669E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Firestore.IntegrationTests", "Google.Cloud.Firestore.IntegrationTests\Google.Cloud.Firestore.IntegrationTests.csproj", "{ECA6C703-9C4B-5DB6-610C-37217893669E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Firestore.Snippets", "Google.Cloud.Firestore.Snippets\Google.Cloud.Firestore.Snippets.csproj", "{5AB44017-319A-FA5E-4BB7-AEE4663EA6F8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Firestore.Snippets", "Google.Cloud.Firestore.Snippets\Google.Cloud.Firestore.Snippets.csproj", "{5AB44017-319A-FA5E-4BB7-AEE4663EA6F8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Firestore.Tests", "Google.Cloud.Firestore.Tests\Google.Cloud.Firestore.Tests.csproj", "{3023B3E0-2A3A-0DE8-37B9-FC5DEFC655A7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Firestore.Tests", "Google.Cloud.Firestore.Tests\Google.Cloud.Firestore.Tests.csproj", "{3023B3E0-2A3A-0DE8-37B9-FC5DEFC655A7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{29974B0C-A7B0-8CA8-AE32-99F622C89044}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{29974B0C-A7B0-8CA8-AE32-99F622C89044}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Firestore.V1", "..\Google.Cloud.Firestore.V1\Google.Cloud.Firestore.V1\Google.Cloud.Firestore.V1.csproj", "{73C26D2D-CC8B-10B3-B6AB-5B25E6859268}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Firestore.V1", "..\Google.Cloud.Firestore.V1\Google.Cloud.Firestore.V1\Google.Cloud.Firestore.V1.csproj", "{73C26D2D-CC8B-10B3-B6AB-5B25E6859268}"
 EndProject
 Global
-    GlobalSection(SolutionConfigurationPlatforms) = preSolution
-        Debug|Any CPU = Debug|Any CPU
-        Release|Any CPU = Release|Any CPU
-    EndGlobalSection
-    GlobalSection(ProjectConfigurationPlatforms) = postSolution
-        {23BB3FFF-DC4C-F978-04B5-C5E146893E68}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-        {23BB3FFF-DC4C-F978-04B5-C5E146893E68}.Debug|Any CPU.Build.0 = Debug|Any CPU
-        {23BB3FFF-DC4C-F978-04B5-C5E146893E68}.Release|Any CPU.ActiveCfg = Release|Any CPU
-        {23BB3FFF-DC4C-F978-04B5-C5E146893E68}.Release|Any CPU.Build.0 = Release|Any CPU
-        {3B576042-1EF8-EA8B-2554-C5FF11CB3F48}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-        {3B576042-1EF8-EA8B-2554-C5FF11CB3F48}.Debug|Any CPU.Build.0 = Debug|Any CPU
-        {3B576042-1EF8-EA8B-2554-C5FF11CB3F48}.Release|Any CPU.ActiveCfg = Release|Any CPU
-        {3B576042-1EF8-EA8B-2554-C5FF11CB3F48}.Release|Any CPU.Build.0 = Release|Any CPU
-        {1A7F1C0F-72C8-8983-9906-1EA379969C43}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-        {1A7F1C0F-72C8-8983-9906-1EA379969C43}.Debug|Any CPU.Build.0 = Debug|Any CPU
-        {1A7F1C0F-72C8-8983-9906-1EA379969C43}.Release|Any CPU.ActiveCfg = Release|Any CPU
-        {1A7F1C0F-72C8-8983-9906-1EA379969C43}.Release|Any CPU.Build.0 = Release|Any CPU
-        {ECA6C703-9C4B-5DB6-610C-37217893669E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-        {ECA6C703-9C4B-5DB6-610C-37217893669E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-        {ECA6C703-9C4B-5DB6-610C-37217893669E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-        {ECA6C703-9C4B-5DB6-610C-37217893669E}.Release|Any CPU.Build.0 = Release|Any CPU
-        {5AB44017-319A-FA5E-4BB7-AEE4663EA6F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-        {5AB44017-319A-FA5E-4BB7-AEE4663EA6F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-        {5AB44017-319A-FA5E-4BB7-AEE4663EA6F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-        {5AB44017-319A-FA5E-4BB7-AEE4663EA6F8}.Release|Any CPU.Build.0 = Release|Any CPU
-        {3023B3E0-2A3A-0DE8-37B9-FC5DEFC655A7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-        {3023B3E0-2A3A-0DE8-37B9-FC5DEFC655A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
-        {3023B3E0-2A3A-0DE8-37B9-FC5DEFC655A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
-        {3023B3E0-2A3A-0DE8-37B9-FC5DEFC655A7}.Release|Any CPU.Build.0 = Release|Any CPU
-        {29974B0C-A7B0-8CA8-AE32-99F622C89044}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-        {29974B0C-A7B0-8CA8-AE32-99F622C89044}.Debug|Any CPU.Build.0 = Debug|Any CPU
-        {29974B0C-A7B0-8CA8-AE32-99F622C89044}.Release|Any CPU.ActiveCfg = Release|Any CPU
-        {29974B0C-A7B0-8CA8-AE32-99F622C89044}.Release|Any CPU.Build.0 = Release|Any CPU
-        {73C26D2D-CC8B-10B3-B6AB-5B25E6859268}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-        {73C26D2D-CC8B-10B3-B6AB-5B25E6859268}.Debug|Any CPU.Build.0 = Debug|Any CPU
-        {73C26D2D-CC8B-10B3-B6AB-5B25E6859268}.Release|Any CPU.ActiveCfg = Release|Any CPU
-        {73C26D2D-CC8B-10B3-B6AB-5B25E6859268}.Release|Any CPU.Build.0 = Release|Any CPU
-    EndGlobalSection
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{23BB3FFF-DC4C-F978-04B5-C5E146893E68}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{23BB3FFF-DC4C-F978-04B5-C5E146893E68}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{23BB3FFF-DC4C-F978-04B5-C5E146893E68}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{23BB3FFF-DC4C-F978-04B5-C5E146893E68}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3B576042-1EF8-EA8B-2554-C5FF11CB3F48}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B576042-1EF8-EA8B-2554-C5FF11CB3F48}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B576042-1EF8-EA8B-2554-C5FF11CB3F48}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3B576042-1EF8-EA8B-2554-C5FF11CB3F48}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1A7F1C0F-72C8-8983-9906-1EA379969C43}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1A7F1C0F-72C8-8983-9906-1EA379969C43}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1A7F1C0F-72C8-8983-9906-1EA379969C43}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1A7F1C0F-72C8-8983-9906-1EA379969C43}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ECA6C703-9C4B-5DB6-610C-37217893669E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ECA6C703-9C4B-5DB6-610C-37217893669E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ECA6C703-9C4B-5DB6-610C-37217893669E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ECA6C703-9C4B-5DB6-610C-37217893669E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5AB44017-319A-FA5E-4BB7-AEE4663EA6F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5AB44017-319A-FA5E-4BB7-AEE4663EA6F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5AB44017-319A-FA5E-4BB7-AEE4663EA6F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5AB44017-319A-FA5E-4BB7-AEE4663EA6F8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3023B3E0-2A3A-0DE8-37B9-FC5DEFC655A7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3023B3E0-2A3A-0DE8-37B9-FC5DEFC655A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3023B3E0-2A3A-0DE8-37B9-FC5DEFC655A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3023B3E0-2A3A-0DE8-37B9-FC5DEFC655A7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{29974B0C-A7B0-8CA8-AE32-99F622C89044}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{29974B0C-A7B0-8CA8-AE32-99F622C89044}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{29974B0C-A7B0-8CA8-AE32-99F622C89044}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{29974B0C-A7B0-8CA8-AE32-99F622C89044}.Release|Any CPU.Build.0 = Release|Any CPU
+		{73C26D2D-CC8B-10B3-B6AB-5B25E6859268}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{73C26D2D-CC8B-10B3-B6AB-5B25E6859268}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{73C26D2D-CC8B-10B3-B6AB-5B25E6859268}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{73C26D2D-CC8B-10B3-B6AB-5B25E6859268}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {46F695E8-04B1-4C09-9C59-1101A63C5BE0}
+	EndGlobalSection
 EndGlobal

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/AggregateQuerySnapshot.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/AggregateQuerySnapshot.cs
@@ -28,6 +28,7 @@ public sealed class AggregateQuerySnapshot : IEquatable<AggregateQuerySnapshot>,
     /// The data within the snapshot. This is a MapField as that provides equality and hashing out of the box.
     /// </summary>
     private readonly MapField<string, Value> _data;
+    private readonly Timestamp? _readTime;
 
     /// <summary>
     /// The query producing this snapshot.
@@ -37,7 +38,7 @@ public sealed class AggregateQuerySnapshot : IEquatable<AggregateQuerySnapshot>,
     /// <summary>
     /// The time at which the snapshot was read.
     /// </summary>
-    public Timestamp ReadTime { get; }
+    public Timestamp ReadTime => _readTime ?? throw new InvalidOperationException("No read time available");
 
     /// <summary>
     /// Number of documents that matches the query. May be null when count aggregation is not applied on the Query.
@@ -47,10 +48,10 @@ public sealed class AggregateQuerySnapshot : IEquatable<AggregateQuerySnapshot>,
         value.ValueTypeCase == Value.ValueTypeOneofCase.IntegerValue
         ? value.IntegerValue : null;
 
-    internal AggregateQuerySnapshot(AggregateQuery query, Timestamp readTime, MapField<string, Value> data)
+    internal AggregateQuerySnapshot(AggregateQuery query, Timestamp? readTime, MapField<string, Value> data)
     {
         Query = query;
-        ReadTime = readTime;
+        _readTime = readTime;
         _data = data;
     }
 

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Query.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Query.cs
@@ -703,11 +703,37 @@ namespace Google.Cloud.Firestore
         /// <returns>A snapshot of documents matching the query.</returns>
         public Task<QuerySnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default) => GetSnapshotAsync(null, cancellationToken);
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public async Task<PlanSummary> ExplainAsync(CancellationToken cancellationToken = default)
+        {
+            var profileSnapshot = await GetProfileSnapshotAsync(transactionId: null, explainOptions: new ExplainOptions { Analyze = false }, cancellationToken).ConfigureAwait(false);
+            return profileSnapshot.Plan;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<QueryProfileInfo<QuerySnapshot>> ExplainAnalyzeAsync(CancellationToken cancellationToken = default) =>
+            GetProfileSnapshotAsync(transactionId: null, explainOptions: new ExplainOptions { Analyze = true }, cancellationToken);
+
         internal async Task<QuerySnapshot> GetSnapshotAsync(ByteString transactionId, CancellationToken cancellationToken)
         {
-            var responses = StreamResponsesAsync(transactionId, cancellationToken, allowLimitToLast: true);
+            var profileSnapshot = await GetProfileSnapshotAsync(transactionId, explainOptions: null, cancellationToken).ConfigureAwait(false);
+            return profileSnapshot.Snapshot;
+        }
+
+        private async Task<QueryProfileInfo<QuerySnapshot>> GetProfileSnapshotAsync(ByteString transactionId, ExplainOptions explainOptions, CancellationToken cancellationToken)
+        {
+            var responses = StreamResponsesAsync(transactionId, explainOptions, cancellationToken, allowLimitToLast: true);
             Timestamp? readTime = null;
             List<DocumentSnapshot> snapshots = new List<DocumentSnapshot>();
+            ExplainMetrics metrics = null;
             await responses.ForEachAsync(response =>
             {
                 if (response.Document != null)
@@ -718,16 +744,21 @@ namespace Google.Cloud.Firestore
                 {
                     readTime = Timestamp.FromProto(response.ReadTime);
                 }
+                // This will be set on the last response, so we can always just remember "just the last value we saw".
+                metrics = response.ExplainMetrics;
             }, cancellationToken).ConfigureAwait(false);
 
-            GaxPreconditions.CheckState(readTime != null, "The stream returned from RunQuery did not provide a read timestamp.");
+            GaxPreconditions.CheckState(readTime is not null || explainOptions?.Analyze == false, "The stream returned from RunQuery did not provide a read timestamp.");
+            GaxPreconditions.CheckState(explainOptions is null || metrics is not null, "The stream returned from RunQuery did not provide metrics.");
             if (IsLimitToLast)
             {
                 // Reverse in-place. We *could* create an IReadOnlyList<T> which acted as a "reversing view"
                 // but that seems like unnecessary work for now.
                 snapshots.Reverse();
             }
-            return QuerySnapshot.ForDocuments(this, snapshots.AsReadOnly(), readTime.Value);
+            // We rely on QuerySnapshot.ReadTime not being accessed when we're just doing an explain operation.
+            var snapshot = QuerySnapshot.ForDocuments(this, snapshots.AsReadOnly(), readTime);
+            return new QueryProfileInfo<QuerySnapshot>(snapshot, metrics);
         }
 
         /// <summary>
@@ -753,20 +784,20 @@ namespace Google.Cloud.Firestore
             StreamAsync(transactionId: null, cancellationToken, false);
 
         internal IAsyncEnumerable<DocumentSnapshot> StreamAsync(ByteString transactionId, CancellationToken cancellationToken, bool allowLimitToLast) =>
-             StreamResponsesAsync(transactionId, cancellationToken, allowLimitToLast)
+             StreamResponsesAsync(transactionId, null, cancellationToken, allowLimitToLast)
                 .Where(resp => resp.Document != null)
                 .Select(resp => DocumentSnapshot.ForDocument(Database, resp.Document, Timestamp.FromProto(resp.ReadTime)));
 
         // Implementation note: this uses an iterator block so that we can dispose of the gRPC call
         // appropriately. The code will only execute when GetEnumerator() is called on the returned value,
         // so the gRPC call *will* be disposed so long as the caller disposes of the iterator (or completes it).
-        private async IAsyncEnumerable<RunQueryResponse> StreamResponsesAsync(ByteString transactionId, [EnumeratorCancellation] CancellationToken cancellationToken, bool allowLimitToLast)
+        private async IAsyncEnumerable<RunQueryResponse> StreamResponsesAsync(ByteString transactionId, ExplainOptions explainOptions, [EnumeratorCancellation] CancellationToken cancellationToken, bool allowLimitToLast)
         {
             if (IsLimitToLast && !allowLimitToLast)
             {
                 throw new InvalidOperationException($"Cannot stream responses for query using {nameof(LimitToLast)}");
             }
-            var request = new RunQueryRequest { StructuredQuery = ToStructuredQuery(), Parent = ParentPath };
+            var request = new RunQueryRequest { StructuredQuery = ToStructuredQuery(), Parent = ParentPath, ExplainOptions = explainOptions };
             if (transactionId != null)
             {
                 request.Transaction = transactionId;

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/QueryProfileInfo.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/QueryProfileInfo.cs
@@ -1,0 +1,48 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License"):
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Firestore.V1;
+
+namespace Google.Cloud.Firestore;
+
+/// <summary>
+/// 
+/// </summary>
+/// <typeparam name="T"></typeparam>
+public sealed class QueryProfileInfo<T>
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public T Snapshot { get; }
+
+    // TODO: Expose an IReadOnlyDictionary<string, object> instead?
+    /// <summary>
+    /// The query plan that was executed or profiled.
+    /// </summary>
+    public PlanSummary Plan { get; }
+
+    // TODO: Expose an IReadOnlyDictionary<string, object> instead?
+    /// <summary>
+    /// The stats for the query, or null if the query was only profiled.
+    /// </summary>
+    public ExecutionStats Stats { get; }
+
+    internal QueryProfileInfo(T snapshot, ExplainMetrics metrics)
+    {
+        Snapshot = snapshot;
+        Plan = metrics?.PlanSummary;
+        Stats = metrics?.ExecutionStats;
+    }
+}

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/QuerySnapshot.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/QuerySnapshot.cs
@@ -28,16 +28,17 @@ namespace Google.Cloud.Firestore
     {
         private readonly Lazy<IReadOnlyList<DocumentSnapshot>> _lazyDocumentList;
         private readonly Lazy<IReadOnlyList<DocumentChange>> _lazyChangeList;
+        private readonly Timestamp? _readTime;
 
-        private QuerySnapshot(Query query, Func<IReadOnlyList<DocumentSnapshot>> documentProvider, Func<IReadOnlyList<DocumentChange>> changesProvider, Timestamp readTime)
+        private QuerySnapshot(Query query, Func<IReadOnlyList<DocumentSnapshot>> documentProvider, Func<IReadOnlyList<DocumentChange>> changesProvider, Timestamp? readTime)
         {
             Query = query;
             _lazyDocumentList = new Lazy<IReadOnlyList<DocumentSnapshot>>(documentProvider, LazyThreadSafetyMode.ExecutionAndPublication);
             _lazyChangeList = new Lazy<IReadOnlyList<DocumentChange>>(changesProvider, LazyThreadSafetyMode.ExecutionAndPublication);
-            ReadTime = readTime;
+            _readTime = readTime;
         }
 
-        internal static QuerySnapshot ForDocuments(Query query, IReadOnlyList<DocumentSnapshot> documents, Timestamp readTime) =>
+        internal static QuerySnapshot ForDocuments(Query query, IReadOnlyList<DocumentSnapshot> documents, Timestamp? readTime) =>
             new QuerySnapshot(query, () => documents, () => new LazyChangeList(documents), readTime);
 
         internal static QuerySnapshot ForChanges(Query query, IEnumerable<DocumentSnapshot> documentSet, IReadOnlyList<DocumentChange> changes, Timestamp readTime) =>
@@ -51,7 +52,7 @@ namespace Google.Cloud.Firestore
         /// <summary>
         /// The time at which the snapshot was read.
         /// </summary>
-        public Timestamp ReadTime { get; }
+        public Timestamp ReadTime => _readTime ?? throw new InvalidOperationException("No read time available");
 
         /// <summary>
         /// The documents in the snapshot.


### PR DESCRIPTION
DO NOT MERGE

This is just to demonstrate initial prototyping. Things that need fixing:

- Rename QueryProfileInfo, probably to ExplainResults to match https://github.com/googleapis/java-firestore/pull/1609
- Create new wrapper types for the various outputs (plan summary and explain metrics).
- Possibly create a new wrapper type for ExplainOptions, and expose a single new method accepting that instead of two new methods that vary by name.