### PR TITLE
Release Google.Cloud.BackupDR.V1 version 2.1.0

### DIFF
--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.csproj
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Backup and DR service, which is a powerful, centralized, cloud-first backup and disaster recovery solution for cloud-based and hybrid workloads.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.3.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />

--- a/apis/Google.Cloud.BackupDR.V1/docs/history.md
+++ b/apis/Google.Cloud.BackupDR.V1/docs/history.md
@@ -1,5 +1,34 @@
 # Version history
 
+## Version 2.1.0, released 2025-01-13
+
+### Bug fixes
+
+- Update field behavior of `resource_type` field in message `BackupPlanAssociation` to `REQUIRED` ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
+
+(This was already the effective behavior.)
+
+### New features
+
+- Add InitializeServiceAPI ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
+- Update field behavior of `networks` field in message `ManagementServer` to `OPTIONAL` ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
+- Add enum to Backup Vault Access Restriction field ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
+- `ignore_backup_plan_references` added to the DeleteBackupVaultRequest ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
+
+### Documentation improvements
+
+- A comment for field `networks` in message `.google.cloud.backupdr.v1.ManagementServer` is changed ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
+- A comment for field `requested_cancellation` in message `.google.cloud.backupdr.v1.OperationMetadata` is changed ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
+- A comment for field `resource_type` in message `.google.cloud.backupdr.v1.BackupPlan` is changed ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
+- A comment for field `backup_retention_days` in message `.google.cloud.backupdr.v1.BackupRule` is changed ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
+- A comment for field `resource_type` in message `.google.cloud.backupdr.v1.BackupPlanAssociation` is changed ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
+- A comment for field `data_source` in message `.google.cloud.backupdr.v1.BackupPlanAssociation` is changed ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
+- A comment for field `rule_id` in message `.google.cloud.backupdr.v1.RuleConfigInfo` is changed ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
+- A comment for field `last_backup_error` in message `.google.cloud.backupdr.v1.RuleConfigInfo` is changed ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
+- A comment for enum value `ACCESS_RESTRICTION_UNSPECIFIED` in enum `AccessRestriction` is changed ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
+- A comment for field `uid` in message `.google.cloud.backupdr.v1.BackupVault` is changed ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
+- A comment for field `access_restriction` in message `.google.cloud.backupdr.v1.BackupVault` is changed ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
+
 ## Version 2.0.0, released 2024-10-14
 
 ### Bug fixes

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -742,7 +742,7 @@
     },
     {
       "id": "Google.Cloud.BackupDR.V1",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "type": "grpc",
       "productName": "Backup and DR Service",
       "productUrl": "https://cloud.google.com/backup-disaster-recovery/docs/concepts/backup-dr",
@@ -752,7 +752,7 @@
         "disaster-recovery"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Iam.V1": "3.4.0",
         "Google.Cloud.Location": "2.3.0",
         "Google.LongRunning": "3.3.0"
       },


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Update field behavior of `resource_type` field in message `BackupPlanAssociation` to `REQUIRED` ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))

(This was already the effective behavior.)

### New features

- Add InitializeServiceAPI ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
- Update field behavior of `networks` field in message `ManagementServer` to `OPTIONAL` ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
- Add enum to Backup Vault Access Restriction field ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
- `ignore_backup_plan_references` added to the DeleteBackupVaultRequest ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))

### Documentation improvements

- A comment for field `networks` in message `.google.cloud.backupdr.v1.ManagementServer` is changed ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
- A comment for field `requested_cancellation` in message `.google.cloud.backupdr.v1.OperationMetadata` is changed ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
- A comment for field `resource_type` in message `.google.cloud.backupdr.v1.BackupPlan` is changed ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
- A comment for field `backup_retention_days` in message `.google.cloud.backupdr.v1.BackupRule` is changed ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
- A comment for field `resource_type` in message `.google.cloud.backupdr.v1.BackupPlanAssociation` is changed ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
- A comment for field `data_source` in message `.google.cloud.backupdr.v1.BackupPlanAssociation` is changed ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
- A comment for field `rule_id` in message `.google.cloud.backupdr.v1.RuleConfigInfo` is changed ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
- A comment for field `last_backup_error` in message `.google.cloud.backupdr.v1.RuleConfigInfo` is changed ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
- A comment for enum value `ACCESS_RESTRICTION_UNSPECIFIED` in enum `AccessRestriction` is changed ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
- A comment for field `uid` in message `.google.cloud.backupdr.v1.BackupVault` is changed ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
- A comment for field `access_restriction` in message `.google.cloud.backupdr.v1.BackupVault` is changed ([commit 5eabb2d](https://github.com/googleapis/google-cloud-dotnet/commit/5eabb2d57f883a54d351b7223d20afa5162da248))
