### PR TITLE
Release Google.Cloud.CloudBuild.V1 version 2.14.0

### DIFF
--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.csproj
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.13.0</Version>
+    <Version>2.14.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Build API v1, which creates and manages builds on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.CloudBuild.V1/docs/history.md
+++ b/apis/Google.Cloud.CloudBuild.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 2.14.0, released 2025-01-13
+
+### New features
+
+- Add option to enable structured logging ([commit 881f147](https://github.com/googleapis/google-cloud-dotnet/commit/881f147890736fc7eb43747dec7db60afa527841))
+- Add GoModule to Artifact and Results messages and new GO_MODULE_H1 hash type ([commit 6903167](https://github.com/googleapis/google-cloud-dotnet/commit/6903167f75cb3fc38012f0780fefd1a2492dcf9f))
+
 ## Version 2.13.0, released 2024-10-29
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -1384,7 +1384,7 @@
     },
     {
       "id": "Google.Cloud.CloudBuild.V1",
-      "version": "2.13.0",
+      "version": "2.14.0",
       "type": "grpc",
       "productName": "Cloud Build",
       "productUrl": "https://cloud.google.com/cloud-build",


### PR DESCRIPTION

Changes in this release:

### New features

- Add option to enable structured logging ([commit 881f147](https://github.com/googleapis/google-cloud-dotnet/commit/881f147890736fc7eb43747dec7db60afa527841))
- Add GoModule to Artifact and Results messages and new GO_MODULE_H1 hash type ([commit 6903167](https://github.com/googleapis/google-cloud-dotnet/commit/6903167f75cb3fc38012f0780fefd1a2492dcf9f))
