### PR TITLE
Release Google.Cloud.Monitoring.V3 version 3.14.0

### DIFF
--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.13.0</Version>
+    <Version>3.14.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Monitoring API, which manages your Google Cloud Monitoring data and configurations.</Description>

--- a/apis/Google.Cloud.Monitoring.V3/docs/history.md
+++ b/apis/Google.Cloud.Monitoring.V3/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.14.0, released 2025-01-13
+
+### New features
+
+- Add active_only field to ListMetricDescriptorsRequest ([commit fa011c0](https://github.com/googleapis/google-cloud-dotnet/commit/fa011c0b115313c5815a59fed28408031743d8e4))
+
 ## Version 3.13.0, released 2024-12-16
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -3449,7 +3449,7 @@
       "protoPath": "google/monitoring/v3",
       "productName": "Google Cloud Monitoring",
       "productUrl": "https://cloud.google.com/monitoring/api/v3/",
-      "version": "3.13.0",
+      "version": "3.14.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Monitoring API, which manages your Google Cloud Monitoring data and configurations.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Add active_only field to ListMetricDescriptorsRequest ([commit fa011c0](https://github.com/googleapis/google-cloud-dotnet/commit/fa011c0b115313c5815a59fed28408031743d8e4))
