### PR TITLE
Release Google.Cloud.NetApp.V1 version 1.7.0

### DIFF
--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.csproj
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.6.0</Version>
+    <Version>1.7.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud NetApp Volumes API, which is a fully-managed, cloud-based data storage service that provides advanced data management capabilities and highly scalable performance with global availability.</Description>

--- a/apis/Google.Cloud.NetApp.V1/docs/history.md
+++ b/apis/Google.Cloud.NetApp.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.7.0, released 2025-01-13
+
+### New features
+
+- Add ValidateDirectoryService API for testing AD connection of a storage pool ([commit 7a948bf](https://github.com/googleapis/google-cloud-dotnet/commit/7a948bf016724e3e8a1cf5a689130991e61cb0a0))
+
+### Documentation improvements
+
+- Removed the format for `replication` in message `google.cloud.netapp.v1.HybridReplicationParameters` ([commit 7a948bf](https://github.com/googleapis/google-cloud-dotnet/commit/7a948bf016724e3e8a1cf5a689130991e61cb0a0))
+
 ## Version 1.6.0, released 2024-12-06
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -3466,7 +3466,7 @@
     },
     {
       "id": "Google.Cloud.NetApp.V1",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "type": "grpc",
       "productName": "NetApp",
       "productUrl": "https://cloud.google.com/netapp/volumes/docs/discover/overview",


### PR DESCRIPTION

Changes in this release:

### New features

- Add ValidateDirectoryService API for testing AD connection of a storage pool ([commit 7a948bf](https://github.com/googleapis/google-cloud-dotnet/commit/7a948bf016724e3e8a1cf5a689130991e61cb0a0))

### Documentation improvements

- Removed the format for `replication` in message `google.cloud.netapp.v1.HybridReplicationParameters` ([commit 7a948bf](https://github.com/googleapis/google-cloud-dotnet/commit/7a948bf016724e3e8a1cf5a689130991e61cb0a0))
