### PR TITLE
Release Google.Cloud.NetworkManagement.V1 version 2.13.0

### DIFF
--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.csproj
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.12.0</Version>
+    <Version>2.13.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Network Management API, which provides a collection of network performance monitoring and diagnostic capabilities.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.3.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />

--- a/apis/Google.Cloud.NetworkManagement.V1/docs/history.md
+++ b/apis/Google.Cloud.NetworkManagement.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.13.0, released 2025-01-13
+
+### New features
+
+- Expose the new v1 vpcflowlogs api proto ([commit 31f0b69](https://github.com/googleapis/google-cloud-dotnet/commit/31f0b691ec321fafc065d17e5b69b6b9a64d004e))
+
 ## Version 2.12.0, released 2024-11-18
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -3535,7 +3535,7 @@
     },
     {
       "id": "Google.Cloud.NetworkManagement.V1",
-      "version": "2.12.0",
+      "version": "2.13.0",
       "type": "grpc",
       "productName": "Network Management",
       "productUrl": "https://cloud.google.com/network-intelligence-center/docs/",
@@ -3549,7 +3549,7 @@
         "diagnostics"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Iam.V1": "3.4.0",
         "Google.Cloud.Location": "2.3.0",
         "Google.LongRunning": "3.3.0"
       },


### PR DESCRIPTION

Changes in this release:

### New features

- Expose the new v1 vpcflowlogs api proto ([commit 31f0b69](https://github.com/googleapis/google-cloud-dotnet/commit/31f0b691ec321fafc065d17e5b69b6b9a64d004e))
