### PR TITLE
Release Google.Cloud.OracleDatabase.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.csproj
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Oracle Database@Google Cloud API which provides a set of APIs to manage Oracle database services, such as Exadata and Autonomous Databases.</Description>

--- a/apis/Google.Cloud.OracleDatabase.V1/docs/history.md
+++ b/apis/Google.Cloud.OracleDatabase.V1/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 1.1.0, released 2025-01-13
+
+### New features
+
+- A new value `ACCOUNT_SUSPENDED` is added to enum `State` ([commit d17c3dd](https://github.com/googleapis/google-cloud-dotnet/commit/d17c3dd20ebb85dbb81ceb293857c9a017b4e37f))
+
+### Documentation improvements
+
+- The CloudVmClusterProperties.system_version field is no longer labeled as output only ([commit 09e1093](https://github.com/googleapis/google-cloud-dotnet/commit/09e109367f4ed3a8021ab1a8477150ea6da602d3))
+- A comment for field `cpu_count` in message `.google.cloud.oracledatabase.v1.CloudExadataInfrastructureProperties` is changed ([commit 69fcadb](https://github.com/googleapis/google-cloud-dotnet/commit/69fcadbc650080094c60295a606bcf8ea46500b8))
+- A comment for field `memory_size_gb` in message `.google.cloud.oracledatabase.v1.CloudExadataInfrastructureProperties` is changed ([commit 69fcadb](https://github.com/googleapis/google-cloud-dotnet/commit/69fcadbc650080094c60295a606bcf8ea46500b8))
+- A comment for field `db_node_storage_size_gb` in message `.google.cloud.oracledatabase.v1.CloudExadataInfrastructureProperties` is changed ([commit 69fcadb](https://github.com/googleapis/google-cloud-dotnet/commit/69fcadbc650080094c60295a606bcf8ea46500b8))
+
 ## Version 1.0.0, released 2024-12-05
 
 No API surface changes; just dependency updates and promotion to GA.

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -3706,7 +3706,7 @@
     },
     {
       "id": "Google.Cloud.OracleDatabase.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Oracle Database@Google Cloud",
       "productUrl": "https://cloud.google.com/oracle/database/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- A new value `ACCOUNT_SUSPENDED` is added to enum `State` ([commit d17c3dd](https://github.com/googleapis/google-cloud-dotnet/commit/d17c3dd20ebb85dbb81ceb293857c9a017b4e37f))

### Documentation improvements

- The CloudVmClusterProperties.system_version field is no longer labeled as output only ([commit 09e1093](https://github.com/googleapis/google-cloud-dotnet/commit/09e109367f4ed3a8021ab1a8477150ea6da602d3))
- A comment for field `cpu_count` in message `.google.cloud.oracledatabase.v1.CloudExadataInfrastructureProperties` is changed ([commit 69fcadb](https://github.com/googleapis/google-cloud-dotnet/commit/69fcadbc650080094c60295a606bcf8ea46500b8))
- A comment for field `memory_size_gb` in message `.google.cloud.oracledatabase.v1.CloudExadataInfrastructureProperties` is changed ([commit 69fcadb](https://github.com/googleapis/google-cloud-dotnet/commit/69fcadbc650080094c60295a606bcf8ea46500b8))
- A comment for field `db_node_storage_size_gb` in message `.google.cloud.oracledatabase.v1.CloudExadataInfrastructureProperties` is changed ([commit 69fcadb](https://github.com/googleapis/google-cloud-dotnet/commit/69fcadbc650080094c60295a606bcf8ea46500b8))
