### PR TITLE
Release Google.Cloud.PubSub.V1 version 3.20.0

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.19.0</Version>
+    <Version>3.20.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.4.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
   <ItemGroup>

--- a/apis/Google.Cloud.PubSub.V1/docs/history.md
+++ b/apis/Google.Cloud.PubSub.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.20.0, released 2025-01-13
+
+### New features
+
+- Add Kafka-based sources to IngestionDataSourceSettings proto and IngestionFailureEvent proto ([commit 9324e45](https://github.com/googleapis/google-cloud-dotnet/commit/9324e45437b5ac8b7e972edaaa183a366f7d4600))
+
 ## Version 3.19.0, released 2024-10-24
 
 ### Bug fixes

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -4130,12 +4130,12 @@
       "protoPath": "google/pubsub/v1",
       "productName": "Cloud Pub/Sub",
       "productUrl": "https://cloud.google.com/pubsub/",
-      "version": "3.19.0",
+      "version": "3.20.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.3.0"
+        "Google.Cloud.Iam.V1": "3.4.0"
       },
       "testDependencies": {
         "Google.Api.Gax.Testing": "default",


### PR DESCRIPTION

Changes in this release:

### New features

- Add Kafka-based sources to IngestionDataSourceSettings proto and IngestionFailureEvent proto ([commit 9324e45](https://github.com/googleapis/google-cloud-dotnet/commit/9324e45437b5ac8b7e972edaaa183a366f7d4600))
