### PR TITLE
Release Google.Maps.Routing.V2 version 1.0.0

### DIFF
--- a/apis/Google.Maps.Routing.V2/.repo-metadata.json
+++ b/apis/Google.Maps.Routing.V2/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Maps.Routing.V2",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://googleapis.dev/dotnet/Google.Maps.Routing.V2/latest",
   "library_type": "GAPIC_AUTO",
   "language": "dotnet",

--- a/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2/Google.Maps.Routing.V2.csproj
+++ b/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2/Google.Maps.Routing.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta15</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Routes Preferred API.</Description>

--- a/apis/Google.Maps.Routing.V2/docs/history.md
+++ b/apis/Google.Maps.Routing.V2/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2025-01-14
+
+No API surface changes; just promotion to GA.
+
 ## Version 1.0.0-beta15, released 2024-12-06
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -6150,7 +6150,7 @@
     },
     {
       "id": "Google.Maps.Routing.V2",
-      "version": "1.0.0-beta15",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Maps Routing",
       "productUrl": "https://developers.google.com/maps/documentation/routes_preferred",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just promotion to GA.
