### PR TITLE
Release Google.Maps.MapsPlatformDatasets.V1 version 1.0.0

### DIFF
--- a/apis/Google.Maps.MapsPlatformDatasets.V1/.repo-metadata.json
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "distribution_name": "Google.Maps.MapsPlatformDatasets.V1",
-  "release_level": "preview",
+  "release_level": "stable",
   "client_documentation": "https://googleapis.dev/dotnet/Google.Maps.MapsPlatformDatasets.V1/latest",
   "library_type": "GAPIC_AUTO",
   "language": "dotnet",

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.csproj
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta06</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Platform Datasets API (v1).</Description>

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/docs/history.md
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 1.0.0, released 2025-01-14
+
+No API surface changes; just promotion to GA.
+
 ## Version 1.0.0-beta06, released 2024-07-22
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -6086,7 +6086,7 @@
     },
     {
       "id": "Google.Maps.MapsPlatformDatasets.V1",
-      "version": "1.0.0-beta06",
+      "version": "1.0.0",
       "type": "grpc",
       "productName": "Maps Platform Datasets",
       "productUrl": "https://developers.google.com/maps/documentation",


### PR DESCRIPTION

Changes in this release:

No API surface changes; just promotion to GA.
