### PR TITLE
chore: Clean non-source files when generating locally

### DIFF
--- a/tools/Google.Cloud.Tools.ReleaseManager/GenerateApisCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/GenerateApisCommand.cs
@@ -112,6 +112,7 @@ internal class GenerateApisCommand : ICommand
             {
                 Generate(api);
             }
+            nonSourceGenerator.CleanApiFiles(api);
             nonSourceGenerator.GenerateApiFiles(api);
         }
         nonSourceGenerator.GenerateNonApiFiles();


### PR DESCRIPTION
(This should probably never make a difference, but it's good to be sure.)