### PR TITLE
Release Google.Cloud.Bigtable.Admin.V2 version 3.22.0

### DIFF
--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.21.0</Version>
+    <Version>3.22.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Bigtable Instance and Table Admin APIs.</Description>
@@ -11,7 +11,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
     <PackageReference Include="Google.Cloud.Bigtable.Common.V2" VersionOverride="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>

--- a/apis/Google.Cloud.Bigtable.Admin.V2/docs/history.md
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.22.0, released 2025-01-27
+
+### Bug fixes
+
+- Extend timeouts for check consistency ([commit 13b35d3](https://github.com/googleapis/google-cloud-dotnet/commit/13b35d36b9a35b8a19139e1f91b04cca289cdff2))
+
 ## Version 3.21.0, released 2024-09-26
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -1160,7 +1160,7 @@
       "protoPath": "google/bigtable/admin/v2",
       "productName": "Google Cloud Bigtable Administration",
       "productUrl": "https://cloud.google.com/bigtable/",
-      "version": "3.21.0",
+      "version": "3.22.0",
       "commonResourcesConfig": "tweaks/Google.Cloud.Bigtable.Common.V2/CommonResourcesConfig.json",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Bigtable Instance and Table Admin APIs.",
@@ -1169,7 +1169,7 @@
       ],
       "dependencies": {
         "Google.Cloud.Bigtable.Common.V2": "3.2.0",
-        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Iam.V1": "3.4.0",
         "Google.LongRunning": "3.3.0"
       },
       "testDependencies": {


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Extend timeouts for check consistency ([commit 13b35d3](https://github.com/googleapis/google-cloud-dotnet/commit/13b35d36b9a35b8a19139e1f91b04cca289cdff2))
