### PR TITLE
Release Google.Cloud.CloudControlsPartner.V1Beta version 1.0.0-beta04

### DIFF
--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.csproj
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Controls Partner API (v1beta) which provides insights about your customers and their Assured Workloads based on your Sovereign Controls by Partners offering.</Description>

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/docs/history.md
@@ -1,5 +1,22 @@
 # Version history
 
+## Version 1.0.0-beta04, released 2025-01-27
+
+### New features
+
+- A new method `CreateCustomer` is added to service `CloudControlsPartnerCore` ([commit e637833](https://github.com/googleapis/google-cloud-dotnet/commit/e637833261207acce8f14e44690eb2b94497a6cf))
+- A new method `UpdateCustomer` is added to service `CloudControlsPartnerCore` ([commit e637833](https://github.com/googleapis/google-cloud-dotnet/commit/e637833261207acce8f14e44690eb2b94497a6cf))
+- A new method `DeleteCustomer` is added to service `CloudControlsPartnerCore` ([commit e637833](https://github.com/googleapis/google-cloud-dotnet/commit/e637833261207acce8f14e44690eb2b94497a6cf))
+- A new field `organization_domain` is added to message `.google.cloud.cloudcontrolspartner.v1beta.Customer` ([commit e637833](https://github.com/googleapis/google-cloud-dotnet/commit/e637833261207acce8f14e44690eb2b94497a6cf))
+- A new message `CreateCustomerRequest` is added ([commit e637833](https://github.com/googleapis/google-cloud-dotnet/commit/e637833261207acce8f14e44690eb2b94497a6cf))
+- A new message `UpdateCustomerRequest` is added ([commit e637833](https://github.com/googleapis/google-cloud-dotnet/commit/e637833261207acce8f14e44690eb2b94497a6cf))
+- A new message `DeleteCustomerRequest` is added ([commit e637833](https://github.com/googleapis/google-cloud-dotnet/commit/e637833261207acce8f14e44690eb2b94497a6cf))
+
+### Documentation improvements
+
+- A comment for field `requested_cancellation` in message `.google.cloud.cloudcontrolspartner.v1beta.OperationMetadata` is changed ([commit e637833](https://github.com/googleapis/google-cloud-dotnet/commit/e637833261207acce8f14e44690eb2b94497a6cf))
+- A comment for enum value `VIRTRU` in enum `EkmSolution` is changed ([commit e637833](https://github.com/googleapis/google-cloud-dotnet/commit/e637833261207acce8f14e44690eb2b94497a6cf))
+
 ## Version 1.0.0-beta03, released 2024-09-16
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -1449,7 +1449,7 @@
     },
     {
       "id": "Google.Cloud.CloudControlsPartner.V1Beta",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0-beta04",
       "type": "grpc",
       "productName": "Cloud Controls Partner",
       "productUrl": "https://cloud.google.com/sovereign-controls-by-partners/docs/sovereign-partners/reference/rest",


### PR DESCRIPTION

Changes in this release:

### New features

- A new method `CreateCustomer` is added to service `CloudControlsPartnerCore` ([commit e637833](https://github.com/googleapis/google-cloud-dotnet/commit/e637833261207acce8f14e44690eb2b94497a6cf))
- A new method `UpdateCustomer` is added to service `CloudControlsPartnerCore` ([commit e637833](https://github.com/googleapis/google-cloud-dotnet/commit/e637833261207acce8f14e44690eb2b94497a6cf))
- A new method `DeleteCustomer` is added to service `CloudControlsPartnerCore` ([commit e637833](https://github.com/googleapis/google-cloud-dotnet/commit/e637833261207acce8f14e44690eb2b94497a6cf))
- A new field `organization_domain` is added to message `.google.cloud.cloudcontrolspartner.v1beta.Customer` ([commit e637833](https://github.com/googleapis/google-cloud-dotnet/commit/e637833261207acce8f14e44690eb2b94497a6cf))
- A new message `CreateCustomerRequest` is added ([commit e637833](https://github.com/googleapis/google-cloud-dotnet/commit/e637833261207acce8f14e44690eb2b94497a6cf))
- A new message `UpdateCustomerRequest` is added ([commit e637833](https://github.com/googleapis/google-cloud-dotnet/commit/e637833261207acce8f14e44690eb2b94497a6cf))
- A new message `DeleteCustomerRequest` is added ([commit e637833](https://github.com/googleapis/google-cloud-dotnet/commit/e637833261207acce8f14e44690eb2b94497a6cf))

### Documentation improvements

- A comment for field `requested_cancellation` in message `.google.cloud.cloudcontrolspartner.v1beta.OperationMetadata` is changed ([commit e637833](https://github.com/googleapis/google-cloud-dotnet/commit/e637833261207acce8f14e44690eb2b94497a6cf))
- A comment for enum value `VIRTRU` in enum `EkmSolution` is changed ([commit e637833](https://github.com/googleapis/google-cloud-dotnet/commit/e637833261207acce8f14e44690eb2b94497a6cf))
