### PR TITLE
Release Google.Cloud.Datastream.V1 version 2.9.0

### DIFF
--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.csproj
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.8.0</Version>
+    <Version>2.9.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Datastream API (v1), which allows you to synchronize data across heterogeneous databases and applications reliably, and with minimal latency and downtime.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.3.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />

--- a/apis/Google.Cloud.Datastream.V1/docs/history.md
+++ b/apis/Google.Cloud.Datastream.V1/docs/history.md
@@ -1,5 +1,22 @@
 # Version history
 
+## Version 2.9.0, released 2025-01-27
+
+### New features
+
+- A new field `ssl_config` is added to message `.google.cloud.datastream.v1.PostgresqlProfile` ([commit d7026f2](https://github.com/googleapis/google-cloud-dotnet/commit/d7026f26a7f2af014a3536e9b1e6023c01c8c3ff))
+- A new message `PostgresqlSslConfig` is added ([commit d7026f2](https://github.com/googleapis/google-cloud-dotnet/commit/d7026f26a7f2af014a3536e9b1e6023c01c8c3ff))
+
+### Documentation improvements
+
+- A comment for message `OracleAsmConfig` is changed ([commit d7026f2](https://github.com/googleapis/google-cloud-dotnet/commit/d7026f26a7f2af014a3536e9b1e6023c01c8c3ff))
+- A comment for field `password` in message `.google.cloud.datastream.v1.OracleAsmConfig` is changed ([commit d7026f2](https://github.com/googleapis/google-cloud-dotnet/commit/d7026f26a7f2af014a3536e9b1e6023c01c8c3ff))
+- A comment for field `name` in message `.google.cloud.datastream.v1.PrivateConnection` is changed ([commit d7026f2](https://github.com/googleapis/google-cloud-dotnet/commit/d7026f26a7f2af014a3536e9b1e6023c01c8c3ff))
+- A comment for field `name` in message `.google.cloud.datastream.v1.Route` is changed ([commit d7026f2](https://github.com/googleapis/google-cloud-dotnet/commit/d7026f26a7f2af014a3536e9b1e6023c01c8c3ff))
+- A comment for field `name` in message `.google.cloud.datastream.v1.ConnectionProfile` is changed ([commit d7026f2](https://github.com/googleapis/google-cloud-dotnet/commit/d7026f26a7f2af014a3536e9b1e6023c01c8c3ff))
+- A comment for field `name` in message `.google.cloud.datastream.v1.Stream` is changed ([commit d7026f2](https://github.com/googleapis/google-cloud-dotnet/commit/d7026f26a7f2af014a3536e9b1e6023c01c8c3ff))
+- A comment for field `name` in message `.google.cloud.datastream.v1.StreamObject` is changed ([commit d7026f2](https://github.com/googleapis/google-cloud-dotnet/commit/d7026f26a7f2af014a3536e9b1e6023c01c8c3ff))
+
 ## Version 2.8.0, released 2024-12-06
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -1944,7 +1944,7 @@
     },
     {
       "id": "Google.Cloud.Datastream.V1",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "type": "grpc",
       "productName": "DataStream",
       "productUrl": "https://cloud.google.com/datastream/docs",
@@ -1954,7 +1954,7 @@
         "synchronization"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Iam.V1": "3.4.0",
         "Google.Cloud.Location": "2.3.0",
         "Google.LongRunning": "3.3.0"
       },


### PR DESCRIPTION

Changes in this release:

### New features

- A new field `ssl_config` is added to message `.google.cloud.datastream.v1.PostgresqlProfile` ([commit d7026f2](https://github.com/googleapis/google-cloud-dotnet/commit/d7026f26a7f2af014a3536e9b1e6023c01c8c3ff))
- A new message `PostgresqlSslConfig` is added ([commit d7026f2](https://github.com/googleapis/google-cloud-dotnet/commit/d7026f26a7f2af014a3536e9b1e6023c01c8c3ff))

### Documentation improvements

- A comment for message `OracleAsmConfig` is changed ([commit d7026f2](https://github.com/googleapis/google-cloud-dotnet/commit/d7026f26a7f2af014a3536e9b1e6023c01c8c3ff))
- A comment for field `password` in message `.google.cloud.datastream.v1.OracleAsmConfig` is changed ([commit d7026f2](https://github.com/googleapis/google-cloud-dotnet/commit/d7026f26a7f2af014a3536e9b1e6023c01c8c3ff))
- A comment for field `name` in message `.google.cloud.datastream.v1.PrivateConnection` is changed ([commit d7026f2](https://github.com/googleapis/google-cloud-dotnet/commit/d7026f26a7f2af014a3536e9b1e6023c01c8c3ff))
- A comment for field `name` in message `.google.cloud.datastream.v1.Route` is changed ([commit d7026f2](https://github.com/googleapis/google-cloud-dotnet/commit/d7026f26a7f2af014a3536e9b1e6023c01c8c3ff))
- A comment for field `name` in message `.google.cloud.datastream.v1.ConnectionProfile` is changed ([commit d7026f2](https://github.com/googleapis/google-cloud-dotnet/commit/d7026f26a7f2af014a3536e9b1e6023c01c8c3ff))
- A comment for field `name` in message `.google.cloud.datastream.v1.Stream` is changed ([commit d7026f2](https://github.com/googleapis/google-cloud-dotnet/commit/d7026f26a7f2af014a3536e9b1e6023c01c8c3ff))
- A comment for field `name` in message `.google.cloud.datastream.v1.StreamObject` is changed ([commit d7026f2](https://github.com/googleapis/google-cloud-dotnet/commit/d7026f26a7f2af014a3536e9b1e6023c01c8c3ff))
