### PR TITLE
Release Google.Cloud.Firestore.Admin.V1 version 3.12.0

### DIFF
--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.csproj
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.11.0</Version>
+    <Version>3.12.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Firestore Admin API.</Description>

--- a/apis/Google.Cloud.Firestore.Admin.V1/docs/history.md
+++ b/apis/Google.Cloud.Firestore.Admin.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.12.0, released 2025-01-27
+
+### Bug fixes
+
+- Bump default deadline on CreateDatabase and RestoreDatabase to 2 minutes ([commit 26c2a9d](https://github.com/googleapis/google-cloud-dotnet/commit/26c2a9d2f746ae1e293fb1fbccb12f6455de0498))
+
+### New features
+
+- Add filter argument to FirestoreAdmin.ListBackupsRequest ([commit 26c2a9d](https://github.com/googleapis/google-cloud-dotnet/commit/26c2a9d2f746ae1e293fb1fbccb12f6455de0498))
+
 ## Version 3.11.0, released 2024-09-09
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -2533,7 +2533,7 @@
       "listingDescription": "Firestore Administration (e.g. index management)",
       "productName": "Firestore Admin",
       "productUrl": "https://firebase.google.com",
-      "version": "3.11.0",
+      "version": "3.12.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Firestore Admin API.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Bump default deadline on CreateDatabase and RestoreDatabase to 2 minutes ([commit 26c2a9d](https://github.com/googleapis/google-cloud-dotnet/commit/26c2a9d2f746ae1e293fb1fbccb12f6455de0498))

### New features

- Add filter argument to FirestoreAdmin.ListBackupsRequest ([commit 26c2a9d](https://github.com/googleapis/google-cloud-dotnet/commit/26c2a9d2f746ae1e293fb1fbccb12f6455de0498))
