### PR TITLE
Release Google.Cloud.Redis.Cluster.V1 version 1.4.0

### DIFF
--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.csproj
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library for the Redis Cluster API (v1), which creates and manages Redis instances on the Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.Redis.Cluster.V1/docs/history.md
+++ b/apis/Google.Cloud.Redis.Cluster.V1/docs/history.md
@@ -1,5 +1,37 @@
 # Version history
 
+## Version 1.4.0, released 2025-01-27
+
+### Bug fixes
+
+- Changed field behavior for an existing field `psc_connection_id` in message `.google.cloud.redis.cluster.v1beta1.PscConnection` ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
+- Changed field behavior for an existing field `address` in message `.google.cloud.redis.cluster.v1beta1.PscConnection` ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
+- Changed field behavior for an existing field `forwarding_rule` in message `.google.cloud.redis.cluster.v1beta1.PscConnection` ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
+- Changed field behavior for an existing field `network` in message `.google.cloud.redis.cluster.v1beta1.PscConnection` ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
+
+### New features
+
+- [Memorystore for Redis Cluster] Added support for maintenance window and rescheduling maintenance ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
+- [Memorystore for Redis Cluster] Added support for Backups and Backup Collections ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
+- [Memorystore for Redis Cluster] Added support for Multiple VPCs ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
+- [Memorystore for Redis Cluster] Added support for Cross Cluster Replication ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
+- [Memorystore for Redis Cluster] Added support for CMEK ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
+- New REQUIRED field `service_attachment` in message `.google.cloud.redis.cluster.v1beta1.PscConnection` ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
+
+### Documentation improvements
+
+- A comment for enum value `NODE_TYPE_UNSPECIFIED` in enum `NodeType` is changed ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
+- A comment for field `name` in message `.google.cloud.redis.cluster.v1beta1.Cluster` is changed ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
+- A comment for field `shard_count` in message `.google.cloud.redis.cluster.v1beta1.Cluster` is changed ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
+- A comment for field `psc_configs` in message `.google.cloud.redis.cluster.v1beta1.Cluster` is changed ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
+- A comment for field `psc_connections` in message `.google.cloud.redis.cluster.v1beta1.Cluster` is changed ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
+- A comment for field `psc_connection_id` in message `.google.cloud.redis.cluster.v1beta1.PscConnection` is changed ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
+- A comment for field `address` in message `.google.cloud.redis.cluster.v1beta1.PscConnection` is changed ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
+- A comment for field `forwarding_rule` in message `.google.cloud.redis.cluster.v1beta1.PscConnection` is changed ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
+- A comment for field `project_id` in message `.google.cloud.redis.cluster.v1beta1.PscConnection` is changed ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
+- A comment for field `network` in message `.google.cloud.redis.cluster.v1beta1.PscConnection` is changed ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
+- A comment for enum value `ALWAYS` in enum `AppendFsync` is changed ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
+
 ## Version 1.3.0, released 2024-06-10
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -4302,7 +4302,7 @@
     },
     {
       "id": "Google.Cloud.Redis.Cluster.V1",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "type": "grpc",
       "productName": "Google Cloud Memorystore for Redis (cluster management)",
       "productUrl": "https://cloud.google.com/memorystore/docs/redis",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Changed field behavior for an existing field `psc_connection_id` in message `.google.cloud.redis.cluster.v1beta1.PscConnection` ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
- Changed field behavior for an existing field `address` in message `.google.cloud.redis.cluster.v1beta1.PscConnection` ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
- Changed field behavior for an existing field `forwarding_rule` in message `.google.cloud.redis.cluster.v1beta1.PscConnection` ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
- Changed field behavior for an existing field `network` in message `.google.cloud.redis.cluster.v1beta1.PscConnection` ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))

### New features

- [Memorystore for Redis Cluster] Added support for maintenance window and rescheduling maintenance ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
- [Memorystore for Redis Cluster] Added support for Backups and Backup Collections ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
- [Memorystore for Redis Cluster] Added support for Multiple VPCs ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
- [Memorystore for Redis Cluster] Added support for Cross Cluster Replication ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
- [Memorystore for Redis Cluster] Added support for CMEK ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
- New REQUIRED field `service_attachment` in message `.google.cloud.redis.cluster.v1beta1.PscConnection` ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))

### Documentation improvements

- A comment for enum value `NODE_TYPE_UNSPECIFIED` in enum `NodeType` is changed ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
- A comment for field `name` in message `.google.cloud.redis.cluster.v1beta1.Cluster` is changed ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
- A comment for field `shard_count` in message `.google.cloud.redis.cluster.v1beta1.Cluster` is changed ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
- A comment for field `psc_configs` in message `.google.cloud.redis.cluster.v1beta1.Cluster` is changed ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
- A comment for field `psc_connections` in message `.google.cloud.redis.cluster.v1beta1.Cluster` is changed ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
- A comment for field `psc_connection_id` in message `.google.cloud.redis.cluster.v1beta1.PscConnection` is changed ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
- A comment for field `address` in message `.google.cloud.redis.cluster.v1beta1.PscConnection` is changed ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
- A comment for field `forwarding_rule` in message `.google.cloud.redis.cluster.v1beta1.PscConnection` is changed ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
- A comment for field `project_id` in message `.google.cloud.redis.cluster.v1beta1.PscConnection` is changed ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
- A comment for field `network` in message `.google.cloud.redis.cluster.v1beta1.PscConnection` is changed ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
- A comment for enum value `ALWAYS` in enum `AppendFsync` is changed ([commit 2a8e11c](https://github.com/googleapis/google-cloud-dotnet/commit/2a8e11cd93533b6f8c34072cc44ac1cfc68c8936))
