### PR TITLE
Release Google.Analytics.Admin.V1Alpha version 2.0.0-alpha21

### DIFF
--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha20</Version>
+    <Version>2.0.0-alpha21</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Admin API (v1alpha)</Description>

--- a/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
+++ b/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+## Version 2.0.0-alpha21, released 2025-02-03
+
+### Bug fixes
+
+- Mark `event_data_retention` field in `DataRetentionSettings` as `REQUIRED` ([commit 22ae76a](https://github.com/googleapis/google-cloud-dotnet/commit/22ae76a162d95a8aee08c1b21a5540f335b2da53))
+
+### New features
+
+- Add `user_data_retention` field to `DataRetentionSettings` and mark as `REQUIRED` ([commit 22ae76a](https://github.com/googleapis/google-cloud-dotnet/commit/22ae76a162d95a8aee08c1b21a5540f335b2da53))
+
+### Documentation improvements
+
+- Replace "GA4" with "Google Analytics" or "GA" in all comments ([commit 22ae76a](https://github.com/googleapis/google-cloud-dotnet/commit/22ae76a162d95a8aee08c1b21a5540f335b2da53))
+
 ## Version 2.0.0-alpha20, released 2024-08-05
 
 ### Bug fixes

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -46,7 +46,7 @@
     },
     {
       "id": "Google.Analytics.Admin.V1Alpha",
-      "version": "2.0.0-alpha20",
+      "version": "2.0.0-alpha21",
       "type": "grpc",
       "productName": "Analytics Admin",
       "productUrl": "https://developers.google.com/analytics",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Mark `event_data_retention` field in `DataRetentionSettings` as `REQUIRED` ([commit 22ae76a](https://github.com/googleapis/google-cloud-dotnet/commit/22ae76a162d95a8aee08c1b21a5540f335b2da53))

### New features

- Add `user_data_retention` field to `DataRetentionSettings` and mark as `REQUIRED` ([commit 22ae76a](https://github.com/googleapis/google-cloud-dotnet/commit/22ae76a162d95a8aee08c1b21a5540f335b2da53))

### Documentation improvements

- Replace "GA4" with "Google Analytics" or "GA" in all comments ([commit 22ae76a](https://github.com/googleapis/google-cloud-dotnet/commit/22ae76a162d95a8aee08c1b21a5540f335b2da53))
