### PR TITLE
Release Google.Analytics.Admin.V1Beta version 1.0.0-beta09

### DIFF
--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.csproj
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta08</Version>
+    <Version>1.0.0-beta09</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Admin API (v1beta)</Description>

--- a/apis/Google.Analytics.Admin.V1Beta/docs/history.md
+++ b/apis/Google.Analytics.Admin.V1Beta/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+## Version 1.0.0-beta09, released 2025-02-03
+
+### Bug fixes
+
+- Mark `event_data_retention` field in `DataRetentionSettings` as `REQUIRED` ([commit 44fa61c](https://github.com/googleapis/google-cloud-dotnet/commit/44fa61cd05e4920e93ddcb281d9cf1e3edac23ff))
+
+### New features
+
+- Add `user_data_retention` field to `DataRetentionSettings` and mark as `REQUIRED` ([commit 44fa61c](https://github.com/googleapis/google-cloud-dotnet/commit/44fa61cd05e4920e93ddcb281d9cf1e3edac23ff))
+
+### Documentation improvements
+
+- Replace "GA4" with "Google Analytics" or "GA" in all comments ([commit 44fa61c](https://github.com/googleapis/google-cloud-dotnet/commit/44fa61cd05e4920e93ddcb281d9cf1e3edac23ff))
+
 ## Version 1.0.0-beta08, released 2024-07-22
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -65,7 +65,7 @@
     },
     {
       "id": "Google.Analytics.Admin.V1Beta",
-      "version": "1.0.0-beta08",
+      "version": "1.0.0-beta09",
       "type": "grpc",
       "productName": "Google Analytics Admin",
       "productUrl": "https://developers.google.com/analytics",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Mark `event_data_retention` field in `DataRetentionSettings` as `REQUIRED` ([commit 44fa61c](https://github.com/googleapis/google-cloud-dotnet/commit/44fa61cd05e4920e93ddcb281d9cf1e3edac23ff))

### New features

- Add `user_data_retention` field to `DataRetentionSettings` and mark as `REQUIRED` ([commit 44fa61c](https://github.com/googleapis/google-cloud-dotnet/commit/44fa61cd05e4920e93ddcb281d9cf1e3edac23ff))

### Documentation improvements

- Replace "GA4" with "Google Analytics" or "GA" in all comments ([commit 44fa61c](https://github.com/googleapis/google-cloud-dotnet/commit/44fa61cd05e4920e93ddcb281d9cf1e3edac23ff))
