### PR TITLE
Release Google.Apps.Meet.V2 version 1.0.0-beta05

### DIFF
--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2/Google.Apps.Meet.V2.csproj
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2/Google.Apps.Meet.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta04</Version>
+    <Version>1.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to create and manage meetings in Google Meet.</Description>

--- a/apis/Google.Apps.Meet.V2/docs/history.md
+++ b/apis/Google.Apps.Meet.V2/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.0.0-beta05, released 2025-02-03
+
+### New features
+
+- Add new OAuth scope `https://www.googleapis.com/auth/meetings.space.settings` to service `SpacesService` ([commit 651537a](https://github.com/googleapis/google-cloud-dotnet/commit/651537a95a5eb6eed4c3b78fc42429f2c4e4d6a4))
+
+### Documentation improvements
+
+- Improve docs for GetSpaceRequest, EndActiveConferenceRequest, ListConferenceRecordsRequest ([commit 651537a](https://github.com/googleapis/google-cloud-dotnet/commit/651537a95a5eb6eed4c3b78fc42429f2c4e4d6a4))
+
 ## Version 1.0.0-beta04, released 2024-05-08
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -162,7 +162,7 @@
     },
     {
       "id": "Google.Apps.Meet.V2",
-      "version": "1.0.0-beta04",
+      "version": "1.0.0-beta05",
       "type": "grpc",
       "productName": "Google Meet",
       "productUrl": "https://developers.google.com/meet/api/guides/overview",


### PR DESCRIPTION

Changes in this release:

### New features

- Add new OAuth scope `https://www.googleapis.com/auth/meetings.space.settings` to service `SpacesService` ([commit 651537a](https://github.com/googleapis/google-cloud-dotnet/commit/651537a95a5eb6eed4c3b78fc42429f2c4e4d6a4))

### Documentation improvements

- Improve docs for GetSpaceRequest, EndActiveConferenceRequest, ListConferenceRecordsRequest ([commit 651537a](https://github.com/googleapis/google-cloud-dotnet/commit/651537a95a5eb6eed4c3b78fc42429f2c4e4d6a4))
