### PR TITLE
Release Google.Apps.Meet.V2Beta version 1.0.0-beta06

### DIFF
--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.csproj
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta05</Version>
+    <Version>1.0.0-beta06</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Create and manage meetings in Google Meet.</Description>

--- a/apis/Google.Apps.Meet.V2Beta/docs/history.md
+++ b/apis/Google.Apps.Meet.V2Beta/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 1.0.0-beta06, released 2025-02-03
+
+### New features
+
+- Add methods for [configuring meeting spaces and members](https://developers.google.com/meet/api/guides/beta/configuration-beta) ([commit df0476e](https://github.com/googleapis/google-cloud-dotnet/commit/df0476e78bb12893756125115567ddfc908734a7))
+- Add new OAuth scope `https://www.googleapis.com/auth/meetings.space.settings` to service `SpacesService` ([commit df0476e](https://github.com/googleapis/google-cloud-dotnet/commit/df0476e78bb12893756125115567ddfc908734a7))
+
+### Documentation improvements
+
+- Improve docs for `GetSpaceRequest`, `EndActiveConferenceRequest`, `ListConferenceRecordsRequest` ([commit df0476e](https://github.com/googleapis/google-cloud-dotnet/commit/df0476e78bb12893756125115567ddfc908734a7))
+- Remove *Developer Preview* label from methods that are now generally available ([commit df0476e](https://github.com/googleapis/google-cloud-dotnet/commit/df0476e78bb12893756125115567ddfc908734a7))
+
 ## Version 1.0.0-beta05, released 2024-05-08
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -182,7 +182,7 @@
     },
     {
       "id": "Google.Apps.Meet.V2Beta",
-      "version": "1.0.0-beta05",
+      "version": "1.0.0-beta06",
       "type": "grpc",
       "productName": "Google Meet",
       "productUrl": "https://developers.google.com/meet/api/guides/overview",


### PR DESCRIPTION

Changes in this release:

### New features

- Add methods for [configuring meeting spaces and members](https://developers.google.com/meet/api/guides/beta/configuration-beta) ([commit df0476e](https://github.com/googleapis/google-cloud-dotnet/commit/df0476e78bb12893756125115567ddfc908734a7))
- Add new OAuth scope `https://www.googleapis.com/auth/meetings.space.settings` to service `SpacesService` ([commit df0476e](https://github.com/googleapis/google-cloud-dotnet/commit/df0476e78bb12893756125115567ddfc908734a7))

### Documentation improvements

- Improve docs for `GetSpaceRequest`, `EndActiveConferenceRequest`, `ListConferenceRecordsRequest` ([commit df0476e](https://github.com/googleapis/google-cloud-dotnet/commit/df0476e78bb12893756125115567ddfc908734a7))
- Remove *Developer Preview* label from methods that are now generally available ([commit df0476e](https://github.com/googleapis/google-cloud-dotnet/commit/df0476e78bb12893756125115567ddfc908734a7))
