### PR TITLE
Release Google.Cloud.AIPlatform.V1Beta1 version 1.0.0-beta15

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta14</Version>
+    <Version>1.0.0-beta15</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AI Platform API (v1beta), which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 1.0.0-beta15, released 2025-02-03
+
+### New features
+
+- Add rag_files_count to RagCorpus to count number of associated files ([commit 39f1a59](https://github.com/googleapis/google-cloud-dotnet/commit/39f1a590bdca3c35a42da95828480f432a56f552))
+- Model Registry Checkpoint API ([commit fc5de1c](https://github.com/googleapis/google-cloud-dotnet/commit/fc5de1c17745fe36bb37ab35f9b3d0078ae5a2a2))
+
 ## Version 1.0.0-beta14, released 2025-01-27
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -373,7 +373,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1Beta1",
-      "version": "1.0.0-beta14",
+      "version": "1.0.0-beta15",
       "type": "grpc",
       "productName": "Cloud AI Platform",
       "productUrl": "https://cloud.google.com/ai-platform/docs/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add rag_files_count to RagCorpus to count number of associated files ([commit 39f1a59](https://github.com/googleapis/google-cloud-dotnet/commit/39f1a590bdca3c35a42da95828480f432a56f552))
- Model Registry Checkpoint API ([commit fc5de1c](https://github.com/googleapis/google-cloud-dotnet/commit/fc5de1c17745fe36bb37ab35f9b3d0078ae5a2a2))
