### PR TITLE
Release Google.Cloud.BigQuery.V2 version 3.11.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.10.0</Version>
+    <Version>3.11.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.</Description>

--- a/apis/Google.Cloud.BigQuery.V2/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.V2/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.11.0, released 2025-02-03
+
+### Bug fixes
+
+- Remove column name validation. ([commit d79c8ff](https://github.com/googleapis/google-cloud-dotnet/commit/d79c8ff6ae3db02b73a5a5bed3b2b56333a55eb9))
+
 ## Version 3.10.0, released 2024-05-30
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -1112,7 +1112,7 @@
       "id": "Google.Cloud.BigQuery.V2",
       "productName": "Google BigQuery",
       "productUrl": "https://cloud.google.com/bigquery/",
-      "version": "3.10.0",
+      "version": "3.11.0",
       "type": "rest",
       "description": "Recommended Google client library to access the BigQuery API. It wraps the Google.Apis.Bigquery.v2 client library, making common operations simpler in client code. BigQuery is a data platform for customers to create, manage, share and query data.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- Remove column name validation. ([commit d79c8ff](https://github.com/googleapis/google-cloud-dotnet/commit/d79c8ff6ae3db02b73a5a5bed3b2b56333a55eb9))
