### PR TITLE
Release Google.Cloud.Compute.V1 version 3.4.0

### DIFF
--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.3.0</Version>
+    <Version>3.4.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Compute Engine API.</Description>

--- a/apis/Google.Cloud.Compute.V1/docs/history.md
+++ b/apis/Google.Cloud.Compute.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.4.0, released 2025-02-03
+
+### New features
+
+- Update Compute Engine API to revision 20250119 ([issue 981](https://github.com/googleapis/google-cloud-dotnet/issues/981)) ([commit 45c3223](https://github.com/googleapis/google-cloud-dotnet/commit/45c322349cb14789bf9318e44974042baa167659))
+
 ## Version 3.3.0, released 2025-01-27
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -1567,7 +1567,7 @@
     },
     {
       "id": "Google.Cloud.Compute.V1",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "type": "regapic",
       "productName": "Compute Engine",
       "productUrl": "https://cloud.google.com/compute",


### PR DESCRIPTION

Changes in this release:

### New features

- Update Compute Engine API to revision 20250119 ([issue 981](https://github.com/googleapis/google-cloud-dotnet/issues/981)) ([commit 45c3223](https://github.com/googleapis/google-cloud-dotnet/commit/45c322349cb14789bf9318e44974042baa167659))
