### PR TITLE
Release Google.Cloud.Monitoring.V3 version 3.15.0

### DIFF
--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.14.0</Version>
+    <Version>3.15.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Monitoring API, which manages your Google Cloud Monitoring data and configurations.</Description>

--- a/apis/Google.Cloud.Monitoring.V3/docs/history.md
+++ b/apis/Google.Cloud.Monitoring.V3/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.15.0, released 2025-02-03
+
+### New features
+
+- Add filter field to snooze proto ([commit 164b017](https://github.com/googleapis/google-cloud-dotnet/commit/164b01761550b4824ad79eff16788995785bd483))
+
+### Documentation improvements
+
+- Remove extra fenced code block markers ([commit 164b017](https://github.com/googleapis/google-cloud-dotnet/commit/164b01761550b4824ad79eff16788995785bd483))
+
 ## Version 3.14.0, released 2025-01-13
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -3493,7 +3493,7 @@
       "protoPath": "google/monitoring/v3",
       "productName": "Google Cloud Monitoring",
       "productUrl": "https://cloud.google.com/monitoring/api/v3/",
-      "version": "3.14.0",
+      "version": "3.15.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Monitoring API, which manages your Google Cloud Monitoring data and configurations.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Add filter field to snooze proto ([commit 164b017](https://github.com/googleapis/google-cloud-dotnet/commit/164b01761550b4824ad79eff16788995785bd483))

### Documentation improvements

- Remove extra fenced code block markers ([commit 164b017](https://github.com/googleapis/google-cloud-dotnet/commit/164b01761550b4824ad79eff16788995785bd483))
