### PR TITLE
Release Google.Cloud.NetApp.V1 version 1.8.0

### DIFF
--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.csproj
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.7.0</Version>
+    <Version>1.8.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud NetApp Volumes API, which is a fully-managed, cloud-based data storage service that provides advanced data management capabilities and highly scalable performance with global availability.</Description>

--- a/apis/Google.Cloud.NetApp.V1/docs/history.md
+++ b/apis/Google.Cloud.NetApp.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 1.8.0, released 2025-02-03
+
+### New features
+
+- Add support for Quota Rule apis ([commit 5c2f27b](https://github.com/googleapis/google-cloud-dotnet/commit/5c2f27b53160e0a373d11fc463f1537339f93e30))
+- Add ipAddress field to MountOption ([commit 5c2f27b](https://github.com/googleapis/google-cloud-dotnet/commit/5c2f27b53160e0a373d11fc463f1537339f93e30))
+
 ## Version 1.7.0, released 2025-01-13
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -3510,7 +3510,7 @@
     },
     {
       "id": "Google.Cloud.NetApp.V1",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "type": "grpc",
       "productName": "NetApp",
       "productUrl": "https://cloud.google.com/netapp/volumes/docs/discover/overview",


### PR DESCRIPTION

Changes in this release:

### New features

- Add support for Quota Rule apis ([commit 5c2f27b](https://github.com/googleapis/google-cloud-dotnet/commit/5c2f27b53160e0a373d11fc463f1537339f93e30))
- Add ipAddress field to MountOption ([commit 5c2f27b](https://github.com/googleapis/google-cloud-dotnet/commit/5c2f27b53160e0a373d11fc463f1537339f93e30))
