### PR TITLE
Release Google.Cloud.PubSub.V1 version 3.21.0

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.20.0</Version>
+    <Version>3.21.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.</Description>

--- a/apis/Google.Cloud.PubSub.V1/docs/history.md
+++ b/apis/Google.Cloud.PubSub.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.21.0, released 2025-02-03
+
+### New features
+
+- Add support for message transforms to Topic and Subscription ([commit 97502ea](https://github.com/googleapis/google-cloud-dotnet/commit/97502ea06aaea8de9b80ac62fb9f3f1635d3fc49))
+
+### Documentation improvements
+
+- Fix link for AnalyticsHubSubscriptionInfo ([commit 97502ea](https://github.com/googleapis/google-cloud-dotnet/commit/97502ea06aaea8de9b80ac62fb9f3f1635d3fc49))
+
 ## Version 3.20.0, released 2025-01-13
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -4173,7 +4173,7 @@
       "protoPath": "google/pubsub/v1",
       "productName": "Cloud Pub/Sub",
       "productUrl": "https://cloud.google.com/pubsub/",
-      "version": "3.20.0",
+      "version": "3.21.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",


### PR DESCRIPTION

Changes in this release:

### New features

- Add support for message transforms to Topic and Subscription ([commit 97502ea](https://github.com/googleapis/google-cloud-dotnet/commit/97502ea06aaea8de9b80ac62fb9f3f1635d3fc49))

### Documentation improvements

- Fix link for AnalyticsHubSubscriptionInfo ([commit 97502ea](https://github.com/googleapis/google-cloud-dotnet/commit/97502ea06aaea8de9b80ac62fb9f3f1635d3fc49))
