### PR TITLE
chore: Fix configuration for Google.Cloud.Redis.Cluster.V1 to match build.bazel

### DIFF
--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -4321,7 +4321,8 @@
       "shortName": "redis",
       "serviceConfigFile": "redis_v1.yaml",
       "restNumericEnums": true,
-      "includeCommonResourcesProto": true
+      "includeCommonResourcesProto": true,
+      "transport": "grpc+rest"
     },
     {
       "id": "Google.Cloud.Redis.V1",


### PR DESCRIPTION
(With this change in, local regeneration goes back to being a no-op - which it always should be.)