### PR TITLE
Release Google.Cloud.ResourceSettings.V1 version 2.5.0

### DIFF
--- a/apis/Google.Cloud.ResourceSettings.V1/Google.Cloud.ResourceSettings.V1/Google.Cloud.ResourceSettings.V1.csproj
+++ b/apis/Google.Cloud.ResourceSettings.V1/Google.Cloud.ResourceSettings.V1/Google.Cloud.ResourceSettings.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Resource Settings API, which allows users to control and modify the behavior of their GCP resources (e.g., VM, firewall, Project, etc.) across the Cloud Resource Hierarchy.</Description>

--- a/apis/Google.Cloud.ResourceSettings.V1/docs/history.md
+++ b/apis/Google.Cloud.ResourceSettings.V1/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+## Version 2.5.0, released 2025-02-05
+
+This release is being used to publish a new front-page of
+documentation, to indicate package deprecation.
+
 ## Version 2.4.0, released 2024-05-14
 
 ### New features

--- a/apis/Google.Cloud.ResourceSettings.V1/docs/index.md
+++ b/apis/Google.Cloud.ResourceSettings.V1/docs/index.md
@@ -1,0 +1,11 @@
+{{title}}
+
+{{description}}
+
+The Resource Settings API is officially deprecated.
+
+The Google.Cloud.ResourceSettings.V1 package is delisted from NuGet,
+and the source code removed from the google-cloud-dotnet repository.
+Any projects that depend on the package will still be
+able to restore that dependency, but the package won't be shown in
+search results on [nuget.org](https://www.nuget.org/).

--- a/apis/Google.Cloud.ResourceSettings.V1/smoketests.json
+++ b/apis/Google.Cloud.ResourceSettings.V1/smoketests.json
@@ -1,9 +1,0 @@
-[
-  {
-    "method": "ListSettings",
-    "client": "ResourceSettingsServiceClient",
-    "arguments": {
-      "parent": "projects/${PROJECT_ID}"
-    }
-  }
-]

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -4393,7 +4393,7 @@
     },
     {
       "id": "Google.Cloud.ResourceSettings.V1",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "type": "grpc",
       "productName": "Resource Settings",
       "productUrl": "https://cloud.google.com/resource-settings/docs",


### PR DESCRIPTION
Changes in this release:

This release is being used to publish a new front-page of documentation, to indicate package deprecation.