### PR TITLE
Release Google.Cloud.AIPlatform.V1Beta1 version 1.0.0-beta17

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta16</Version>
+    <Version>1.0.0-beta17</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Vertex AI API (v1beta), which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+## Version 1.0.0-beta17, released 2025-02-10
+
+### New features
+
+- A new field `response_id` is added to message `.google.cloud.aiplatform.v1.GenerateContentResponse` ([commit 96edae6](https://github.com/googleapis/google-cloud-dotnet/commit/96edae615ae72e283fd7bcffc73aab724a24c17e))
+- A new field `create_time` is added to message `.google.cloud.aiplatform.v1.GenerateContentResponse` ([commit 96edae6](https://github.com/googleapis/google-cloud-dotnet/commit/96edae615ae72e283fd7bcffc73aab724a24c17e))
+- Add Notebooks Runtime Software Configuration ([commit 40f33a4](https://github.com/googleapis/google-cloud-dotnet/commit/40f33a4326873c397b8b6ed56c8373940dfe6684))
+- Add RolloutOptions to DeployedModel in v1beta1 endpoint.proto, add additional Probe options in v1beta1 model.proto ([commit aeee7bc](https://github.com/googleapis/google-cloud-dotnet/commit/aeee7bcc9bc126bbf92bebaffa135d4c68a74ca0))
+
+### Documentation improvements
+
+- A comment for field `filter` in message `.google.cloud.aiplatform.v1beta1.ListNotebookRuntimeTemplatesRequest` is changed ([commit 40f33a4](https://github.com/googleapis/google-cloud-dotnet/commit/40f33a4326873c397b8b6ed56c8373940dfe6684))
+- A comment for field `filter` in message `.google.cloud.aiplatform.v1beta1.ListNotebookRuntimesRequest` is changed ([commit 40f33a4](https://github.com/googleapis/google-cloud-dotnet/commit/40f33a4326873c397b8b6ed56c8373940dfe6684))
+
 ## Version 1.0.0-beta16, released 2025-02-06
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -373,7 +373,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1Beta1",
-      "version": "1.0.0-beta16",
+      "version": "1.0.0-beta17",
       "type": "grpc",
       "productName": "Vertex AI",
       "productUrl": "https://cloud.google.com/vertex-ai/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- A new field `response_id` is added to message `.google.cloud.aiplatform.v1.GenerateContentResponse` ([commit 96edae6](https://github.com/googleapis/google-cloud-dotnet/commit/96edae615ae72e283fd7bcffc73aab724a24c17e))
- A new field `create_time` is added to message `.google.cloud.aiplatform.v1.GenerateContentResponse` ([commit 96edae6](https://github.com/googleapis/google-cloud-dotnet/commit/96edae615ae72e283fd7bcffc73aab724a24c17e))
- Add Notebooks Runtime Software Configuration ([commit 40f33a4](https://github.com/googleapis/google-cloud-dotnet/commit/40f33a4326873c397b8b6ed56c8373940dfe6684))
- Add RolloutOptions to DeployedModel in v1beta1 endpoint.proto, add additional Probe options in v1beta1 model.proto ([commit aeee7bc](https://github.com/googleapis/google-cloud-dotnet/commit/aeee7bcc9bc126bbf92bebaffa135d4c68a74ca0))

### Documentation improvements

- A comment for field `filter` in message `.google.cloud.aiplatform.v1beta1.ListNotebookRuntimeTemplatesRequest` is changed ([commit 40f33a4](https://github.com/googleapis/google-cloud-dotnet/commit/40f33a4326873c397b8b6ed56c8373940dfe6684))
- A comment for field `filter` in message `.google.cloud.aiplatform.v1beta1.ListNotebookRuntimesRequest` is changed ([commit 40f33a4](https://github.com/googleapis/google-cloud-dotnet/commit/40f33a4326873c397b8b6ed56c8373940dfe6684))
