### PR TITLE
Release Google.Cloud.Dataplex.V1 version 3.6.0

### DIFF
--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.csproj
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.5.0</Version>
+    <Version>3.6.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataplex API, which is used to manage the lifecycle of data lakes.</Description>

--- a/apis/Google.Cloud.Dataplex.V1/docs/history.md
+++ b/apis/Google.Cloud.Dataplex.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.6.0, released 2025-02-10
+
+### New features
+
+- Added value `NONE` to  the `SyncMode` enum ([commit e7d4c50](https://github.com/googleapis/google-cloud-dotnet/commit/e7d4c509db3d64a8dfa007aecc7bafb1832f9609))
+
+### Documentation improvements
+
+- Modified various comments ([commit e7d4c50](https://github.com/googleapis/google-cloud-dotnet/commit/e7d4c509db3d64a8dfa007aecc7bafb1832f9609))
+
 ## Version 3.5.0, released 2025-01-06
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -1844,7 +1844,7 @@
     },
     {
       "id": "Google.Cloud.Dataplex.V1",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "type": "grpc",
       "productName": "Cloud Dataplex",
       "productUrl": "https://cloud.google.com/dataplex/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Added value `NONE` to  the `SyncMode` enum ([commit e7d4c50](https://github.com/googleapis/google-cloud-dotnet/commit/e7d4c509db3d64a8dfa007aecc7bafb1832f9609))

### Documentation improvements

- Modified various comments ([commit e7d4c50](https://github.com/googleapis/google-cloud-dotnet/commit/e7d4c509db3d64a8dfa007aecc7bafb1832f9609))
