### PR TITLE
Release Google.Cloud.Memorystore.V1 version 1.0.0-beta02

### DIFF
--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.csproj
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to administer Cloud Memorystore (v1), a fully-managed database service that provides a managed version of popular open source caching solutions.</Description>

--- a/apis/Google.Cloud.Memorystore.V1/docs/history.md
+++ b/apis/Google.Cloud.Memorystore.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2025-02-10
+
+### New features
+
+- Add Instance.Mode.CLUSTER_DISABLED value, and deprecate STANDALONE ([commit 27fb9d0](https://github.com/googleapis/google-cloud-dotnet/commit/27fb9d000e95b30c40356da91445b030cb8a0c41))
+
+### Documentation improvements
+
+- A comment for enum value `STANDALONE` in enum `Mode` is changed ([commit 27fb9d0](https://github.com/googleapis/google-cloud-dotnet/commit/27fb9d000e95b30c40356da91445b030cb8a0c41))
+
 ## Version 1.0.0-beta01, released 2025-01-23
 
 Initial release.

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -3352,7 +3352,7 @@
     },
     {
       "id": "Google.Cloud.Memorystore.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Memorystore",
       "productUrl": "https://cloud.google.com/memorystore/docs/valkey",


### PR DESCRIPTION

Changes in this release:

### New features

- Add Instance.Mode.CLUSTER_DISABLED value, and deprecate STANDALONE ([commit 27fb9d0](https://github.com/googleapis/google-cloud-dotnet/commit/27fb9d000e95b30c40356da91445b030cb8a0c41))

### Documentation improvements

- A comment for enum value `STANDALONE` in enum `Mode` is changed ([commit 27fb9d0](https://github.com/googleapis/google-cloud-dotnet/commit/27fb9d000e95b30c40356da91445b030cb8a0c41))
