### PR TITLE
Release Google.Cloud.Run.V2 version 2.13.0

### DIFF
--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/Google.Cloud.Run.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.12.0</Version>
+    <Version>2.13.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Run Admin API (v2)</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.3.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />

--- a/apis/Google.Cloud.Run.V2/docs/history.md
+++ b/apis/Google.Cloud.Run.V2/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+## Version 2.13.0, released 2025-02-10
+
+### New features
+
+- Add BuildConfig to Services for configuring Run functions ([commit a73130d](https://github.com/googleapis/google-cloud-dotnet/commit/a73130d3ce4213d802eefe51edc748fe07287f9e))
+- Add BuildInfo to Revision for displaying BuildConfig used for a specific revision deployment ([commit a73130d](https://github.com/googleapis/google-cloud-dotnet/commit/a73130d3ce4213d802eefe51edc748fe07287f9e))
+- Add Base Image URI to Container ([commit a73130d](https://github.com/googleapis/google-cloud-dotnet/commit/a73130d3ce4213d802eefe51edc748fe07287f9e))
+- Add creator field to Execution ([commit a73130d](https://github.com/googleapis/google-cloud-dotnet/commit/a73130d3ce4213d802eefe51edc748fe07287f9e))
+- Add project_descriptor to BuildspackBuild ([commit a73130d](https://github.com/googleapis/google-cloud-dotnet/commit/a73130d3ce4213d802eefe51edc748fe07287f9e))
+
+### Documentation improvements
+
+- Some typos were fixed and formatting changed ([commit a73130d](https://github.com/googleapis/google-cloud-dotnet/commit/a73130d3ce4213d802eefe51edc748fe07287f9e))
+
 ## Version 2.12.0, released 2024-12-06
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -4416,7 +4416,7 @@
     },
     {
       "id": "Google.Cloud.Run.V2",
-      "version": "2.12.0",
+      "version": "2.13.0",
       "type": "grpc",
       "productName": "Cloud Run Admin",
       "productUrl": "https://cloud.google.com/run/docs",
@@ -4426,7 +4426,7 @@
         "admin"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Iam.V1": "3.4.0",
         "Google.Cloud.Location": "2.3.0",
         "Google.LongRunning": "3.3.0"
       },


### PR DESCRIPTION

Changes in this release:

### New features

- Add BuildConfig to Services for configuring Run functions ([commit a73130d](https://github.com/googleapis/google-cloud-dotnet/commit/a73130d3ce4213d802eefe51edc748fe07287f9e))
- Add BuildInfo to Revision for displaying BuildConfig used for a specific revision deployment ([commit a73130d](https://github.com/googleapis/google-cloud-dotnet/commit/a73130d3ce4213d802eefe51edc748fe07287f9e))
- Add Base Image URI to Container ([commit a73130d](https://github.com/googleapis/google-cloud-dotnet/commit/a73130d3ce4213d802eefe51edc748fe07287f9e))
- Add creator field to Execution ([commit a73130d](https://github.com/googleapis/google-cloud-dotnet/commit/a73130d3ce4213d802eefe51edc748fe07287f9e))
- Add project_descriptor to BuildspackBuild ([commit a73130d](https://github.com/googleapis/google-cloud-dotnet/commit/a73130d3ce4213d802eefe51edc748fe07287f9e))

### Documentation improvements

- Some typos were fixed and formatting changed ([commit a73130d](https://github.com/googleapis/google-cloud-dotnet/commit/a73130d3ce4213d802eefe51edc748fe07287f9e))
