### PR TITLE
Release Google.Cloud.Batch.V1 version 2.13.0

### DIFF
--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.12.0</Version>
+    <Version>2.13.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Batch API (v1), which allows you to manage the running of batch jobs on Google Cloud Platform.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.3.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />

--- a/apis/Google.Cloud.Batch.V1/docs/history.md
+++ b/apis/Google.Cloud.Batch.V1/docs/history.md
@@ -1,5 +1,21 @@
 # Version history
 
+## Version 2.13.0, released 2025-02-18
+
+### New features
+
+- Promote cancel job API to GA ([commit 5f94220](https://github.com/googleapis/google-cloud-dotnet/commit/5f9422098afd09e3a380f87da95015dad6685734))
+
+### Documentation improvements
+
+- Fix broken references in comments ([commit 945b0e2](https://github.com/googleapis/google-cloud-dotnet/commit/945b0e287dffcf7e6c623de90ac7853c0c860181))
+- Clarify options for logs ([commit e86bb14](https://github.com/googleapis/google-cloud-dotnet/commit/e86bb14daa6647f1feae65c4aca5b82fcaa2240a))
+- Clarify the custom instance template needs to be in the same project ([commit e86bb14](https://github.com/googleapis/google-cloud-dotnet/commit/e86bb14daa6647f1feae65c4aca5b82fcaa2240a))
+- Rephrase reservation field doc ([commit 1d9b15d](https://github.com/googleapis/google-cloud-dotnet/commit/1d9b15d706a0579dd249d1d7076f2befe3b188ef))
+- Update reservation field to include NO_RESERVATION ([commit 1735012](https://github.com/googleapis/google-cloud-dotnet/commit/17350123570a6aaf13df90421c804a2361eb1336))
+- Clarify that user provided labels will also be applied to Cloud Logging ([commit 1735012](https://github.com/googleapis/google-cloud-dotnet/commit/17350123570a6aaf13df90421c804a2361eb1336))
+- Clarify Batch only supports global custom instance template now ([commit a8f24e4](https://github.com/googleapis/google-cloud-dotnet/commit/a8f24e494bc361e2548ab5876b9f5acd25847459))
+
 ## Version 2.12.0, released 2024-09-09
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -790,7 +790,7 @@
     },
     {
       "id": "Google.Cloud.Batch.V1",
-      "version": "2.12.0",
+      "version": "2.13.0",
       "type": "grpc",
       "productName": "Batch",
       "productUrl": "https://cloud.google.com/batch/docs/",
@@ -799,7 +799,7 @@
         "batch"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Iam.V1": "3.4.0",
         "Google.Cloud.Location": "2.3.0",
         "Google.LongRunning": "3.3.0"
       },


### PR DESCRIPTION

Changes in this release:

### New features

- Promote cancel job API to GA ([commit 5f94220](https://github.com/googleapis/google-cloud-dotnet/commit/5f9422098afd09e3a380f87da95015dad6685734))

### Documentation improvements

- Fix broken references in comments ([commit 945b0e2](https://github.com/googleapis/google-cloud-dotnet/commit/945b0e287dffcf7e6c623de90ac7853c0c860181))
- Clarify options for logs ([commit e86bb14](https://github.com/googleapis/google-cloud-dotnet/commit/e86bb14daa6647f1feae65c4aca5b82fcaa2240a))
- Clarify the custom instance template needs to be in the same project ([commit e86bb14](https://github.com/googleapis/google-cloud-dotnet/commit/e86bb14daa6647f1feae65c4aca5b82fcaa2240a))
- Rephrase reservation field doc ([commit 1d9b15d](https://github.com/googleapis/google-cloud-dotnet/commit/1d9b15d706a0579dd249d1d7076f2befe3b188ef))
- Update reservation field to include NO_RESERVATION ([commit 1735012](https://github.com/googleapis/google-cloud-dotnet/commit/17350123570a6aaf13df90421c804a2361eb1336))
- Clarify that user provided labels will also be applied to Cloud Logging ([commit 1735012](https://github.com/googleapis/google-cloud-dotnet/commit/17350123570a6aaf13df90421c804a2361eb1336))
- Clarify Batch only supports global custom instance template now ([commit a8f24e4](https://github.com/googleapis/google-cloud-dotnet/commit/a8f24e494bc361e2548ab5876b9f5acd25847459))
