### PR TITLE
Release Google.Cloud.CloudBuild.V1 version 2.15.0

### DIFF
--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.csproj
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.14.0</Version>
+    <Version>2.15.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Build API v1, which creates and manages builds on Google Cloud Platform.</Description>

--- a/apis/Google.Cloud.CloudBuild.V1/docs/history.md
+++ b/apis/Google.Cloud.CloudBuild.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 2.15.0, released 2025-02-18
+
+### New features
+
+- Support for git proxy setup ([commit 377ec77](https://github.com/googleapis/google-cloud-dotnet/commit/377ec7749999ee4d288205056975c1c39bfb3d64))
+- Add option to enable fetching dependencies ([commit f4430c8](https://github.com/googleapis/google-cloud-dotnet/commit/f4430c836be3850d8444a8009d33924b89224dee))
+
+### Documentation improvements
+
+- Updates to proto message comments ([commit 377ec77](https://github.com/googleapis/google-cloud-dotnet/commit/377ec7749999ee4d288205056975c1c39bfb3d64))
+
 ## Version 2.14.0, released 2025-01-13
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -1384,7 +1384,7 @@
     },
     {
       "id": "Google.Cloud.CloudBuild.V1",
-      "version": "2.14.0",
+      "version": "2.15.0",
       "type": "grpc",
       "productName": "Cloud Build",
       "productUrl": "https://cloud.google.com/cloud-build",


### PR DESCRIPTION

Changes in this release:

### New features

- Support for git proxy setup ([commit 377ec77](https://github.com/googleapis/google-cloud-dotnet/commit/377ec7749999ee4d288205056975c1c39bfb3d64))
- Add option to enable fetching dependencies ([commit f4430c8](https://github.com/googleapis/google-cloud-dotnet/commit/f4430c836be3850d8444a8009d33924b89224dee))

### Documentation improvements

- Updates to proto message comments ([commit 377ec77](https://github.com/googleapis/google-cloud-dotnet/commit/377ec7749999ee4d288205056975c1c39bfb3d64))
