### PR TITLE
Release Google.Cloud.Parallelstore.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.csproj
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library for Parallelstore: a fully managed, low-latency distributed file system designed to meet the demands of high performance computing (HPC) and data-intensive applications.</Description>

--- a/apis/Google.Cloud.Parallelstore.V1/docs/history.md
+++ b/apis/Google.Cloud.Parallelstore.V1/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+## Version 1.1.0, released 2025-02-18
+
+### New features
+
+- Deprecating `daos_version` field ([commit c133d25](https://github.com/googleapis/google-cloud-dotnet/commit/c133d25e73be86850b049be876652dd07cd50cef))
+- Adding `deployment_type` field ([commit c133d25](https://github.com/googleapis/google-cloud-dotnet/commit/c133d25e73be86850b049be876652dd07cd50cef))
+
+### Documentation improvements
+
+- Updated documentation for field `daos_version` in message `.google.cloud.parallelstore.v1.Instance` to reflect that the field is deprecated. ([commit c133d25](https://github.com/googleapis/google-cloud-dotnet/commit/c133d25e73be86850b049be876652dd07cd50cef))
+- Updated field `file_stripe_level` in message `.google.cloud.parallelstore.v1.Instance` to reflected that message is now immutable ([commit c133d25](https://github.com/googleapis/google-cloud-dotnet/commit/c133d25e73be86850b049be876652dd07cd50cef))
+- Updated `directory_stripe_level` in message `.google.cloud.parallelstore.v1.Instance` to reflect that the field is now immutable ([commit c133d25](https://github.com/googleapis/google-cloud-dotnet/commit/c133d25e73be86850b049be876652dd07cd50cef))
+- Fix links in documentation ([commit 20306d8](https://github.com/googleapis/google-cloud-dotnet/commit/20306d8ebb4f5721a26a5fbfd664403328d5ae71))
+
 ## Version 1.0.0, released 2024-12-05
 
 No API surface changes; just dependency updates and promotion to GA.

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -3948,7 +3948,7 @@
     },
     {
       "id": "Google.Cloud.Parallelstore.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Parallelstore",
       "productUrl": "https://cloud.google.com/parallelstore?hl=en",


### PR DESCRIPTION

Changes in this release:

### New features

- Deprecating `daos_version` field ([commit c133d25](https://github.com/googleapis/google-cloud-dotnet/commit/c133d25e73be86850b049be876652dd07cd50cef))
- Adding `deployment_type` field ([commit c133d25](https://github.com/googleapis/google-cloud-dotnet/commit/c133d25e73be86850b049be876652dd07cd50cef))

### Documentation improvements

- Updated documentation for field `daos_version` in message `.google.cloud.parallelstore.v1.Instance` to reflect that the field is deprecated. ([commit c133d25](https://github.com/googleapis/google-cloud-dotnet/commit/c133d25e73be86850b049be876652dd07cd50cef))
- Updated field `file_stripe_level` in message `.google.cloud.parallelstore.v1.Instance` to reflected that message is now immutable ([commit c133d25](https://github.com/googleapis/google-cloud-dotnet/commit/c133d25e73be86850b049be876652dd07cd50cef))
- Updated `directory_stripe_level` in message `.google.cloud.parallelstore.v1.Instance` to reflect that the field is now immutable ([commit c133d25](https://github.com/googleapis/google-cloud-dotnet/commit/c133d25e73be86850b049be876652dd07cd50cef))
- Fix links in documentation ([commit 20306d8](https://github.com/googleapis/google-cloud-dotnet/commit/20306d8ebb4f5721a26a5fbfd664403328d5ae71))
