### PR TITLE
Release Google.Cloud.SecurityCenter.V2 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.csproj
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Security Command Center API (v2), which helps security teams gather data, identify threats, and act on them before they result in business damage or loss.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>

--- a/apis/Google.Cloud.SecurityCenter.V2/docs/history.md
+++ b/apis/Google.Cloud.SecurityCenter.V2/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 1.1.0, released 2025-02-18
+
+### New features
+
+- Added more information about DDoS attack in cloud armor proto ([commit 960927e](https://github.com/googleapis/google-cloud-dotnet/commit/960927e2a7049e69035e761de9246b76de2bd8ac))
+- Added data access event fields to finding proto ([commit 960927e](https://github.com/googleapis/google-cloud-dotnet/commit/960927e2a7049e69035e761de9246b76de2bd8ac))
+
+### Documentation improvements
+
+- Clarified comments for tag_values field in resource_value_config to make it clear that field represents tag value ids, not tag values ([commit 960927e](https://github.com/googleapis/google-cloud-dotnet/commit/960927e2a7049e69035e761de9246b76de2bd8ac))
+
 ## Version 1.0.0, released 2024-12-05
 
 No API surface changes; just dependency updates and promotion to GA.

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -4695,7 +4695,7 @@
     },
     {
       "id": "Google.Cloud.SecurityCenter.V2",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "Security Command Center",
       "productUrl": "https://cloud.google.com/security-command-center/docs/reference/rest",
@@ -4705,7 +4705,7 @@
         "data risk"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Iam.V1": "3.4.0",
         "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",


### PR DESCRIPTION

Changes in this release:

### New features

- Added more information about DDoS attack in cloud armor proto ([commit 960927e](https://github.com/googleapis/google-cloud-dotnet/commit/960927e2a7049e69035e761de9246b76de2bd8ac))
- Added data access event fields to finding proto ([commit 960927e](https://github.com/googleapis/google-cloud-dotnet/commit/960927e2a7049e69035e761de9246b76de2bd8ac))

### Documentation improvements

- Clarified comments for tag_values field in resource_value_config to make it clear that field represents tag value ids, not tag values ([commit 960927e](https://github.com/googleapis/google-cloud-dotnet/commit/960927e2a7049e69035e761de9246b76de2bd8ac))
