### PR TITLE
Release Google.Apps.Chat.V1 version 1.0.0-beta12

### DIFF
--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/Google.Apps.Chat.V1.csproj
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/Google.Apps.Chat.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta11</Version>
+    <Version>1.0.0-beta12</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Chat API, which lets you build Chat apps to integrate your services with Google Chat and manage Chat resources such as spaces, members, and messages.</Description>

--- a/apis/Google.Apps.Chat.V1/docs/history.md
+++ b/apis/Google.Apps.Chat.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.0.0-beta12, released 2025-02-25
+
+### New features
+
+- Add DeletionType.SPACE_MEMBER. This is returned when a message sent by an app is deleted by a human in a space ([commit b729eb0](https://github.com/googleapis/google-cloud-dotnet/commit/b729eb04fba00bc1013ba4e534537354c25e1698))
+
+### Documentation improvements
+
+- Update Google chat app command documentation ([commit 43e29cc](https://github.com/googleapis/google-cloud-dotnet/commit/43e29cc276ad371ab5446e6f8f30be819e34c357))
+
 ## Version 1.0.0-beta11, released 2025-02-03
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -119,7 +119,7 @@
     },
     {
       "id": "Google.Apps.Chat.V1",
-      "version": "1.0.0-beta11",
+      "version": "1.0.0-beta12",
       "type": "grpc",
       "productName": "Google Chat",
       "productUrl": "https://developers.google.com/chat/concepts",


### PR DESCRIPTION

Changes in this release:

### New features

- Add DeletionType.SPACE_MEMBER. This is returned when a message sent by an app is deleted by a human in a space ([commit b729eb0](https://github.com/googleapis/google-cloud-dotnet/commit/b729eb04fba00bc1013ba4e534537354c25e1698))

### Documentation improvements

- Update Google chat app command documentation ([commit 43e29cc](https://github.com/googleapis/google-cloud-dotnet/commit/43e29cc276ad371ab5446e6f8f30be819e34c357))
