### PR TITLE
Release Google.Cloud.ConfidentialComputing.V1 version 1.8.0

### DIFF
--- a/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.csproj
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.7.0</Version>
+    <Version>1.8.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Confidential Computing API (v1)</Description>

--- a/apis/Google.Cloud.ConfidentialComputing.V1/docs/history.md
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.8.0, released 2025-02-25
+
+### New features
+
+- A new field `attester` is added to message `.google.cloud.confidentialcomputing.v1.VerifyAttestationRequest` ([commit 99aef8d](https://github.com/googleapis/google-cloud-dotnet/commit/99aef8d372669dc95bb063459f0aeb9fb8621f86))
+
+### Documentation improvements
+
+- Fixed a typo in `VerifyAttestationRequest` comment ([commit 99aef8d](https://github.com/googleapis/google-cloud-dotnet/commit/99aef8d372669dc95bb063459f0aeb9fb8621f86))
+
 ## Version 1.7.0, released 2024-12-06
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -1591,7 +1591,7 @@
     },
     {
       "id": "Google.Cloud.ConfidentialComputing.V1",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "type": "grpc",
       "productName": "Confidential Computing",
       "productUrl": "https://cloud.google.com/confidential-computing",


### PR DESCRIPTION

Changes in this release:

### New features

- A new field `attester` is added to message `.google.cloud.confidentialcomputing.v1.VerifyAttestationRequest` ([commit 99aef8d](https://github.com/googleapis/google-cloud-dotnet/commit/99aef8d372669dc95bb063459f0aeb9fb8621f86))

### Documentation improvements

- Fixed a typo in `VerifyAttestationRequest` comment ([commit 99aef8d](https://github.com/googleapis/google-cloud-dotnet/commit/99aef8d372669dc95bb063459f0aeb9fb8621f86))
