### PR TITLE
Release Google.Cloud.Dataproc.V1 version 5.17.0

### DIFF
--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.16.0</Version>
+    <Version>5.17.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataproc API, which manages Hadoop-based clusters and jobs on Google Cloud Platform.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>

--- a/apis/Google.Cloud.Dataproc.V1/docs/history.md
+++ b/apis/Google.Cloud.Dataproc.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 5.17.0, released 2025-02-25
+
+### New features
+
+- Added support for the AuthenticationConfig field to Dataproc serverless workload configurations, allowing specification of the user workload identity as either the end user or a service account ([commit e67b038](https://github.com/googleapis/google-cloud-dotnet/commit/e67b038e604c9f21b531f5f1bf779297a31620c8))
+
 ## Version 5.16.0, released 2024-10-21
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -1872,7 +1872,7 @@
       "protoPath": "google/cloud/dataproc/v1",
       "productName": "Google Cloud Dataproc",
       "productUrl": "https://cloud.google.com/dataproc/docs/concepts/overview",
-      "version": "5.16.0",
+      "version": "5.17.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Dataproc API, which manages Hadoop-based clusters and jobs on Google Cloud Platform.",
       "tags": [
@@ -1880,7 +1880,7 @@
         "Hadoop"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Iam.V1": "3.4.0",
         "Google.LongRunning": "3.3.0"
       },
       "shortName": "dataproc",


### PR DESCRIPTION

Changes in this release:

### New features

- Added support for the AuthenticationConfig field to Dataproc serverless workload configurations, allowing specification of the user workload identity as either the end user or a service account ([commit e67b038](https://github.com/googleapis/google-cloud-dotnet/commit/e67b038e604c9f21b531f5f1bf779297a31620c8))
