### PR TITLE
Release Google.Cloud.Kms.V1 version 3.16.0

### DIFF
--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.csproj
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.15.0</Version>
+    <Version>3.16.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Key Management Service API, which manages encryption for your cloud services the same way you do on-premises. You can generate, use, rotate, and destroy AES256 encryption keys.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.3.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />

--- a/apis/Google.Cloud.Kms.V1/docs/history.md
+++ b/apis/Google.Cloud.Kms.V1/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 3.16.0, released 2025-02-25
+
+### New features
+
+- Support PQC asymmetric signing algorithms ML_DSA_65 and SLH_DSA_SHA2_128s ([commit 0f261f0](https://github.com/googleapis/google-cloud-dotnet/commit/0f261f0ccd662035e9eabd289b64aeb1271d5c59))
+- Add a PublicKeyFormat enum to allow specifying the format the public is going to be exported in ([commit 0f261f0](https://github.com/googleapis/google-cloud-dotnet/commit/0f261f0ccd662035e9eabd289b64aeb1271d5c59))
+
+### Documentation improvements
+
+- Modify enum comment ([commit 0cf6e5b](https://github.com/googleapis/google-cloud-dotnet/commit/0cf6e5bb7fbbcaffa670bc844b1cd517c92dd01b))
+- Code documentation improvements ([commit 87c4799](https://github.com/googleapis/google-cloud-dotnet/commit/87c479909782d2cc1859dd94652cb8507933c9f2))
+- A comment for enum `CryptoKeyVersionAlgorithm` is changed ([commit d7e6cd5](https://github.com/googleapis/google-cloud-dotnet/commit/d7e6cd5afe2c0b14d09dcd9a41cd5edb676bc741))
+
 ## Version 3.15.0, released 2024-10-30
 
 ### Documentation improvements

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -3020,7 +3020,7 @@
       "protoPath": "google/cloud/kms/v1",
       "productName": "Google Cloud Key Management Service",
       "productUrl": "https://cloud.google.com/kms/",
-      "version": "3.15.0",
+      "version": "3.16.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Key Management Service API, which manages encryption for your cloud services the same way you do on-premises. You can generate, use, rotate, and destroy AES256 encryption keys.",
       "tags": [
@@ -3030,7 +3030,7 @@
         "encryption"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Iam.V1": "3.4.0",
         "Google.Cloud.Location": "2.3.0",
         "Google.LongRunning": "3.3.0"
       },


### PR DESCRIPTION

Changes in this release:

### New features

- Support PQC asymmetric signing algorithms ML_DSA_65 and SLH_DSA_SHA2_128s ([commit 0f261f0](https://github.com/googleapis/google-cloud-dotnet/commit/0f261f0ccd662035e9eabd289b64aeb1271d5c59))
- Add a PublicKeyFormat enum to allow specifying the format the public is going to be exported in ([commit 0f261f0](https://github.com/googleapis/google-cloud-dotnet/commit/0f261f0ccd662035e9eabd289b64aeb1271d5c59))

### Documentation improvements

- Modify enum comment ([commit 0cf6e5b](https://github.com/googleapis/google-cloud-dotnet/commit/0cf6e5bb7fbbcaffa670bc844b1cd517c92dd01b))
- Code documentation improvements ([commit 87c4799](https://github.com/googleapis/google-cloud-dotnet/commit/87c479909782d2cc1859dd94652cb8507933c9f2))
- A comment for enum `CryptoKeyVersionAlgorithm` is changed ([commit d7e6cd5](https://github.com/googleapis/google-cloud-dotnet/commit/d7e6cd5afe2c0b14d09dcd9a41cd5edb676bc741))
