### PR TITLE
Release Google.Apps.Meet.V2Beta version 1.0.0-beta07

### DIFF
--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.csproj
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta06</Version>
+    <Version>1.0.0-beta07</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Create and manage meetings in Google Meet.</Description>

--- a/apis/Google.Apps.Meet.V2Beta/docs/history.md
+++ b/apis/Google.Apps.Meet.V2Beta/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta07, released 2025-03-03
+
+### New features
+
+- Add `ConnectActiveConference` method to `SpacesService` ([commit 3df6acc](https://github.com/googleapis/google-cloud-dotnet/commit/3df6accf01c07cb6414ec4c2d6a882f4f78f24af))
+
 ## Version 1.0.0-beta06, released 2025-02-03
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -182,7 +182,7 @@
     },
     {
       "id": "Google.Apps.Meet.V2Beta",
-      "version": "1.0.0-beta06",
+      "version": "1.0.0-beta07",
       "type": "grpc",
       "productName": "Google Meet",
       "productUrl": "https://developers.google.com/meet/api/guides/overview",


### PR DESCRIPTION

Changes in this release:

### New features

- Add `ConnectActiveConference` method to `SpacesService` ([commit 3df6acc](https://github.com/googleapis/google-cloud-dotnet/commit/3df6accf01c07cb6414ec4c2d6a882f4f78f24af))
