### PR TITLE
Release Google.Cloud.AIPlatform.V1 version 3.20.0

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.19.0</Version>
+    <Version>3.20.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Vertex AI API (v1), which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 3.20.0, released 2025-03-03
+
+### New features
+
+- Add VertexAISearch.engine option ([commit cffeac2](https://github.com/googleapis/google-cloud-dotnet/commit/cffeac2417604e2cce38884d322b5f40141775b8))
+- Add EnterpriseWebSearch tool option ([commit 1b04726](https://github.com/googleapis/google-cloud-dotnet/commit/1b047263b3b77afdb0ee4f7c3072aaeef6070af1))
+
 ## Version 3.19.0, released 2025-02-18
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -397,7 +397,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1",
-      "version": "3.19.0",
+      "version": "3.20.0",
       "type": "grpc",
       "productName": "Vertex AI",
       "productUrl": "https://cloud.google.com/vertex-ai/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add VertexAISearch.engine option ([commit cffeac2](https://github.com/googleapis/google-cloud-dotnet/commit/cffeac2417604e2cce38884d322b5f40141775b8))
- Add EnterpriseWebSearch tool option ([commit 1b04726](https://github.com/googleapis/google-cloud-dotnet/commit/1b047263b3b77afdb0ee4f7c3072aaeef6070af1))
