### PR TITLE
Release Google.Cloud.Dataform.V1Beta1 version 1.0.0-beta08

### DIFF
--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.csproj
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta07</Version>
+    <Version>1.0.0-beta08</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataform API (v1beta1) which allows you to develop and operationalize scalable data transformations pipelines in BigQuery using SQL.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.3.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>

--- a/apis/Google.Cloud.Dataform.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Dataform.V1Beta1/docs/history.md
@@ -1,5 +1,31 @@
 # Version history
 
+## Version 1.0.0-beta08, released 2025-03-03
+
+### Bug fixes
+
+- **BREAKING CHANGE** Response type of method `CommitRepositoryChanges` is changed from `.google.protobuf.Empty` to `.google.cloud.dataform.v1beta1.CommitRepositoryChangesResponse` in service `Dataform` ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
+- **BREAKING CHANGE** Response type of method `PullGitCommits` is changed from `.google.protobuf.Empty` to `.google.cloud.dataform.v1beta1.PullGitCommitsResponse` in service `Dataform` ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
+- **BREAKING CHANGE** Response type of method `PushGitCommits` is changed from `.google.protobuf.Empty` to `.google.cloud.dataform.v1beta1.PushGitCommitsResponse` in service `Dataform` ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
+- **BREAKING CHANGE** Response type of method `CommitWorkspaceChanges` is changed from `.google.protobuf.Empty` to `.google.cloud.dataform.v1beta1.CommitWorkspaceChangesResponse` in service `Dataform` ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
+- **BREAKING CHANGE** Response type of method `ResetWorkspaceChanges` is changed from `.google.protobuf.Empty` to `.google.cloud.dataform.v1beta1.ResetWorkspaceChangesResponse` in service `Dataform` ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
+- **BREAKING CHANGE** Response type of method `RemoveDirectory` is changed from `.google.protobuf.Empty` to `.google.cloud.dataform.v1beta1.RemoveDirectoryResponse` in service `Dataform` ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
+- **BREAKING CHANGE** Response type of method `RemoveFileRequest` is changed from `.google.protobuf.Empty` to `.google.cloud.dataform.v1beta1.RemoveFileResponse` in service `Dataform` ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
+- **BREAKING CHANGE** Response type of method `CancelWorkflowInvocation` is changed from `.google.protobuf.Empty` to `.google.cloud.dataform.v1beta1.CancelWorkflowInvocationResponse` in service `Dataform` ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
+- **BREAKING CHANGE** An existing field `bigquery_action` is moved in to oneof in message `.google.cloud.dataform.v1beta1.WorkflowInvocationAction` ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
+
+### New features
+
+- Added new field `internal_metadata` to all resources to export all the metadata information that is used internally to serve the resource ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
+- Returning `commit_sha` in the response of method `CommitRepositoryChanges` ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
+- Moving existing field `bigquery_action` to oneof in message `.google.cloud.dataform.v1beta1.WorkflowInvocationAction` to allow adding more actions types such as `notebook_action` ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
+
+### Documentation improvements
+
+- Explained the effect of field `page_token` on the pagination in several messages ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
+- Adds known limitations on several methods such as `UpdateRepository`, `UpdateReleaseConfig` and `UpdateWorkflowConfig` ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
+- Several comments reformatted ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
+
 ## Version 1.0.0-beta07, released 2024-06-04
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -1819,7 +1819,7 @@
     },
     {
       "id": "Google.Cloud.Dataform.V1Beta1",
-      "version": "1.0.0-beta07",
+      "version": "1.0.0-beta08",
       "type": "grpc",
       "productName": "Dataform",
       "productUrl": "https://cloud.google.com/dataform",
@@ -1831,7 +1831,7 @@
         "dataform"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Iam.V1": "3.4.0",
         "Google.Cloud.Location": "2.3.0"
       },
       "generator": "micro",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Response type of method `CommitRepositoryChanges` is changed from `.google.protobuf.Empty` to `.google.cloud.dataform.v1beta1.CommitRepositoryChangesResponse` in service `Dataform` ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
- **BREAKING CHANGE** Response type of method `PullGitCommits` is changed from `.google.protobuf.Empty` to `.google.cloud.dataform.v1beta1.PullGitCommitsResponse` in service `Dataform` ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
- **BREAKING CHANGE** Response type of method `PushGitCommits` is changed from `.google.protobuf.Empty` to `.google.cloud.dataform.v1beta1.PushGitCommitsResponse` in service `Dataform` ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
- **BREAKING CHANGE** Response type of method `CommitWorkspaceChanges` is changed from `.google.protobuf.Empty` to `.google.cloud.dataform.v1beta1.CommitWorkspaceChangesResponse` in service `Dataform` ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
- **BREAKING CHANGE** Response type of method `ResetWorkspaceChanges` is changed from `.google.protobuf.Empty` to `.google.cloud.dataform.v1beta1.ResetWorkspaceChangesResponse` in service `Dataform` ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
- **BREAKING CHANGE** Response type of method `RemoveDirectory` is changed from `.google.protobuf.Empty` to `.google.cloud.dataform.v1beta1.RemoveDirectoryResponse` in service `Dataform` ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
- **BREAKING CHANGE** Response type of method `RemoveFileRequest` is changed from `.google.protobuf.Empty` to `.google.cloud.dataform.v1beta1.RemoveFileResponse` in service `Dataform` ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
- **BREAKING CHANGE** Response type of method `CancelWorkflowInvocation` is changed from `.google.protobuf.Empty` to `.google.cloud.dataform.v1beta1.CancelWorkflowInvocationResponse` in service `Dataform` ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
- **BREAKING CHANGE** An existing field `bigquery_action` is moved in to oneof in message `.google.cloud.dataform.v1beta1.WorkflowInvocationAction` ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))

### New features

- Added new field `internal_metadata` to all resources to export all the metadata information that is used internally to serve the resource ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
- Returning `commit_sha` in the response of method `CommitRepositoryChanges` ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
- Moving existing field `bigquery_action` to oneof in message `.google.cloud.dataform.v1beta1.WorkflowInvocationAction` to allow adding more actions types such as `notebook_action` ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))

### Documentation improvements

- Explained the effect of field `page_token` on the pagination in several messages ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
- Adds known limitations on several methods such as `UpdateRepository`, `UpdateReleaseConfig` and `UpdateWorkflowConfig` ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
- Several comments reformatted ([commit 4985789](https://github.com/googleapis/google-cloud-dotnet/commit/4985789a9865a50a2f07e24360b42ea9438a9ca5))
