### PR TITLE
Release Google.Cloud.Dialogflow.Cx.V3 version 2.22.0

### DIFF
--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.21.0</Version>
+    <Version>2.22.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Builds conversational interfaces (for example, chatbots, and voice-powered apps and devices).</Description>

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 2.22.0, released 2025-03-03
+
+### New features
+
+- Exposed Zone Separation & Zone Isolation status of an agent ([commit ff7c7ed](https://github.com/googleapis/google-cloud-dotnet/commit/ff7c7ed843331cf6121e8be1eb404032ba5a9b56))
+- Added support for document_processing_mode ([commit ff7c7ed](https://github.com/googleapis/google-cloud-dotnet/commit/ff7c7ed843331cf6121e8be1eb404032ba5a9b56))
+
+### Documentation improvements
+
+- Clarified wording around use_timeout_based_endpointing ([commit ff7c7ed](https://github.com/googleapis/google-cloud-dotnet/commit/ff7c7ed843331cf6121e8be1eb404032ba5a9b56))
+- Clarified wording around StreamingDetectIntentRequest ([commit ff7c7ed](https://github.com/googleapis/google-cloud-dotnet/commit/ff7c7ed843331cf6121e8be1eb404032ba5a9b56))
+
 ## Version 2.21.0, released 2024-11-18
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -2144,7 +2144,7 @@
     },
     {
       "id": "Google.Cloud.Dialogflow.Cx.V3",
-      "version": "2.21.0",
+      "version": "2.22.0",
       "type": "grpc",
       "productName": "Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow/cx/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Exposed Zone Separation & Zone Isolation status of an agent ([commit ff7c7ed](https://github.com/googleapis/google-cloud-dotnet/commit/ff7c7ed843331cf6121e8be1eb404032ba5a9b56))
- Added support for document_processing_mode ([commit ff7c7ed](https://github.com/googleapis/google-cloud-dotnet/commit/ff7c7ed843331cf6121e8be1eb404032ba5a9b56))

### Documentation improvements

- Clarified wording around use_timeout_based_endpointing ([commit ff7c7ed](https://github.com/googleapis/google-cloud-dotnet/commit/ff7c7ed843331cf6121e8be1eb404032ba5a9b56))
- Clarified wording around StreamingDetectIntentRequest ([commit ff7c7ed](https://github.com/googleapis/google-cloud-dotnet/commit/ff7c7ed843331cf6121e8be1eb404032ba5a9b56))
