### PR TITLE
Release Google.Cloud.Logging.Console version 1.4.0

### DIFF
--- a/apis/Google.Cloud.Logging.Console/Google.Cloud.Logging.Console/Google.Cloud.Logging.Console.csproj
+++ b/apis/Google.Cloud.Logging.Console/Google.Cloud.Logging.Console/Google.Cloud.Logging.Console.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.1</Version>
+    <Version>1.4.0</Version>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>ConsoleFormatter for Google Cloud Logging.</Description>

--- a/apis/Google.Cloud.Logging.Console/docs/history.md
+++ b/apis/Google.Cloud.Logging.Console/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.4.0, released 2025-03-03
+
+### New features
+
+- Add formatting augmenter to console logging ([issue 14284](https://github.com/googleapis/google-cloud-dotnet/issues/14284)) ([commit e5d0659](https://github.com/googleapis/google-cloud-dotnet/commit/e5d0659e2c98417d72f99629af9d10703d4822b6))
+
 ## Version 1.3.1, released 2024-11-18
 
 No API surface changes, just an update of the Microsoft.Extensions.Logging.Console dependency. This transitively updates System.Text.Json, addressing a security vulnerability in the earlier version.

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -3154,7 +3154,7 @@
     },
     {
       "id": "Google.Cloud.Logging.Console",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "type": "other",
       "metadataType": "INTEGRATION",
       "targetFrameworks": "netstandard2.0",


### PR DESCRIPTION

Changes in this release:

### New features

- Add formatting augmenter to console logging ([issue 14284](https://github.com/googleapis/google-cloud-dotnet/issues/14284)) ([commit e5d0659](https://github.com/googleapis/google-cloud-dotnet/commit/e5d0659e2c98417d72f99629af9d10703d4822b6))
