### PR TITLE
Release Google.Maps.FleetEngine.Delivery.V1 version 2.2.0

### DIFF
--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.csproj
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Fleet Engine Delivery API (v1), which enables access to Deliveries Solutions.</Description>

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/docs/history.md
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/docs/history.md
@@ -1,5 +1,20 @@
 # Version history
 
+## Version 2.2.0, released 2025-03-03
+
+### New features
+
+- Added Fleet Engine Delete APIs ([commit cac2084](https://github.com/googleapis/google-cloud-dotnet/commit/cac2084441145afce9db04966a108f3a058593ae))
+- A new field `past_locations` is added to message `.maps.fleetengine.delivery.v1.DeliveryVehicle` ([commit a7863c7](https://github.com/googleapis/google-cloud-dotnet/commit/a7863c77477b062918f45c0928f453d24d42ff82))
+- A new field `past_locations` is added to message `.maps.fleetengine.v1.Vehicle` ([commit a7863c7](https://github.com/googleapis/google-cloud-dotnet/commit/a7863c77477b062918f45c0928f453d24d42ff82))
+
+### Documentation improvements
+
+- Updated documentation for field `task` in message `.maps.fleetengine.delivery.v1.CreateTaskRequest` to clarify certain fields can be optionally set. ([commit a7863c7](https://github.com/googleapis/google-cloud-dotnet/commit/a7863c77477b062918f45c0928f453d24d42ff82))
+- Update comment link for ListTasks filter ([commit 5970dc3](https://github.com/googleapis/google-cloud-dotnet/commit/5970dc352347ca721bb71a88cdc7b9f4f64c5d48))
+- Document that delivery_vehicle.type can be set on CreateDeliveryVehicle ([commit 658fd07](https://github.com/googleapis/google-cloud-dotnet/commit/658fd07382a9af2e1a3a55e5c8fa75f955efe20b))
+- Clarify behavior of UpdateDeliveryVehicle ([commit 4acca65](https://github.com/googleapis/google-cloud-dotnet/commit/4acca6552767fe47081ef563ac9c570a43970631))
+
 ## Version 2.1.0, released 2024-06-04
 
 ### Documentation improvements

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -6066,7 +6066,7 @@
     },
     {
       "id": "Google.Maps.FleetEngine.Delivery.V1",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "productName": "Last Mile Fleet Solution Delivery",
       "productUrl": "https://developers.google.com/maps/documentation/transportation-logistics/mobility",


### PR DESCRIPTION

Changes in this release:

### New features

- Added Fleet Engine Delete APIs ([commit cac2084](https://github.com/googleapis/google-cloud-dotnet/commit/cac2084441145afce9db04966a108f3a058593ae))
- A new field `past_locations` is added to message `.maps.fleetengine.delivery.v1.DeliveryVehicle` ([commit a7863c7](https://github.com/googleapis/google-cloud-dotnet/commit/a7863c77477b062918f45c0928f453d24d42ff82))
- A new field `past_locations` is added to message `.maps.fleetengine.v1.Vehicle` ([commit a7863c7](https://github.com/googleapis/google-cloud-dotnet/commit/a7863c77477b062918f45c0928f453d24d42ff82))

### Documentation improvements

- Updated documentation for field `task` in message `.maps.fleetengine.delivery.v1.CreateTaskRequest` to clarify certain fields can be optionally set. ([commit a7863c7](https://github.com/googleapis/google-cloud-dotnet/commit/a7863c77477b062918f45c0928f453d24d42ff82))
- Update comment link for ListTasks filter ([commit 5970dc3](https://github.com/googleapis/google-cloud-dotnet/commit/5970dc352347ca721bb71a88cdc7b9f4f64c5d48))
- Document that delivery_vehicle.type can be set on CreateDeliveryVehicle ([commit 658fd07](https://github.com/googleapis/google-cloud-dotnet/commit/658fd07382a9af2e1a3a55e5c8fa75f955efe20b))
- Clarify behavior of UpdateDeliveryVehicle ([commit 4acca65](https://github.com/googleapis/google-cloud-dotnet/commit/4acca6552767fe47081ef563ac9c570a43970631))
