### PR TITLE
Release Google.Maps.FleetEngine.V1 version 2.2.0

### DIFF
--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.csproj
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Maps Fleet Engine API (v1), which enables access to On Demand Rides and Deliveries and Last Mile Fleet Solutions.</Description>

--- a/apis/Google.Maps.FleetEngine.V1/docs/history.md
+++ b/apis/Google.Maps.FleetEngine.V1/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 2.2.0, released 2025-03-03
+
+### New features
+
+- Added Fleet Engine Delete APIs ([commit 1c59977](https://github.com/googleapis/google-cloud-dotnet/commit/1c5997740c604c9392ecd97faabdfda79acce4fd))
+- A new field `past_locations` is added to message `.maps.fleetengine.delivery.v1.DeliveryVehicle` ([commit be87d8a](https://github.com/googleapis/google-cloud-dotnet/commit/be87d8af68a552a4f4d2efd737114cd9bb3e5486))
+- A new field `past_locations` is added to message `.maps.fleetengine.v1.Vehicle` ([commit be87d8a](https://github.com/googleapis/google-cloud-dotnet/commit/be87d8af68a552a4f4d2efd737114cd9bb3e5486))
+
+### Documentation improvements
+
+- Updated documentation for field `task` in message `.maps.fleetengine.delivery.v1.CreateTaskRequest` to clarify certain fields can be optionally set. ([commit be87d8a](https://github.com/googleapis/google-cloud-dotnet/commit/be87d8af68a552a4f4d2efd737114cd9bb3e5486))
+- Correct SearchVehiclesRequest.ordered_by description ([commit 74de6e8](https://github.com/googleapis/google-cloud-dotnet/commit/74de6e8615055d9941308bd821a1edf5ae282fda))
+
 ## Version 2.1.0, released 2024-06-04
 
 ### Documentation improvements

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -6087,7 +6087,7 @@
     },
     {
       "id": "Google.Maps.FleetEngine.V1",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "type": "grpc",
       "productName": "Local Rides and Deliveries",
       "productUrl": "https://developers.google.com/maps/documentation/transportation-logistics/mobility",


### PR DESCRIPTION

Changes in this release:

### New features

- Added Fleet Engine Delete APIs ([commit 1c59977](https://github.com/googleapis/google-cloud-dotnet/commit/1c5997740c604c9392ecd97faabdfda79acce4fd))
- A new field `past_locations` is added to message `.maps.fleetengine.delivery.v1.DeliveryVehicle` ([commit be87d8a](https://github.com/googleapis/google-cloud-dotnet/commit/be87d8af68a552a4f4d2efd737114cd9bb3e5486))
- A new field `past_locations` is added to message `.maps.fleetengine.v1.Vehicle` ([commit be87d8a](https://github.com/googleapis/google-cloud-dotnet/commit/be87d8af68a552a4f4d2efd737114cd9bb3e5486))

### Documentation improvements

- Updated documentation for field `task` in message `.maps.fleetengine.delivery.v1.CreateTaskRequest` to clarify certain fields can be optionally set. ([commit be87d8a](https://github.com/googleapis/google-cloud-dotnet/commit/be87d8af68a552a4f4d2efd737114cd9bb3e5486))
- Correct SearchVehiclesRequest.ordered_by description ([commit 74de6e8](https://github.com/googleapis/google-cloud-dotnet/commit/74de6e8615055d9941308bd821a1edf5ae282fda))
