### PR TITLE
Release Google.Cloud.AIPlatform.V1 version 3.21.0

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.20.0</Version>
+    <Version>3.21.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Vertex AI API (v1), which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 3.21.0, released 2025-03-04
+
+Note: the bug fix here is clearly a breaking change due to an API
+publication error. We believe it is less disruptive to publish this
+in a minor version (one day after the now-removed API surface was
+published) than to take a new major version. Apologies if you are
+disrupted by this.
+
+### Bug fixes
+
+- **BREAKING CHANGE** Remove VertexAISearch.engine option ([commit 966aaea](https://github.com/googleapis/google-cloud-dotnet/commit/966aaea6a4398972d2ae0ad3df399044c584ac7d))
+
 ## Version 3.20.0, released 2025-03-03
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -397,7 +397,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1",
-      "version": "3.20.0",
+      "version": "3.21.0",
       "type": "grpc",
       "productName": "Vertex AI",
       "productUrl": "https://cloud.google.com/vertex-ai/docs",


### PR DESCRIPTION

Changes in this release:

Note: the bug fix here is clearly a breaking change due to an API publication error. We believe it is less disruptive to publish this in a minor version (one day after the now-removed API surface was published) than to take a new major version. Apologies if you are disrupted by this.

### Bug fixes

- **BREAKING CHANGE** Remove VertexAISearch.engine option ([commit 966aaea](https://github.com/googleapis/google-cloud-dotnet/commit/966aaea6a4398972d2ae0ad3df399044c584ac7d))
