### PR TITLE
Release Google.Cloud.AIPlatform.V1Beta1 version 1.0.0-beta20

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta19</Version>
+    <Version>1.0.0-beta20</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Vertex AI API (v1beta), which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta20, released 2025-03-04
+
+### Bug fixes
+
+- **BREAKING CHANGE** Remove VertexAISearch.engine option ([commit 18d4598](https://github.com/googleapis/google-cloud-dotnet/commit/18d4598f4fb71440f1c2b82505a0a79a7bbe3d46))
+
 ## Version 1.0.0-beta19, released 2025-03-03
 
 ### Bug fixes

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -373,7 +373,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1Beta1",
-      "version": "1.0.0-beta19",
+      "version": "1.0.0-beta20",
       "type": "grpc",
       "productName": "Vertex AI",
       "productUrl": "https://cloud.google.com/vertex-ai/docs",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Remove VertexAISearch.engine option ([commit 18d4598](https://github.com/googleapis/google-cloud-dotnet/commit/18d4598f4fb71440f1c2b82505a0a79a7bbe3d46))
