### PR TITLE
Release Google.Analytics.Admin.V1Alpha version 2.0.0-alpha22

### DIFF
--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha21</Version>
+    <Version>2.0.0-alpha22</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Admin API (v1alpha)</Description>

--- a/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
+++ b/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.0.0-alpha22, released 2025-03-10
+
+### New features
+
+- Added support for KeyEvents AdminAPI ChangeHistory ([commit 9112be9](https://github.com/googleapis/google-cloud-dotnet/commit/9112be9248c78c11e105d3f47a3776ce64425545))
+
 ## Version 2.0.0-alpha21, released 2025-02-03
 
 ### Bug fixes

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -46,7 +46,7 @@
     },
     {
       "id": "Google.Analytics.Admin.V1Alpha",
-      "version": "2.0.0-alpha21",
+      "version": "2.0.0-alpha22",
       "type": "grpc",
       "productName": "Analytics Admin",
       "productUrl": "https://developers.google.com/analytics",


### PR DESCRIPTION

Changes in this release:

### New features

- Added support for KeyEvents AdminAPI ChangeHistory ([commit 9112be9](https://github.com/googleapis/google-cloud-dotnet/commit/9112be9248c78c11e105d3f47a3776ce64425545))
