### PR TITLE
Release Google.Cloud.AIPlatform.V1 version 3.22.0

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.21.0</Version>
+    <Version>3.22.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Vertex AI API (v1), which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 3.22.0, released 2025-03-10
+
+### New features
+
+- Allowing users to specify the version id of the Model Garden model ([commit caed93e](https://github.com/googleapis/google-cloud-dotnet/commit/caed93e21d3b7227caf1f3d93bc213c02435899b))
+- Allowing users to choose whether to use the hf model cache ([commit caed93e](https://github.com/googleapis/google-cloud-dotnet/commit/caed93e21d3b7227caf1f3d93bc213c02435899b))
+- Add Layout Parser to RAG v1 API ([commit d85534f](https://github.com/googleapis/google-cloud-dotnet/commit/d85534fbb08fe54a671822f19c69fd9dca0b1a00))
+
 ## Version 3.21.0, released 2025-03-04
 
 Note: the bug fix here is clearly a breaking change due to an API

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -397,7 +397,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1",
-      "version": "3.21.0",
+      "version": "3.22.0",
       "type": "grpc",
       "productName": "Vertex AI",
       "productUrl": "https://cloud.google.com/vertex-ai/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Allowing users to specify the version id of the Model Garden model ([commit caed93e](https://github.com/googleapis/google-cloud-dotnet/commit/caed93e21d3b7227caf1f3d93bc213c02435899b))
- Allowing users to choose whether to use the hf model cache ([commit caed93e](https://github.com/googleapis/google-cloud-dotnet/commit/caed93e21d3b7227caf1f3d93bc213c02435899b))
- Add Layout Parser to RAG v1 API ([commit d85534f](https://github.com/googleapis/google-cloud-dotnet/commit/d85534fbb08fe54a671822f19c69fd9dca0b1a00))
