### PR TITLE
Release Google.Cloud.Audit version 2.5.0

### DIFF
--- a/apis/Google.Cloud.Audit/Google.Cloud.Audit/Google.Cloud.Audit.csproj
+++ b/apis/Google.Cloud.Audit/Google.Cloud.Audit/Google.Cloud.Audit.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Protobuf messages for Google Cloud audit logs.</Description>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.Protobuf" VersionOverride="[3.25.0, 4.0.0)" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Audit/docs/history.md
+++ b/apis/Google.Cloud.Audit/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 2.5.0, released 2025-03-10
+
+### New features
+
+- Updates audit_log proto with PermissionType ([commit 47a5d72](https://github.com/googleapis/google-cloud-dotnet/commit/47a5d72fa0f4f266487685b0894003d808c103f6))
+
 ## Version 2.4.0, released 2024-03-26
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -703,7 +703,7 @@
     },
     {
       "id": "Google.Cloud.Audit",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "productName": "Google Cloud Audit",
       "productUrl": "https://cloud.google.com/logging/docs/audit",
       "type": "other",
@@ -712,7 +712,7 @@
         "audit"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.2.0",
+        "Google.Cloud.Iam.V1": "3.4.0",
         "Google.Protobuf": "3.25.0"
       },
       "generator": "proto",


### PR DESCRIPTION

Changes in this release:

### New features

- Updates audit_log proto with PermissionType ([commit 47a5d72](https://github.com/googleapis/google-cloud-dotnet/commit/47a5d72fa0f4f266487685b0894003d808c103f6))
