### PR TITLE
Release Google.Cloud.Bigtable.Admin.V2 version 3.24.0

### DIFF
--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.23.0</Version>
+    <Version>3.24.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Bigtable Instance and Table Admin APIs.</Description>

--- a/apis/Google.Cloud.Bigtable.Admin.V2/docs/history.md
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.24.0, released 2025-03-10
+
+### New features
+
+- Add MaterializedViews and LogicalViews APIs ([commit b1837ff](https://github.com/googleapis/google-cloud-dotnet/commit/b1837ff2b5188bbb3f3b7b8960e77cfecf2e717b))
+
+### Documentation improvements
+
+- Fixed formatting of resource path strings ([commit e99d573](https://github.com/googleapis/google-cloud-dotnet/commit/e99d573e9dee6a5e157974ebbc1f0c6ed599a77e))
+
 ## Version 3.23.0, released 2025-03-03
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -1160,7 +1160,7 @@
       "protoPath": "google/bigtable/admin/v2",
       "productName": "Google Cloud Bigtable Administration",
       "productUrl": "https://cloud.google.com/bigtable/",
-      "version": "3.23.0",
+      "version": "3.24.0",
       "commonResourcesConfig": "tweaks/Google.Cloud.Bigtable.Common.V2/CommonResourcesConfig.json",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Bigtable Instance and Table Admin APIs.",


### PR DESCRIPTION

Changes in this release:

### New features

- Add MaterializedViews and LogicalViews APIs ([commit b1837ff](https://github.com/googleapis/google-cloud-dotnet/commit/b1837ff2b5188bbb3f3b7b8960e77cfecf2e717b))

### Documentation improvements

- Fixed formatting of resource path strings ([commit e99d573](https://github.com/googleapis/google-cloud-dotnet/commit/e99d573e9dee6a5e157974ebbc1f0c6ed599a77e))
