### PR TITLE
Release Google.Cloud.Bigtable.V2 version 3.16.0

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.15.0</Version>
+    <Version>3.16.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Bigtable API.</Description>

--- a/apis/Google.Cloud.Bigtable.V2/docs/history.md
+++ b/apis/Google.Cloud.Bigtable.V2/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 3.16.0, released 2025-03-10
+
+### New features
+
+- Add PrepareQuery api and update ExecuteQuery to support it ([commit f222067](https://github.com/googleapis/google-cloud-dotnet/commit/f2220677139a51d4304c872292aad1b7c353831b))
+
+### Documentation improvements
+
+- Update ExecuteQuery API docs to reflect changes ([commit f222067](https://github.com/googleapis/google-cloud-dotnet/commit/f2220677139a51d4304c872292aad1b7c353831b))
+
 ## Version 3.15.0, released 2024-10-29
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -1202,7 +1202,7 @@
       "protoPath": "google/bigtable/v2",
       "productName": "Google Bigtable",
       "productUrl": "https://cloud.google.com/bigtable/",
-      "version": "3.15.0",
+      "version": "3.16.0",
       "commonResourcesConfig": "tweaks/Google.Cloud.Bigtable.Common.V2/CommonResourcesConfig.json",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",


### PR DESCRIPTION

Changes in this release:

### New features

- Add PrepareQuery api and update ExecuteQuery to support it ([commit f222067](https://github.com/googleapis/google-cloud-dotnet/commit/f2220677139a51d4304c872292aad1b7c353831b))

### Documentation improvements

- Update ExecuteQuery API docs to reflect changes ([commit f222067](https://github.com/googleapis/google-cloud-dotnet/commit/f2220677139a51d4304c872292aad1b7c353831b))
