### PR TITLE
Release Google.Cloud.Dialogflow.Cx.V3 version 2.23.0

### DIFF
--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.22.0</Version>
+    <Version>2.23.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Builds conversational interfaces (for example, chatbots, and voice-powered apps and devices).</Description>

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.23.0, released 2025-03-10
+
+### New features
+
+- Change client_secret in OAuthConfig from required to optional ([commit ac2c71f](https://github.com/googleapis/google-cloud-dotnet/commit/ac2c71f1315b87338f62da9752f5ea63e3d1188a))
+
+### Documentation improvements
+
+- A comment for field `client_secret` in message `.google.cloud.dialogflow.cx.v3.Webhook` is changed ([commit ac2c71f](https://github.com/googleapis/google-cloud-dotnet/commit/ac2c71f1315b87338f62da9752f5ea63e3d1188a))
+
 ## Version 2.22.0, released 2025-03-03
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -2144,7 +2144,7 @@
     },
     {
       "id": "Google.Cloud.Dialogflow.Cx.V3",
-      "version": "2.22.0",
+      "version": "2.23.0",
       "type": "grpc",
       "productName": "Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow/cx/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Change client_secret in OAuthConfig from required to optional ([commit ac2c71f](https://github.com/googleapis/google-cloud-dotnet/commit/ac2c71f1315b87338f62da9752f5ea63e3d1188a))

### Documentation improvements

- A comment for field `client_secret` in message `.google.cloud.dialogflow.cx.v3.Webhook` is changed ([commit ac2c71f](https://github.com/googleapis/google-cloud-dotnet/commit/ac2c71f1315b87338f62da9752f5ea63e3d1188a))
