### PR TITLE
Release Google.Cloud.Dialogflow.V2Beta1 version 1.0.0-beta23

### DIFF
--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.csproj
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta22</Version>
+    <Version>1.0.0-beta23</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Dialogflow API (v2beta1).</Description>

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/docs/history.md
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+## Version 1.0.0-beta23, released 2025-03-10
+
+### New features
+
+- Add new RPC IngestContextReferences, GenerateSuggestions ([commit fe50c27](https://github.com/googleapis/google-cloud-dotnet/commit/fe50c27239e19b8b75bf0f37c7a90561688f7504))
+
+### Documentation improvements
+
+- Clarified wording around phrase_sets ([commit fe50c27](https://github.com/googleapis/google-cloud-dotnet/commit/fe50c27239e19b8b75bf0f37c7a90561688f7504))
+- Clarified wording around document_correctness ([commit 9e1f4fc](https://github.com/googleapis/google-cloud-dotnet/commit/9e1f4fc09fa22717440d72b6faa0e63a988f851a))
+- Clarified wording around use_timeout_based_endpointing ([commit 9e1f4fc](https://github.com/googleapis/google-cloud-dotnet/commit/9e1f4fc09fa22717440d72b6faa0e63a988f851a))
+- Clarified wording around BoostSpec and filter_specs ([commit 9e1f4fc](https://github.com/googleapis/google-cloud-dotnet/commit/9e1f4fc09fa22717440d72b6faa0e63a988f851a))
+- Clarified wording around send_time ([commit 9e1f4fc](https://github.com/googleapis/google-cloud-dotnet/commit/9e1f4fc09fa22717440d72b6faa0e63a988f851a))
+
 ## Version 1.0.0-beta22, released 2025-02-18
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -2194,7 +2194,7 @@
     },
     {
       "id": "Google.Cloud.Dialogflow.V2Beta1",
-      "version": "1.0.0-beta22",
+      "version": "1.0.0-beta23",
       "type": "grpc",
       "productName": "Google Cloud Dialogflow",
       "productUrl": "https://cloud.google.com/dialogflow-enterprise/",


### PR DESCRIPTION

Changes in this release:

### New features

- Add new RPC IngestContextReferences, GenerateSuggestions ([commit fe50c27](https://github.com/googleapis/google-cloud-dotnet/commit/fe50c27239e19b8b75bf0f37c7a90561688f7504))

### Documentation improvements

- Clarified wording around phrase_sets ([commit fe50c27](https://github.com/googleapis/google-cloud-dotnet/commit/fe50c27239e19b8b75bf0f37c7a90561688f7504))
- Clarified wording around document_correctness ([commit 9e1f4fc](https://github.com/googleapis/google-cloud-dotnet/commit/9e1f4fc09fa22717440d72b6faa0e63a988f851a))
- Clarified wording around use_timeout_based_endpointing ([commit 9e1f4fc](https://github.com/googleapis/google-cloud-dotnet/commit/9e1f4fc09fa22717440d72b6faa0e63a988f851a))
- Clarified wording around BoostSpec and filter_specs ([commit 9e1f4fc](https://github.com/googleapis/google-cloud-dotnet/commit/9e1f4fc09fa22717440d72b6faa0e63a988f851a))
- Clarified wording around send_time ([commit 9e1f4fc](https://github.com/googleapis/google-cloud-dotnet/commit/9e1f4fc09fa22717440d72b6faa0e63a988f851a))
