### PR TITLE
Release Google.Cloud.PubSub.V1 version 3.22.0

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.21.0</Version>
+    <Version>3.22.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.</Description>

--- a/apis/Google.Cloud.PubSub.V1/docs/history.md
+++ b/apis/Google.Cloud.PubSub.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 3.22.0, released 2025-03-10
+
+### New features
+
+- Deprecate `enabled` field for message transforms and add `disabled` field ([commit d75a0b0](https://github.com/googleapis/google-cloud-dotnet/commit/d75a0b0413aef83a015e6f8dcd87f47d9b3530a7))
+
+### Documentation improvements
+
+- Deprecate `enabled` field for message transforms and add `disabled` field ([commit d75a0b0](https://github.com/googleapis/google-cloud-dotnet/commit/d75a0b0413aef83a015e6f8dcd87f47d9b3530a7))
+- A comment for field `code` in message `.google.pubsub.v1.JavaScriptUDF` is changed ([commit e82746a](https://github.com/googleapis/google-cloud-dotnet/commit/e82746acd04df7a91742fd9b77a8b327e6995368))
+
 ## Version 3.21.0, released 2025-02-03
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -4173,7 +4173,7 @@
       "protoPath": "google/pubsub/v1",
       "productName": "Cloud Pub/Sub",
       "productUrl": "https://cloud.google.com/pubsub/",
-      "version": "3.21.0",
+      "version": "3.22.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",


### PR DESCRIPTION

Changes in this release:

### New features

- Deprecate `enabled` field for message transforms and add `disabled` field ([commit d75a0b0](https://github.com/googleapis/google-cloud-dotnet/commit/d75a0b0413aef83a015e6f8dcd87f47d9b3530a7))

### Documentation improvements

- Deprecate `enabled` field for message transforms and add `disabled` field ([commit d75a0b0](https://github.com/googleapis/google-cloud-dotnet/commit/d75a0b0413aef83a015e6f8dcd87f47d9b3530a7))
- A comment for field `code` in message `.google.pubsub.v1.JavaScriptUDF` is changed ([commit e82746a](https://github.com/googleapis/google-cloud-dotnet/commit/e82746acd04df7a91742fd9b77a8b327e6995368))
