### PR TITLE
Release Google.Cloud.Storage.V1 version 4.11.0

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.10.0</Version>
+    <Version>4.11.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.</Description>

--- a/apis/Google.Cloud.Storage.V1/docs/history.md
+++ b/apis/Google.Cloud.Storage.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 4.11.0, released 2025-03-10
+
+### New features
+
+- Allowing users to specify the version id of the Model Garden model ([commit 33f9df1](https://github.com/googleapis/google-cloud-dotnet/commit/33f9df1a2607447629d6edc3241b67717d3ccc91))
+- Allowing users to choose whether to use the hf model cache ([commit 33f9df1](https://github.com/googleapis/google-cloud-dotnet/commit/33f9df1a2607447629d6edc3241b67717d3ccc91))
+- Bucket soft delete ([commit f773cad](https://github.com/googleapis/google-cloud-dotnet/commit/f773cadaa1bc5c2e32402c6a8ea2e7e2d287ecb9))
+
 ## Version 4.10.0, released 2024-03-26
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -5129,7 +5129,7 @@
       "id": "Google.Cloud.Storage.V1",
       "productName": "Google Cloud Storage",
       "productUrl": "https://cloud.google.com/storage/",
-      "version": "4.10.0",
+      "version": "4.11.0",
       "type": "rest",
       "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Allowing users to specify the version id of the Model Garden model ([commit 33f9df1](https://github.com/googleapis/google-cloud-dotnet/commit/33f9df1a2607447629d6edc3241b67717d3ccc91))
- Allowing users to choose whether to use the hf model cache ([commit 33f9df1](https://github.com/googleapis/google-cloud-dotnet/commit/33f9df1a2607447629d6edc3241b67717d3ccc91))
- Bucket soft delete ([commit f773cad](https://github.com/googleapis/google-cloud-dotnet/commit/f773cadaa1bc5c2e32402c6a8ea2e7e2d287ecb9))
