### PR TITLE
Release Google.Shopping.Merchant.Accounts.V1Beta version 1.0.0-beta04

### DIFF
--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.csproj
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Merchant Accounts API (v1beta) which allows developers to programmatically manage conversion sources.</Description>

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/docs/history.md
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/docs/history.md
@@ -1,5 +1,29 @@
 # Version history
 
+## Version 1.0.0-beta04, released 2025-03-10
+
+### Bug fixes
+
+- **BREAKING CHANGE** An existing optional field `type` is converted to required field in message .google.shopping.merchant.accounts.v1beta.OnlineReturnPolicy ([commit 0ce5f8b](https://github.com/googleapis/google-cloud-dotnet/commit/0ce5f8bd4f7da0218f84246e78573332265feb80))
+- **BREAKING CHANGE** An existing optional field `label` is converted to required field in message .google.shopping.merchant.accounts.v1beta.OnlineReturnPolicy ([commit 0ce5f8b](https://github.com/googleapis/google-cloud-dotnet/commit/0ce5f8bd4f7da0218f84246e78573332265feb80))
+- **BREAKING CHANGE** An existing optional field `countries` is converted to required field in message .google.shopping.merchant.accounts.v1beta.OnlineReturnPolicy ([commit 0ce5f8b](https://github.com/googleapis/google-cloud-dotnet/commit/0ce5f8bd4f7da0218f84246e78573332265feb80))
+- **BREAKING CHANGE** An existing optional field `return_policy_uri` is converted to required field in message .google.shopping.merchant.accounts.v1beta.OnlineReturnPolicy ([commit 0ce5f8b](https://github.com/googleapis/google-cloud-dotnet/commit/0ce5f8bd4f7da0218f84246e78573332265feb80))
+
+### New features
+
+- A new message `SeasonalOverride` is added ([commit 0ce5f8b](https://github.com/googleapis/google-cloud-dotnet/commit/0ce5f8bd4f7da0218f84246e78573332265feb80))
+- A new field `seasonal_overrides` is added to message .google.shopping.merchant.accounts.v1beta.OnlineReturnPolicy ([commit 0ce5f8b](https://github.com/googleapis/google-cloud-dotnet/commit/0ce5f8bd4f7da0218f84246e78573332265feb80))
+
+### Documentation improvements
+
+- The documentation for method `GetOnlineReturnPolicy` in service `OnlineReturnPolicyService` is improved ([commit 0ce5f8b](https://github.com/googleapis/google-cloud-dotnet/commit/0ce5f8bd4f7da0218f84246e78573332265feb80))
+- The documentation for method `ListOnlineReturnPolicies` in service `OnlineReturnPolicyService` is improved ([commit 0ce5f8b](https://github.com/googleapis/google-cloud-dotnet/commit/0ce5f8bd4f7da0218f84246e78573332265feb80))
+- The documentation for field `parent` in message `.google.shopping.merchant.accounts.v1beta.ListOnlineReturnPoliciesRequest` is improved ([commit 0ce5f8b](https://github.com/googleapis/google-cloud-dotnet/commit/0ce5f8bd4f7da0218f84246e78573332265feb80))
+- The documentation for field `type` in message `.google.shopping.merchant.accounts.v1beta.OnlineReturnPolicy` is improved ([commit 0ce5f8b](https://github.com/googleapis/google-cloud-dotnet/commit/0ce5f8bd4f7da0218f84246e78573332265feb80))
+- The documentation for field `label` in message `.google.shopping.merchant.accounts.v1beta.OnlineReturnPolicy` is improved ([commit 0ce5f8b](https://github.com/googleapis/google-cloud-dotnet/commit/0ce5f8bd4f7da0218f84246e78573332265feb80))
+- The documentation for field `countries` in message `.google.shopping.merchant.accounts.v1beta.OnlineReturnPolicy` is improved ([commit 0ce5f8b](https://github.com/googleapis/google-cloud-dotnet/commit/0ce5f8bd4f7da0218f84246e78573332265feb80))
+- The documentation for field `return_policy_uri` in message `.google.shopping.merchant.accounts.v1beta.OnlineReturnPolicy` is improved ([commit 0ce5f8b](https://github.com/googleapis/google-cloud-dotnet/commit/0ce5f8bd4f7da0218f84246e78573332265feb80))
+
 ## Version 1.0.0-beta03, released 2024-09-30
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -6220,7 +6220,7 @@
     },
     {
       "id": "Google.Shopping.Merchant.Accounts.V1Beta",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0-beta04",
       "type": "grpc",
       "productName": "Merchant",
       "productUrl": "https://developers.google.com/merchant/api",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** An existing optional field `type` is converted to required field in message .google.shopping.merchant.accounts.v1beta.OnlineReturnPolicy ([commit 0ce5f8b](https://github.com/googleapis/google-cloud-dotnet/commit/0ce5f8bd4f7da0218f84246e78573332265feb80))
- **BREAKING CHANGE** An existing optional field `label` is converted to required field in message .google.shopping.merchant.accounts.v1beta.OnlineReturnPolicy ([commit 0ce5f8b](https://github.com/googleapis/google-cloud-dotnet/commit/0ce5f8bd4f7da0218f84246e78573332265feb80))
- **BREAKING CHANGE** An existing optional field `countries` is converted to required field in message .google.shopping.merchant.accounts.v1beta.OnlineReturnPolicy ([commit 0ce5f8b](https://github.com/googleapis/google-cloud-dotnet/commit/0ce5f8bd4f7da0218f84246e78573332265feb80))
- **BREAKING CHANGE** An existing optional field `return_policy_uri` is converted to required field in message .google.shopping.merchant.accounts.v1beta.OnlineReturnPolicy ([commit 0ce5f8b](https://github.com/googleapis/google-cloud-dotnet/commit/0ce5f8bd4f7da0218f84246e78573332265feb80))

### New features

- A new message `SeasonalOverride` is added ([commit 0ce5f8b](https://github.com/googleapis/google-cloud-dotnet/commit/0ce5f8bd4f7da0218f84246e78573332265feb80))
- A new field `seasonal_overrides` is added to message .google.shopping.merchant.accounts.v1beta.OnlineReturnPolicy ([commit 0ce5f8b](https://github.com/googleapis/google-cloud-dotnet/commit/0ce5f8bd4f7da0218f84246e78573332265feb80))

### Documentation improvements

- The documentation for method `GetOnlineReturnPolicy` in service `OnlineReturnPolicyService` is improved ([commit 0ce5f8b](https://github.com/googleapis/google-cloud-dotnet/commit/0ce5f8bd4f7da0218f84246e78573332265feb80))
- The documentation for method `ListOnlineReturnPolicies` in service `OnlineReturnPolicyService` is improved ([commit 0ce5f8b](https://github.com/googleapis/google-cloud-dotnet/commit/0ce5f8bd4f7da0218f84246e78573332265feb80))
- The documentation for field `parent` in message `.google.shopping.merchant.accounts.v1beta.ListOnlineReturnPoliciesRequest` is improved ([commit 0ce5f8b](https://github.com/googleapis/google-cloud-dotnet/commit/0ce5f8bd4f7da0218f84246e78573332265feb80))
- The documentation for field `type` in message `.google.shopping.merchant.accounts.v1beta.OnlineReturnPolicy` is improved ([commit 0ce5f8b](https://github.com/googleapis/google-cloud-dotnet/commit/0ce5f8bd4f7da0218f84246e78573332265feb80))
- The documentation for field `label` in message `.google.shopping.merchant.accounts.v1beta.OnlineReturnPolicy` is improved ([commit 0ce5f8b](https://github.com/googleapis/google-cloud-dotnet/commit/0ce5f8bd4f7da0218f84246e78573332265feb80))
- The documentation for field `countries` in message `.google.shopping.merchant.accounts.v1beta.OnlineReturnPolicy` is improved ([commit 0ce5f8b](https://github.com/googleapis/google-cloud-dotnet/commit/0ce5f8bd4f7da0218f84246e78573332265feb80))
- The documentation for field `return_policy_uri` in message `.google.shopping.merchant.accounts.v1beta.OnlineReturnPolicy` is improved ([commit 0ce5f8b](https://github.com/googleapis/google-cloud-dotnet/commit/0ce5f8bd4f7da0218f84246e78573332265feb80))
