### PR TITLE
feat: Implement Datastore query profiling

### DIFF
--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/DatastoreQueryTest.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Tests/DatastoreQueryTest.cs
@@ -1,0 +1,82 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License"):
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Xunit;
+
+namespace Google.Cloud.Datastore.V1.Tests;
+
+public class DatastoreQueryTest
+{
+    private static readonly GqlQuery s_gqlQuery = new GqlQuery();
+    private static readonly Query s_query = new Query();
+    private static readonly AggregationQuery s_aggregationQuery = new AggregationQuery();
+    private static readonly PartitionId s_partitionId = new PartitionId();
+
+    public static TheoryData<DatastoreQuery> InvalidRegularQueries = new()
+    {
+        new DatastoreQuery(),
+        new DatastoreQuery { AggregationQuery = s_aggregationQuery },
+        new DatastoreQuery { AggregationQuery = s_aggregationQuery, Query = s_query },
+        new DatastoreQuery { GqlQuery = s_gqlQuery, Query = s_query },
+    };
+
+    public static TheoryData<DatastoreQuery> InvalidAggregationQueries = new()
+    {
+        new DatastoreQuery(),
+        new DatastoreQuery { Query = s_query },
+        new DatastoreQuery { AggregationQuery = s_aggregationQuery, Query = s_query },
+        new DatastoreQuery { GqlQuery = s_gqlQuery, AggregationQuery = s_aggregationQuery },
+    };
+
+    [Fact]
+    public void ToRequest_Valid()
+    {
+        var query = new DatastoreQuery { Query = s_query };
+        var expected = new RunQueryRequest
+        {
+            Query = s_query,
+            ProjectId = "project",
+            DatabaseId = "database",
+            PartitionId = s_partitionId
+        };
+        var actual = query.ToRequest("project", "database", s_partitionId);
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidRegularQueries))]
+    public void ToRequest_Invalid(DatastoreQuery query) =>
+        Assert.Throws<InvalidOperationException>(() => query.ToRequest("project", "database", s_partitionId));
+
+    [Fact]
+    public void ToAggregationRequest_Valid()
+    {
+        var query = new DatastoreQuery { AggregationQuery = s_aggregationQuery };
+        var expected = new RunAggregationQueryRequest
+        {
+            AggregationQuery = s_aggregationQuery,
+            ProjectId = "project",
+            DatabaseId = "database",
+            PartitionId = s_partitionId
+        };
+        var actual = query.ToAggregationRequest("project", "database", s_partitionId);
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidAggregationQueries))]
+    public void ToAggregationRequest_Invalid(DatastoreQuery query) =>
+        Assert.Throws<InvalidOperationException>(() => query.ToAggregationRequest("project", "database", s_partitionId));
+}

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.sln
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.sln
@@ -3,47 +3,53 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.2.32516.85
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Datastore.V1", "Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj", "{8D442A59-2660-609D-33A9-844FA37132AA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Datastore.V1", "Google.Cloud.Datastore.V1\Google.Cloud.Datastore.V1.csproj", "{8D442A59-2660-609D-33A9-844FA37132AA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Datastore.V1.Snippets", "Google.Cloud.Datastore.V1.Snippets\Google.Cloud.Datastore.V1.Snippets.csproj", "{B05695A0-022D-652A-8FBE-BD5976085F58}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Datastore.V1.Snippets", "Google.Cloud.Datastore.V1.Snippets\Google.Cloud.Datastore.V1.Snippets.csproj", "{B05695A0-022D-652A-8FBE-BD5976085F58}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Datastore.V1.GeneratedSnippets", "Google.Cloud.Datastore.V1.GeneratedSnippets\Google.Cloud.Datastore.V1.GeneratedSnippets.csproj", "{D71882DB-B962-6046-E4D2-76BFADC6C0C4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Datastore.V1.GeneratedSnippets", "Google.Cloud.Datastore.V1.GeneratedSnippets\Google.Cloud.Datastore.V1.GeneratedSnippets.csproj", "{D71882DB-B962-6046-E4D2-76BFADC6C0C4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Datastore.V1.IntegrationTests", "Google.Cloud.Datastore.V1.IntegrationTests\Google.Cloud.Datastore.V1.IntegrationTests.csproj", "{6A1CB7FE-3F24-EBBB-28A1-0F64ED124D81}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Datastore.V1.IntegrationTests", "Google.Cloud.Datastore.V1.IntegrationTests\Google.Cloud.Datastore.V1.IntegrationTests.csproj", "{6A1CB7FE-3F24-EBBB-28A1-0F64ED124D81}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Datastore.V1.Tests", "Google.Cloud.Datastore.V1.Tests\Google.Cloud.Datastore.V1.Tests.csproj", "{0E4BEA11-EB67-2BF9-1A53-69D3CE17FC14}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Datastore.V1.Tests", "Google.Cloud.Datastore.V1.Tests\Google.Cloud.Datastore.V1.Tests.csproj", "{0E4BEA11-EB67-2BF9-1A53-69D3CE17FC14}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{29974B0C-A7B0-8CA8-AE32-99F622C89044}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{29974B0C-A7B0-8CA8-AE32-99F622C89044}"
 EndProject
 Global
-    GlobalSection(SolutionConfigurationPlatforms) = preSolution
-        Debug|Any CPU = Debug|Any CPU
-        Release|Any CPU = Release|Any CPU
-    EndGlobalSection
-    GlobalSection(ProjectConfigurationPlatforms) = postSolution
-        {8D442A59-2660-609D-33A9-844FA37132AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-        {8D442A59-2660-609D-33A9-844FA37132AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-        {8D442A59-2660-609D-33A9-844FA37132AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-        {8D442A59-2660-609D-33A9-844FA37132AA}.Release|Any CPU.Build.0 = Release|Any CPU
-        {B05695A0-022D-652A-8FBE-BD5976085F58}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-        {B05695A0-022D-652A-8FBE-BD5976085F58}.Debug|Any CPU.Build.0 = Debug|Any CPU
-        {B05695A0-022D-652A-8FBE-BD5976085F58}.Release|Any CPU.ActiveCfg = Release|Any CPU
-        {B05695A0-022D-652A-8FBE-BD5976085F58}.Release|Any CPU.Build.0 = Release|Any CPU
-        {D71882DB-B962-6046-E4D2-76BFADC6C0C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-        {D71882DB-B962-6046-E4D2-76BFADC6C0C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-        {D71882DB-B962-6046-E4D2-76BFADC6C0C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-        {D71882DB-B962-6046-E4D2-76BFADC6C0C4}.Release|Any CPU.Build.0 = Release|Any CPU
-        {6A1CB7FE-3F24-EBBB-28A1-0F64ED124D81}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-        {6A1CB7FE-3F24-EBBB-28A1-0F64ED124D81}.Debug|Any CPU.Build.0 = Debug|Any CPU
-        {6A1CB7FE-3F24-EBBB-28A1-0F64ED124D81}.Release|Any CPU.ActiveCfg = Release|Any CPU
-        {6A1CB7FE-3F24-EBBB-28A1-0F64ED124D81}.Release|Any CPU.Build.0 = Release|Any CPU
-        {0E4BEA11-EB67-2BF9-1A53-69D3CE17FC14}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-        {0E4BEA11-EB67-2BF9-1A53-69D3CE17FC14}.Debug|Any CPU.Build.0 = Debug|Any CPU
-        {0E4BEA11-EB67-2BF9-1A53-69D3CE17FC14}.Release|Any CPU.ActiveCfg = Release|Any CPU
-        {0E4BEA11-EB67-2BF9-1A53-69D3CE17FC14}.Release|Any CPU.Build.0 = Release|Any CPU
-        {29974B0C-A7B0-8CA8-AE32-99F622C89044}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-        {29974B0C-A7B0-8CA8-AE32-99F622C89044}.Debug|Any CPU.Build.0 = Debug|Any CPU
-        {29974B0C-A7B0-8CA8-AE32-99F622C89044}.Release|Any CPU.ActiveCfg = Release|Any CPU
-        {29974B0C-A7B0-8CA8-AE32-99F622C89044}.Release|Any CPU.Build.0 = Release|Any CPU
-    EndGlobalSection
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8D442A59-2660-609D-33A9-844FA37132AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D442A59-2660-609D-33A9-844FA37132AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D442A59-2660-609D-33A9-844FA37132AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D442A59-2660-609D-33A9-844FA37132AA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B05695A0-022D-652A-8FBE-BD5976085F58}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B05695A0-022D-652A-8FBE-BD5976085F58}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B05695A0-022D-652A-8FBE-BD5976085F58}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B05695A0-022D-652A-8FBE-BD5976085F58}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D71882DB-B962-6046-E4D2-76BFADC6C0C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D71882DB-B962-6046-E4D2-76BFADC6C0C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D71882DB-B962-6046-E4D2-76BFADC6C0C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D71882DB-B962-6046-E4D2-76BFADC6C0C4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A1CB7FE-3F24-EBBB-28A1-0F64ED124D81}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A1CB7FE-3F24-EBBB-28A1-0F64ED124D81}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A1CB7FE-3F24-EBBB-28A1-0F64ED124D81}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A1CB7FE-3F24-EBBB-28A1-0F64ED124D81}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0E4BEA11-EB67-2BF9-1A53-69D3CE17FC14}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0E4BEA11-EB67-2BF9-1A53-69D3CE17FC14}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0E4BEA11-EB67-2BF9-1A53-69D3CE17FC14}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0E4BEA11-EB67-2BF9-1A53-69D3CE17FC14}.Release|Any CPU.Build.0 = Release|Any CPU
+		{29974B0C-A7B0-8CA8-AE32-99F622C89044}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{29974B0C-A7B0-8CA8-AE32-99F622C89044}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{29974B0C-A7B0-8CA8-AE32-99F622C89044}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{29974B0C-A7B0-8CA8-AE32-99F622C89044}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {69E8BF28-102E-4CFC-BB48-6543F4E335CC}
+	EndGlobalSection
 EndGlobal

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/AsyncLazyDatastoreQuery.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/AsyncLazyDatastoreQuery.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using static Google.Cloud.Datastore.V1.QueryResultBatch.Types;
 
 namespace Google.Cloud.Datastore.V1
 {
@@ -63,9 +64,10 @@ namespace Google.Cloud.Datastore.V1
             // cursors etc, but that's likely to be insignificant compared with the
             // entity data, and is immediately eligible for garbage collection.
             var responses = await _responses.ToListAsync().ConfigureAwait(false);
-            var entities = responses.SelectMany(r => r.Batch.EntityResults.Select(er => er.Entity)).ToList().AsReadOnly();
+            var entities = responses.SelectMany(r => r.Batch?.EntityResults.Select(er => er.Entity) ?? Enumerable.Empty<Entity>()).ToList().AsReadOnly();
             var lastBatch = responses.Last().Batch;
-            return new DatastoreQueryResults(entities, lastBatch.MoreResults, lastBatch.EndCursor);
+            var metrics = responses.Last().ExplainMetrics;
+            return new DatastoreQueryResults(entities, lastBatch?.MoreResults ?? MoreResultsType.Unspecified, lastBatch?.EndCursor, metrics);
         }
 
         /// <inheritdoc />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreDb.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreDb.cs
@@ -108,6 +108,17 @@ namespace Google.Cloud.Datastore.V1
         /// number of results, for example to build a web application which fetches results in pages.
         /// </summary>
         /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>The complete query results.</returns>
+        public virtual DatastoreQueryResults RunQuery(DatastoreQuery query, CallSettings callSettings = null) =>
+            RunQueryLazily(query, callSettings).GetAllResults();
+
+        /// <summary>
+        /// Runs the given query eagerly, retrieving all results in memory and indicating whether more
+        /// results may be available beyond the query's limit. Use this method when your query has a limited
+        /// number of results, for example to build a web application which fetches results in pages.
+        /// </summary>
+        /// <param name="query">The query to execute. Must not be null.</param>
         /// <param name="readConsistency">If not null, overrides the read consistency of the query.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
         /// <returns>The complete query results.</returns>
@@ -121,12 +132,34 @@ namespace Google.Cloud.Datastore.V1
         /// number of results, for example to build a web application which fetches results in pages.
         /// </summary>
         /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>A task representing the asynchronous operation. The result of the task is the complete set of query results.</returns>
+        public virtual Task<DatastoreQueryResults> RunQueryAsync(DatastoreQuery query, CallSettings callSettings = null) =>
+            RunQueryLazilyAsync(query, callSettings).GetAllResultsAsync();
+
+        /// <summary>
+        /// Runs the given query eagerly and asynchronously, retrieving all results in memory and indicating whether more
+        /// results may be available beyond the query's limit. Use this method when your query has a limited
+        /// number of results, for example to build a web application which fetches results in pages.
+        /// </summary>
+        /// <param name="query">The query to execute. Must not be null.</param>
         /// <param name="readConsistency">If not null, overrides the read consistency of the query.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
         /// <returns>A task representing the asynchronous operation. The result of the task is the complete set of query results.</returns>
         public virtual Task<DatastoreQueryResults> RunQueryAsync(
             Query query, ReadConsistency? readConsistency = null, CallSettings callSettings = null) =>
             RunQueryLazilyAsync(query, readConsistency, callSettings).GetAllResultsAsync();
+
+        /// <summary>
+        /// Executes the given query.
+        /// </summary>
+        /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>An <see cref="AggregationQueryResults"/> holds result of aggregations.</returns>
+        public virtual AggregationQueryResults RunAggregationQuery(DatastoreQuery query, CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
 
         /// <summary>
         /// Executes the given structured query.
@@ -148,6 +181,17 @@ namespace Google.Cloud.Datastore.V1
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
         /// <returns>An <see cref="AggregationQueryResults"/> holds result of aggregations.</returns>
         public virtual AggregationQueryResults RunAggregationQuery(GqlQuery query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Executes the given query.
+        /// </summary>
+        /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>An <see cref="AggregationQueryResults"/> holds result of aggregations.</returns>
+        public virtual Task<AggregationQueryResults> RunAggregationQueryAsync(DatastoreQuery query, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
@@ -185,11 +229,44 @@ namespace Google.Cloud.Datastore.V1
         /// multiple times will execute the query again, potentially returning different results.
         /// </remarks>
         /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>A <see cref="LazyDatastoreQuery"/> representing the lazy query results.</returns>
+        public virtual LazyDatastoreQuery RunQueryLazily(
+            DatastoreQuery query, CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Lazily executes the given structured query.
+        /// </summary>
+        /// <remarks>
+        /// The results are requested lazily: no API calls will be made until the application starts
+        /// iterating over the results. Iterating over the same <see cref="LazyDatastoreQuery"/> object
+        /// multiple times will execute the query again, potentially returning different results.
+        /// </remarks>
+        /// <param name="query">The query to execute. Must not be null.</param>
         /// <param name="readConsistency">If not null, overrides the read consistency of the query.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
         /// <returns>A <see cref="LazyDatastoreQuery"/> representing the lazy query results.</returns>
         public virtual LazyDatastoreQuery RunQueryLazily(
             Query query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Lazily executes the given structured query for asynchronous consumption.
+        /// </summary>
+        /// <remarks>
+        /// The results are requested lazily: no API calls will be made until the application starts
+        /// iterating over the results. Iterating over the same <see cref="LazyDatastoreQuery"/> object
+        /// multiple times will execute the query again, potentially returning different results.
+        /// </remarks>
+        /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>An <see cref="AsyncLazyDatastoreQuery"/> representing the lazy query results.</returns>
+        public virtual AsyncLazyDatastoreQuery RunQueryLazilyAsync(DatastoreQuery query, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreDbImpl.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreDbImpl.cs
@@ -15,9 +15,7 @@
 using Google.Api.Gax;
 using Google.Api.Gax.Grpc;
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using static Google.Cloud.Datastore.V1.CommitRequest.Types;
@@ -88,16 +86,7 @@ namespace Google.Cloud.Datastore.V1
             CallSettings callSettings = null)
         {
             GaxPreconditions.CheckNotNull(query, nameof(query));
-            var request = new RunQueryRequest
-            {
-                ProjectId = ProjectId,
-                DatabaseId = DatabaseId,
-                PartitionId = _partitionId,
-                Query = query,
-                ReadOptions = GetReadOptions(readConsistency)
-            };
-            var streamer = new QueryStreamer(request, Client.RunQueryApiCall, callSettings);
-            return new LazyDatastoreQuery(streamer.Sync());
+            return RunQueryLazily(new DatastoreQuery { Query = query, ReadConsistency = readConsistency }, callSettings);
         }
 
         /// <inheritdoc/>
@@ -111,31 +100,15 @@ namespace Google.Cloud.Datastore.V1
         /// <inheritdoc/>
         public override AggregationQueryResults RunAggregationQuery(AggregationQuery query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
         {
-            var request = new RunAggregationQueryRequest
-            {
-                AggregationQuery = query,
-                ProjectId = ProjectId,
-                DatabaseId = DatabaseId,
-                PartitionId = _partitionId,
-                ReadOptions = GetReadOptions(readConsistency)
-            };
-            var runAggregationQueryResponse = Client.RunAggregationQuery(request, callSettings);
-            return AggregationQueryResults.FromRunAggregationQueryResponse(runAggregationQueryResponse);
+            GaxPreconditions.CheckNotNull(query, nameof(query));
+            return RunAggregationQuery(new DatastoreQuery { AggregationQuery = query, ReadConsistency = readConsistency }, callSettings);
         }
 
         /// <inheritdoc/>
         public override AggregationQueryResults RunAggregationQuery(GqlQuery query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
         {
-            var request = new RunAggregationQueryRequest
-            {
-                GqlQuery = query,
-                ProjectId = ProjectId,
-                DatabaseId = DatabaseId,
-                PartitionId = _partitionId,
-                ReadOptions = GetReadOptions(readConsistency)
-            };
-            var runAggregationQueryResponse = Client.RunAggregationQuery(request, callSettings);
-            return AggregationQueryResults.FromRunAggregationQueryResponse(runAggregationQueryResponse);
+            GaxPreconditions.CheckNotNull(query, nameof(query));
+            return RunAggregationQuery(new DatastoreQuery { GqlQuery = query, ReadConsistency = readConsistency }, callSettings);
         }
 
         /// <inheritdoc/>
@@ -147,33 +120,17 @@ namespace Google.Cloud.Datastore.V1
         }
 
         /// <inheritdoc/>
-        public override async Task<AggregationQueryResults> RunAggregationQueryAsync(AggregationQuery query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
+        public override Task<AggregationQueryResults> RunAggregationQueryAsync(AggregationQuery query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
         {
-            var request = new RunAggregationQueryRequest
-            {
-                AggregationQuery = query,
-                ProjectId = ProjectId,
-                DatabaseId = DatabaseId,
-                PartitionId = _partitionId,
-                ReadOptions = GetReadOptions(readConsistency)
-            };
-            var runAggregationQueryResponse = await Client.RunAggregationQueryAsync(request, callSettings).ConfigureAwait(false);
-            return AggregationQueryResults.FromRunAggregationQueryResponse(runAggregationQueryResponse);
+            GaxPreconditions.CheckNotNull(query, nameof(query));
+            return RunAggregationQueryAsync(new DatastoreQuery { AggregationQuery = query, ReadConsistency = readConsistency }, callSettings);
         }
 
         /// <inheritdoc/>
-        public override async Task<AggregationQueryResults> RunAggregationQueryAsync(GqlQuery query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
+        public override Task<AggregationQueryResults> RunAggregationQueryAsync(GqlQuery query, ReadConsistency? readConsistency = null, CallSettings callSettings = null)
         {
-            var request = new RunAggregationQueryRequest
-            {
-                GqlQuery = query,
-                ProjectId = ProjectId,
-                DatabaseId = DatabaseId,
-                PartitionId = _partitionId,
-                ReadOptions = GetReadOptions(readConsistency)
-            };
-            var runAggregationQueryResponse = await Client.RunAggregationQueryAsync(request, callSettings).ConfigureAwait(false);
-            return AggregationQueryResults.FromRunAggregationQueryResponse(runAggregationQueryResponse);
+            GaxPreconditions.CheckNotNull(query, nameof(query));
+            return RunAggregationQueryAsync(new DatastoreQuery { GqlQuery = query, ReadConsistency = readConsistency }, callSettings);
         }
 
         /// <inheritdoc/>
@@ -183,16 +140,7 @@ namespace Google.Cloud.Datastore.V1
             CallSettings callSettings = null)
         {
             GaxPreconditions.CheckNotNull(query, nameof(query));
-            var request = new RunQueryRequest
-            {
-                ProjectId = ProjectId,
-                DatabaseId = DatabaseId,
-                PartitionId = _partitionId,
-                Query = query,
-                ReadOptions = GetReadOptions(readConsistency)
-            };
-            var streamer = new QueryStreamer(request, Client.RunQueryApiCall, callSettings);
-            return new AsyncLazyDatastoreQuery(streamer.Async());
+            return RunQueryLazilyAsync(new DatastoreQuery { Query = query, ReadConsistency = readConsistency }, callSettings);
         }
 
         /// <inheritdoc/>
@@ -202,16 +150,7 @@ namespace Google.Cloud.Datastore.V1
             CallSettings callSettings = null)
         {
             GaxPreconditions.CheckNotNull(gqlQuery, nameof(gqlQuery));
-            var request = new RunQueryRequest
-            {
-                ProjectId = ProjectId,
-                DatabaseId = DatabaseId,
-                PartitionId = _partitionId,
-                GqlQuery = gqlQuery,
-                ReadOptions = GetReadOptions(readConsistency)
-            };
-            var streamer = new QueryStreamer(request, Client.RunQueryApiCall, callSettings);
-            return new LazyDatastoreQuery(streamer.Sync());
+            return RunQueryLazily(new DatastoreQuery { GqlQuery = gqlQuery, ReadConsistency = readConsistency }, callSettings);
         }
 
         /// <inheritdoc/>
@@ -221,16 +160,7 @@ namespace Google.Cloud.Datastore.V1
             CallSettings callSettings = null)
         {
             GaxPreconditions.CheckNotNull(gqlQuery, nameof(gqlQuery));
-            var request = new RunQueryRequest
-            {
-                ProjectId = ProjectId,
-                DatabaseId = DatabaseId,
-                PartitionId = _partitionId,
-                GqlQuery = gqlQuery,
-                ReadOptions = GetReadOptions(readConsistency)
-            };
-            var streamer = new QueryStreamer(request, Client.RunQueryApiCall, callSettings);
-            return new AsyncLazyDatastoreQuery(streamer.Async());
+            return RunQueryLazilyAsync(new DatastoreQuery { GqlQuery = gqlQuery, ReadConsistency = readConsistency }, callSettings);
         }
 
         /// <inheritdoc/>

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreQuery.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreQuery.cs
@@ -1,0 +1,107 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License"):
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using static Google.Cloud.Datastore.V1.ReadOptions.Types;
+
+namespace Google.Cloud.Datastore.V1;
+
+/// <summary>
+/// A Datastore query with additional options for features such as read consistency and profiling.
+/// </summary>
+public sealed class DatastoreQuery
+{
+    /// <summary>
+    /// The aggregation query to execute. For regular queries, this must be null.
+    /// For aggregation queries, exactly one of this property or <see cref="GqlQuery"/>
+    /// must be set when the query is executed.
+    /// </summary>
+    public AggregationQuery AggregationQuery { get; set; }
+
+    /// <summary>
+    /// The GQL query to execute. For regular queries, exactly one of this property or <see cref="Query"/>
+    /// must be set when the query is executed. For aggregation queries,
+    /// exactly one of this property or <see cref="AggregationQuery"/> must be set when the query is executed.
+    /// </summary>
+    public GqlQuery GqlQuery { get; set; }
+
+    /// <summary>
+    /// The structured query to execute. For regular queries, exactly one of this property or <see cref="GqlQuery"/>
+    /// must be set when the query is executed. For aggregation queries, this must be null.
+    /// </summary>
+    public Query Query { get; set; }
+
+    /// <summary>
+    /// The profiling (explain) options to use for query execution, if any.
+    /// </summary>
+    public ExplainOptions ExplainOptions { get; set; }
+
+    /// <summary>
+    /// The level of read consistency to apply, if any. This property is ignored when the query is executed in a transaction.
+    /// </summary>
+    public ReadConsistency? ReadConsistency { get; set; }
+
+    internal RunQueryRequest ToRequest(string projectId, string databaseId, PartitionId partitionId)
+    {
+        var request = new RunQueryRequest
+        {
+            ProjectId = projectId,
+            DatabaseId = databaseId,
+            PartitionId = partitionId,
+            ReadOptions = GetReadOptions(ReadConsistency),
+            ExplainOptions = ExplainOptions
+        };
+        GaxPreconditions.CheckState(AggregationQuery is null, "{0} must not be set when executing a regular query", nameof(AggregationQuery));
+        switch (GqlQuery, Query)
+        {
+            case (GqlQuery gqlQuery, null): request.GqlQuery = gqlQuery;
+                break;
+            case (null, Query query): request.Query = query;
+                break;
+            default:
+                GaxPreconditions.CheckState(false, "Exactly one of {0} and {1} must be set", nameof(GqlQuery), nameof(Query));
+                break;
+        }
+        return request;
+    }
+
+    internal RunAggregationQueryRequest ToAggregationRequest(string projectId, string databaseId, PartitionId partitionId)
+    {
+        var request = new RunAggregationQueryRequest
+        {
+            ProjectId = projectId,
+            DatabaseId = databaseId,
+            PartitionId = partitionId,
+            ReadOptions = GetReadOptions(ReadConsistency),
+            ExplainOptions = ExplainOptions
+        };
+        GaxPreconditions.CheckState(Query is null, "{0} must not be set when executing a regular query", nameof(Query));
+        switch (GqlQuery, AggregationQuery)
+        {
+            case (GqlQuery gqlQuery, null):
+                request.GqlQuery = gqlQuery;
+                break;
+            case (null, AggregationQuery aggregationQuery):
+                request.AggregationQuery = aggregationQuery;
+                break;
+            default:
+                GaxPreconditions.CheckState(false, "Exactly one of {0} and {1} must be set", nameof(GqlQuery), nameof(AggregationQuery));
+                break;
+        }
+        return request;
+    }
+
+    private static ReadOptions GetReadOptions(ReadConsistency? readConsistency) =>
+        readConsistency == null ? null : new ReadOptions { ReadConsistency = readConsistency.Value };
+}

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreQueryResults.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreQueryResults.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,18 +38,27 @@ namespace Google.Cloud.Datastore.V1
         public MoreResultsType MoreResults { get; }
 
         /// <summary>
-        /// The cursor at the end of the results. This will never be null.
+        /// The cursor at the end of the results. This will only be null for "explain" queries,
+        /// where the query has not actually been executed.
         /// </summary>
         public ByteString EndCursor { get; }
+
+        /// <summary>
+        /// The information about planning and execution (if any) of the query. This will
+        /// be null if no analysis was requested.
+        /// </summary>
+        public ExplainMetrics Metrics { get; }
 
         internal DatastoreQueryResults(
             IReadOnlyList<Entity> entities,
             MoreResultsType endCondition,
-            ByteString endCursor)
+            ByteString endCursor,
+            ExplainMetrics metrics)
         {
             MoreResults = endCondition;
             Entities = entities;
             EndCursor = endCursor;
+            Metrics = metrics;
         }
     }
 }

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreTransaction.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreTransaction.cs
@@ -108,8 +108,48 @@ namespace Google.Cloud.Datastore.V1
         /// <param name="query">The query to execute. Must not be null.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
         /// <returns>The complete query results.</returns>
+        public virtual DatastoreQueryResults RunQuery(DatastoreQuery query, CallSettings callSettings = null) =>
+            RunQueryLazily(query, callSettings).GetAllResults();
+
+        /// <summary>
+        /// Runs the given query eagerly in this transaction, retrieving all results in memory and indicating whether more
+        /// results may be available beyond the query's limit. Use this method when your query has a limited
+        /// number of results, for example to build a web application which fetches results in pages.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Using a transaction ensures that a commit operation will fail if any of the entities returned
+        /// by this query have been modified while the transaction is active. Note that modifications performed
+        /// as part of this operation are not reflected in the query results.
+        /// </para>
+        /// <para>The default implementation of this method delegates to <see cref="RunQueryLazily(Query, CallSettings)"/>
+        /// and calls <see cref="LazyDatastoreQuery.GetAllResults"/> on the return value.</para>
+        /// </remarks>
+        /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>The complete query results.</returns>
         public virtual DatastoreQueryResults RunQuery(Query query, CallSettings callSettings = null) =>
             RunQueryLazily(query, callSettings).GetAllResults();
+
+        /// <summary>
+        /// Runs the given query eagerly and asynchronously in this transaction, retrieving all results in memory
+        /// and indicating whether more results may be available beyond the query's limit. Use this method when your query has a limited
+        /// number of results, for example to build a web application which fetches results in pages.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Using a transaction ensures that a commit operation will fail if any of the entities returned
+        /// by this query have been modified while the transaction is active. Note that modifications performed
+        /// as part of this operation are not reflected in the query results.
+        /// </para>
+        /// <para>The default implementation of this method delegates to <see cref="RunQueryLazilyAsync(Query, CallSettings)"/>
+        /// and calls <see cref="AsyncLazyDatastoreQuery.GetAllResultsAsync"/> on the return value.</para>
+        /// </remarks>
+        /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>A task representing the asynchronous operation. The result of the task is the complete set of query results.</returns>
+        public virtual Task<DatastoreQueryResults> RunQueryAsync(DatastoreQuery query, CallSettings callSettings = null) =>
+            RunQueryLazilyAsync(query, callSettings).GetAllResultsAsync();
 
         /// <summary>
         /// Runs the given query eagerly and asynchronously in this transaction, retrieving all results in memory
@@ -132,6 +172,17 @@ namespace Google.Cloud.Datastore.V1
             RunQueryLazilyAsync(query, callSettings).GetAllResultsAsync();
 
         /// <summary>
+        /// Runs the given <see cref="DatastoreQuery"/> in this transaction.
+        /// </summary>
+        /// <param name="query">The <see cref="AggregationQuery"/> to execute. Must not be null.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>The result of aggregation query.</returns>
+        public virtual AggregationQueryResults RunAggregationQuery(DatastoreQuery query, CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// Runs the given <see cref="AggregationQuery"/> in this transaction.
         /// </summary>
         /// <param name="query">The <see cref="AggregationQuery"/> to execute. Must not be null.</param>
@@ -149,6 +200,17 @@ namespace Google.Cloud.Datastore.V1
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
         /// <returns>The result of aggregation query.</returns>
         public virtual AggregationQueryResults RunAggregationQuery(GqlQuery query, CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Runs the given <see cref="DatastoreQuery"/> in this transaction.
+        /// </summary>
+        /// <param name="query">The <see cref="AggregationQuery"/> to execute. Must not be null.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>A task representing the asynchronous operation. The result of the task is the result of the aggregation query.</returns>
+        public virtual Task<AggregationQueryResults> RunAggregationQueryAsync(DatastoreQuery query, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }
@@ -193,7 +255,53 @@ namespace Google.Cloud.Datastore.V1
         /// <param name="query">The query to execute. Must not be null.</param>
         /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
         /// <returns>A <see cref="LazyDatastoreQuery"/> representing the the lazy query results.</returns>
+        public virtual LazyDatastoreQuery RunQueryLazily(DatastoreQuery query, CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Lazily executes the given structured query in this transaction.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Using a transaction ensures that a commit operation will fail if any of the entities returned
+        /// by this query have been modified while the transaction is active. Note that modifications performed
+        /// as part of this operation are not reflected in the query results.
+        /// </para>
+        /// <para>
+        /// The results are requested lazily: no API calls will be made until the application starts
+        /// iterating over the results. Iterating over the same <see cref="LazyDatastoreQuery"/> object
+        /// multiple times will execute the query again, potentially returning different results.
+        /// </para>
+        /// </remarks>
+        /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>A <see cref="LazyDatastoreQuery"/> representing the the lazy query results.</returns>
         public virtual LazyDatastoreQuery RunQueryLazily(Query query, CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Lazily executes the given structured query in this transaction for asynchronous consumption.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Using a transaction ensures that a commit operation will fail if any of the entities returned
+        /// by this query have been modified while the transaction is active. Note that modifications performed
+        /// as part of this operation are not reflected in the query results.
+        /// </para>
+        /// <para>
+        /// The results are requested lazily: no API calls will be made until the application starts
+        /// iterating over the results. Iterating over the same <see cref="LazyDatastoreQuery"/> object
+        /// multiple times will execute the query again, potentially returning different results.
+        /// </para>
+        /// </remarks>
+        /// <param name="query">The query to execute. Must not be null.</param>
+        /// <param name="callSettings">If not null, applies overrides to RPC calls.</param>
+        /// <returns>An <see cref="AsyncLazyDatastoreQuery"/> representing the result of the query.</returns>
+        public virtual AsyncLazyDatastoreQuery RunQueryLazilyAsync(DatastoreQuery query, CallSettings callSettings = null)
         {
             throw new NotImplementedException();
         }

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreTransactionImpl.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreTransactionImpl.cs
@@ -107,69 +107,34 @@ namespace Google.Cloud.Datastore.V1
         public override LazyDatastoreQuery RunQueryLazily(Query query, CallSettings callSettings = null)
         {
             GaxPreconditions.CheckNotNull(query, nameof(query));
-            var request = new RunQueryRequest
-            {
-                ProjectId = _projectId,
-                DatabaseId = _databaseId,
-                PartitionId = _partitionId,
-                Query = query,
-                ReadOptions = _readOptions
-            };
-            var streamer = new QueryStreamer(request, _client.RunQueryApiCall, callSettings);
-            return new LazyDatastoreQuery(streamer.Sync());
+            return RunQueryLazily(new DatastoreQuery { Query = query }, callSettings);
         }
 
         /// <inheritdoc />
         public override AsyncLazyDatastoreQuery RunQueryLazilyAsync(Query query, CallSettings callSettings = null)
         {
             GaxPreconditions.CheckNotNull(query, nameof(query));
-            var request = new RunQueryRequest
-            {
-                ProjectId = _projectId,
-                DatabaseId = _databaseId,
-                PartitionId = _partitionId,
-                Query = query,
-                ReadOptions = _readOptions
-            };
-            var streamer = new QueryStreamer(request, _client.RunQueryApiCall, callSettings);
-            return new AsyncLazyDatastoreQuery(streamer.Async());
+            return RunQueryLazilyAsync(new DatastoreQuery { Query = query }, callSettings);
         }
 
         /// <inheritdoc />
         public override LazyDatastoreQuery RunQueryLazily(GqlQuery gqlQuery, CallSettings callSettings = null)
         {
             GaxPreconditions.CheckNotNull(gqlQuery, nameof(gqlQuery));
-            var request = new RunQueryRequest
-            {
-                ProjectId = _projectId,
-                DatabaseId = _databaseId,
-                PartitionId = _partitionId,
-                GqlQuery = gqlQuery,
-                ReadOptions = _readOptions
-            };
-            var streamer = new QueryStreamer(request, _client.RunQueryApiCall, callSettings);
-            return new LazyDatastoreQuery(streamer.Sync());
+            return RunQueryLazily(new DatastoreQuery { GqlQuery = gqlQuery }, callSettings);
         }
 
         /// <inheritdoc />
         public override AsyncLazyDatastoreQuery RunQueryLazilyAsync(GqlQuery gqlQuery, CallSettings callSettings = null)
         {
             GaxPreconditions.CheckNotNull(gqlQuery, nameof(gqlQuery));
-            var request = new RunQueryRequest
-            {
-                ProjectId = _projectId,
-                DatabaseId = _databaseId,
-                PartitionId = _partitionId,
-                GqlQuery = gqlQuery,
-                ReadOptions = _readOptions
-            };
-            var streamer = new QueryStreamer(request, _client.RunQueryApiCall, callSettings);
-            return new AsyncLazyDatastoreQuery(streamer.Async());
+            return RunQueryLazilyAsync(new DatastoreQuery { GqlQuery = gqlQuery }, callSettings);
         }
 
         /// <inheritdoc/>
         public override AggregationQueryResults RunAggregationQuery(DatastoreQuery query, CallSettings callSettings = null)
         {
+            GaxPreconditions.CheckNotNull(query, nameof(query));
             var request = query.ToAggregationRequest(_projectId, _databaseId, _partitionId);
             request.ReadOptions = _readOptions;
             var runAggregationQueryResponse = _client.RunAggregationQuery(request, callSettings);
@@ -179,36 +144,21 @@ namespace Google.Cloud.Datastore.V1
         /// <inheritdoc/>
         public override AggregationQueryResults RunAggregationQuery(AggregationQuery query, CallSettings callSettings = null)
         {
-            var request = new RunAggregationQueryRequest
-            {
-                AggregationQuery = query,
-                ProjectId = _projectId,
-                DatabaseId = _databaseId,
-                PartitionId = _partitionId,
-                ReadOptions = _readOptions
-            };
-            var runAggregationQueryResponse = _client.RunAggregationQuery(request, callSettings);
-            return AggregationQueryResults.FromRunAggregationQueryResponse(runAggregationQueryResponse);
+            GaxPreconditions.CheckNotNull(query, nameof(query));
+            return RunAggregationQuery(new DatastoreQuery { AggregationQuery = query }, callSettings);
         }
 
         /// <inheritdoc/>
         public override AggregationQueryResults RunAggregationQuery(GqlQuery query, CallSettings callSettings = null)
         {
-            var request = new RunAggregationQueryRequest
-            {
-                GqlQuery = query,
-                ProjectId = _projectId,
-                DatabaseId = _databaseId,
-                PartitionId = _partitionId,
-                ReadOptions = _readOptions
-            };
-            var runAggregationQueryResponse = _client.RunAggregationQuery(request, callSettings);
-            return AggregationQueryResults.FromRunAggregationQueryResponse(runAggregationQueryResponse);
+            GaxPreconditions.CheckNotNull(query, nameof(query));
+            return RunAggregationQuery(new DatastoreQuery { GqlQuery = query }, callSettings);
         }
 
         /// <inheritdoc/>
         public override async Task<AggregationQueryResults> RunAggregationQueryAsync(DatastoreQuery query, CallSettings callSettings = null)
         {
+            GaxPreconditions.CheckNotNull(query, nameof(query));
             var request = query.ToAggregationRequest(_projectId, _databaseId, _partitionId);
             request.ReadOptions = _readOptions;
             var runAggregationQueryResponse = await _client.RunAggregationQueryAsync(request, callSettings).ConfigureAwait(false);
@@ -216,33 +166,17 @@ namespace Google.Cloud.Datastore.V1
         }
 
         /// <inheritdoc/>
-        public override async Task<AggregationQueryResults> RunAggregationQueryAsync(AggregationQuery query, CallSettings callSettings = null)
+        public override Task<AggregationQueryResults> RunAggregationQueryAsync(AggregationQuery query, CallSettings callSettings = null)
         {
-            var request = new RunAggregationQueryRequest
-            {
-                AggregationQuery = query,
-                ProjectId = _projectId,
-                DatabaseId = _databaseId,
-                PartitionId = _partitionId,
-                ReadOptions = _readOptions
-            };
-            var runAggregationQueryResponse = await _client.RunAggregationQueryAsync(request, callSettings).ConfigureAwait(false);
-            return AggregationQueryResults.FromRunAggregationQueryResponse(runAggregationQueryResponse);
+            GaxPreconditions.CheckNotNull(query, nameof(query));
+            return RunAggregationQueryAsync(new DatastoreQuery { AggregationQuery = query }, callSettings);
         }
 
         /// <inheritdoc/>
-        public override async Task<AggregationQueryResults> RunAggregationQueryAsync(GqlQuery query, CallSettings callSettings = null)
+        public override Task<AggregationQueryResults> RunAggregationQueryAsync(GqlQuery query, CallSettings callSettings = null)
         {
-            var request = new RunAggregationQueryRequest
-            {
-                GqlQuery = query,
-                ProjectId = _projectId,
-                DatabaseId = _databaseId,
-                PartitionId = _partitionId,
-                ReadOptions = _readOptions
-            };
-            var runAggregationQueryResponse = await _client.RunAggregationQueryAsync(request, callSettings).ConfigureAwait(false);
-            return AggregationQueryResults.FromRunAggregationQueryResponse(runAggregationQueryResponse);
+            GaxPreconditions.CheckNotNull(query, nameof(query));
+            return RunAggregationQueryAsync(new DatastoreQuery { GqlQuery = query }, callSettings);
         }
 
         /// <inheritdoc />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreTransactionImpl.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreTransactionImpl.cs
@@ -84,6 +84,26 @@ namespace Google.Cloud.Datastore.V1
         }
 
         /// <inheritdoc />
+        public override LazyDatastoreQuery RunQueryLazily(DatastoreQuery query, CallSettings callSettings = null)
+        {
+            GaxPreconditions.CheckNotNull(query, nameof(query));
+            var request = query.ToRequest(_projectId, _databaseId, _partitionId);
+            request.ReadOptions = _readOptions;
+            var streamer = new QueryStreamer(request, _client.RunQueryApiCall, callSettings);
+            return new LazyDatastoreQuery(streamer.Sync());
+        }
+
+        /// <inheritdoc />
+        public override AsyncLazyDatastoreQuery RunQueryLazilyAsync(DatastoreQuery query, CallSettings callSettings = null)
+        {
+            GaxPreconditions.CheckNotNull(query, nameof(query));
+            var request = query.ToRequest(_projectId, _databaseId, _partitionId);
+            request.ReadOptions = _readOptions;
+            var streamer = new QueryStreamer(request, _client.RunQueryApiCall, callSettings);
+            return new AsyncLazyDatastoreQuery(streamer.Async());
+        }
+
+        /// <inheritdoc />
         public override LazyDatastoreQuery RunQueryLazily(Query query, CallSettings callSettings = null)
         {
             GaxPreconditions.CheckNotNull(query, nameof(query));
@@ -148,6 +168,15 @@ namespace Google.Cloud.Datastore.V1
         }
 
         /// <inheritdoc/>
+        public override AggregationQueryResults RunAggregationQuery(DatastoreQuery query, CallSettings callSettings = null)
+        {
+            var request = query.ToAggregationRequest(_projectId, _databaseId, _partitionId);
+            request.ReadOptions = _readOptions;
+            var runAggregationQueryResponse = _client.RunAggregationQuery(request, callSettings);
+            return AggregationQueryResults.FromRunAggregationQueryResponse(runAggregationQueryResponse);
+        }
+
+        /// <inheritdoc/>
         public override AggregationQueryResults RunAggregationQuery(AggregationQuery query, CallSettings callSettings = null)
         {
             var request = new RunAggregationQueryRequest
@@ -174,6 +203,15 @@ namespace Google.Cloud.Datastore.V1
                 ReadOptions = _readOptions
             };
             var runAggregationQueryResponse = _client.RunAggregationQuery(request, callSettings);
+            return AggregationQueryResults.FromRunAggregationQueryResponse(runAggregationQueryResponse);
+        }
+
+        /// <inheritdoc/>
+        public override async Task<AggregationQueryResults> RunAggregationQueryAsync(DatastoreQuery query, CallSettings callSettings = null)
+        {
+            var request = query.ToAggregationRequest(_projectId, _databaseId, _partitionId);
+            request.ReadOptions = _readOptions;
+            var runAggregationQueryResponse = await _client.RunAggregationQueryAsync(request, callSettings).ConfigureAwait(false);
             return AggregationQueryResults.FromRunAggregationQueryResponse(runAggregationQueryResponse);
         }
 

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/LazyDatastoreQuery.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/LazyDatastoreQuery.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ using Google.Api.Gax.Grpc;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using static Google.Cloud.Datastore.V1.QueryResultBatch.Types;
 
 namespace Google.Cloud.Datastore.V1
 {
@@ -61,9 +62,10 @@ namespace Google.Cloud.Datastore.V1
             // cursors etc, but that's likely to be insignificant compared with the
             // entity data, and is immediately eligible for garbage collection.
             var responses = _responses.ToList();
-            var entities = responses.SelectMany(r => r.Batch.EntityResults.Select(er => er.Entity)).ToList().AsReadOnly();
+            var entities = responses.SelectMany(r => r.Batch?.EntityResults.Select(er => er.Entity) ?? Enumerable.Empty<Entity>()).ToList().AsReadOnly();
             var lastBatch = responses.Last().Batch;
-            return new DatastoreQueryResults(entities, lastBatch.MoreResults, lastBatch.EndCursor);
+            var metrics = responses.Last().ExplainMetrics;
+            return new DatastoreQueryResults(entities, lastBatch?.MoreResults ?? MoreResultsType.Unspecified, lastBatch?.EndCursor, metrics);
         }
 
         /// <inheritdoc />

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/QueryStreamer.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/QueryStreamer.cs
@@ -41,11 +41,23 @@ namespace Google.Cloud.Datastore.V1
 
         private static void ModifyRequest(RunQueryRequest request, RunQueryResponse response)
         {
+            // Explain-only responses don't have batches, but will only have one response anyway.
+            if (response.Batch is null)
+            {
+                return;
+            }
+
             // Transition from GQL to structured queries.
             if (response.Query != null)
             {
+                // If the response doesn't have a query, presumably we're in explain-only mode; return.
+                if (response.Query is null)
+                {
+                    return;
+                }
                 request.Query = response.Query;
             }
+
             // Offset/limit/cursor handling.
             var query = request.Query;
             var batch = response.Batch;
@@ -58,7 +70,7 @@ namespace Google.Cloud.Datastore.V1
         }
 
         private static bool MoreResultsAvailable(RunQueryResponse response) =>
-            response.Batch.MoreResults == MoreResultsType.NotFinished;
+            response.Batch?.MoreResults == MoreResultsType.NotFinished;
 
         internal IAsyncEnumerable<RunQueryResponse> Async() => new AsyncQueryEnumerable(this);
 


### PR DESCRIPTION
This centers around a new DatastoreQuery type that encapsulates all the relevant options for a query (both aggregation queries and regular ones). All previous query operations are now implemented via `DatastoreQuery`.