### PR TITLE
Release Firestore libraries version 3.10.0

### DIFF
--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.9.0</Version>
+    <Version>3.10.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Low-level Google client library to access the Firestore API. Users are recommended to use the Google.Cloud.Firestore package instead.</Description>

--- a/apis/Google.Cloud.Firestore.V1/docs/history.md
+++ b/apis/Google.Cloud.Firestore.V1/docs/history.md
@@ -4,6 +4,13 @@ This package is primarily a dependency of Google.Cloud.Firestore. See the
 [Google.Cloud.Firestore version history](https://googleapis.dev/dotnet/Google.Cloud.Firestore/latest/history.html)
 for more details.
 
+## Version 3.10.0, released 2025-03-12
+
+### Documentation improvements
+
+- Minor documentation updates to `StructuredQuery` ([commit a35c988](https://github.com/googleapis/google-cloud-dotnet/commit/a35c98889228ea0291cc7d843eabb875711d667b))
+- Minor documentation changes for `distance_threshold` ([commit a35c988](https://github.com/googleapis/google-cloud-dotnet/commit/a35c98889228ea0291cc7d843eabb875711d667b))
+
 ## Version 3.9.0, released 2024-09-26
 
 ### New features

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/Google.Cloud.Firestore.IntegrationTests.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/Google.Cloud.Firestore.IntegrationTests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Google.Api.Gax.Testing" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Firestore\Google.Cloud.Firestore.csproj" />
-    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" VersionOverride="[3.11.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" VersionOverride="[3.12.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core.Testing" VersionOverride="[2.46.6, 3.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/Google.Cloud.Firestore.Snippets.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Snippets/Google.Cloud.Firestore.Snippets.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Google.Api.Gax.Testing" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Firestore\Google.Cloud.Firestore.csproj" />
-    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" VersionOverride="[3.11.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" VersionOverride="[3.12.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core.Testing" VersionOverride="[2.46.6, 3.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Google.Cloud.Firestore.Tests.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.Tests/Google.Cloud.Firestore.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Google.Api.Gax.Testing" />
     <ProjectReference Include="..\..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
     <ProjectReference Include="..\Google.Cloud.Firestore\Google.Cloud.Firestore.csproj" />
-    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" VersionOverride="[3.11.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Firestore.Admin.V1" VersionOverride="[3.12.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core.Testing" VersionOverride="[2.46.6, 3.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.sln
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.sln
@@ -3,65 +3,59 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.2.32516.85
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Firestore", "Google.Cloud.Firestore\Google.Cloud.Firestore.csproj", "{23BB3FFF-DC4C-F978-04B5-C5E146893E68}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Firestore", "Google.Cloud.Firestore\Google.Cloud.Firestore.csproj", "{23BB3FFF-DC4C-F978-04B5-C5E146893E68}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Firestore.Benchmarks", "Google.Cloud.Firestore.Benchmarks\Google.Cloud.Firestore.Benchmarks.csproj", "{3B576042-1EF8-EA8B-2554-C5FF11CB3F48}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Firestore.Benchmarks", "Google.Cloud.Firestore.Benchmarks\Google.Cloud.Firestore.Benchmarks.csproj", "{3B576042-1EF8-EA8B-2554-C5FF11CB3F48}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Firestore.CleanTestData", "Google.Cloud.Firestore.CleanTestData\Google.Cloud.Firestore.CleanTestData.csproj", "{1A7F1C0F-72C8-8983-9906-1EA379969C43}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Firestore.CleanTestData", "Google.Cloud.Firestore.CleanTestData\Google.Cloud.Firestore.CleanTestData.csproj", "{1A7F1C0F-72C8-8983-9906-1EA379969C43}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Firestore.IntegrationTests", "Google.Cloud.Firestore.IntegrationTests\Google.Cloud.Firestore.IntegrationTests.csproj", "{ECA6C703-9C4B-5DB6-610C-37217893669E}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Firestore.IntegrationTests", "Google.Cloud.Firestore.IntegrationTests\Google.Cloud.Firestore.IntegrationTests.csproj", "{ECA6C703-9C4B-5DB6-610C-37217893669E}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Firestore.Snippets", "Google.Cloud.Firestore.Snippets\Google.Cloud.Firestore.Snippets.csproj", "{5AB44017-319A-FA5E-4BB7-AEE4663EA6F8}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Firestore.Snippets", "Google.Cloud.Firestore.Snippets\Google.Cloud.Firestore.Snippets.csproj", "{5AB44017-319A-FA5E-4BB7-AEE4663EA6F8}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Firestore.Tests", "Google.Cloud.Firestore.Tests\Google.Cloud.Firestore.Tests.csproj", "{3023B3E0-2A3A-0DE8-37B9-FC5DEFC655A7}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Firestore.Tests", "Google.Cloud.Firestore.Tests\Google.Cloud.Firestore.Tests.csproj", "{3023B3E0-2A3A-0DE8-37B9-FC5DEFC655A7}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{29974B0C-A7B0-8CA8-AE32-99F622C89044}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.ClientTesting", "..\..\tools\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj", "{29974B0C-A7B0-8CA8-AE32-99F622C89044}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Firestore.V1", "..\Google.Cloud.Firestore.V1\Google.Cloud.Firestore.V1\Google.Cloud.Firestore.V1.csproj", "{73C26D2D-CC8B-10B3-B6AB-5B25E6859268}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Firestore.V1", "..\Google.Cloud.Firestore.V1\Google.Cloud.Firestore.V1\Google.Cloud.Firestore.V1.csproj", "{73C26D2D-CC8B-10B3-B6AB-5B25E6859268}"
 EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{23BB3FFF-DC4C-F978-04B5-C5E146893E68}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{23BB3FFF-DC4C-F978-04B5-C5E146893E68}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{23BB3FFF-DC4C-F978-04B5-C5E146893E68}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{23BB3FFF-DC4C-F978-04B5-C5E146893E68}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3B576042-1EF8-EA8B-2554-C5FF11CB3F48}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3B576042-1EF8-EA8B-2554-C5FF11CB3F48}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3B576042-1EF8-EA8B-2554-C5FF11CB3F48}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3B576042-1EF8-EA8B-2554-C5FF11CB3F48}.Release|Any CPU.Build.0 = Release|Any CPU
-		{1A7F1C0F-72C8-8983-9906-1EA379969C43}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{1A7F1C0F-72C8-8983-9906-1EA379969C43}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1A7F1C0F-72C8-8983-9906-1EA379969C43}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1A7F1C0F-72C8-8983-9906-1EA379969C43}.Release|Any CPU.Build.0 = Release|Any CPU
-		{ECA6C703-9C4B-5DB6-610C-37217893669E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{ECA6C703-9C4B-5DB6-610C-37217893669E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{ECA6C703-9C4B-5DB6-610C-37217893669E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{ECA6C703-9C4B-5DB6-610C-37217893669E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5AB44017-319A-FA5E-4BB7-AEE4663EA6F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5AB44017-319A-FA5E-4BB7-AEE4663EA6F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5AB44017-319A-FA5E-4BB7-AEE4663EA6F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5AB44017-319A-FA5E-4BB7-AEE4663EA6F8}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3023B3E0-2A3A-0DE8-37B9-FC5DEFC655A7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3023B3E0-2A3A-0DE8-37B9-FC5DEFC655A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3023B3E0-2A3A-0DE8-37B9-FC5DEFC655A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3023B3E0-2A3A-0DE8-37B9-FC5DEFC655A7}.Release|Any CPU.Build.0 = Release|Any CPU
-		{29974B0C-A7B0-8CA8-AE32-99F622C89044}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{29974B0C-A7B0-8CA8-AE32-99F622C89044}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{29974B0C-A7B0-8CA8-AE32-99F622C89044}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{29974B0C-A7B0-8CA8-AE32-99F622C89044}.Release|Any CPU.Build.0 = Release|Any CPU
-		{73C26D2D-CC8B-10B3-B6AB-5B25E6859268}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{73C26D2D-CC8B-10B3-B6AB-5B25E6859268}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{73C26D2D-CC8B-10B3-B6AB-5B25E6859268}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{73C26D2D-CC8B-10B3-B6AB-5B25E6859268}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {46F695E8-04B1-4C09-9C59-1101A63C5BE0}
-	EndGlobalSection
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {23BB3FFF-DC4C-F978-04B5-C5E146893E68}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {23BB3FFF-DC4C-F978-04B5-C5E146893E68}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {23BB3FFF-DC4C-F978-04B5-C5E146893E68}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {23BB3FFF-DC4C-F978-04B5-C5E146893E68}.Release|Any CPU.Build.0 = Release|Any CPU
+        {3B576042-1EF8-EA8B-2554-C5FF11CB3F48}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {3B576042-1EF8-EA8B-2554-C5FF11CB3F48}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {3B576042-1EF8-EA8B-2554-C5FF11CB3F48}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {3B576042-1EF8-EA8B-2554-C5FF11CB3F48}.Release|Any CPU.Build.0 = Release|Any CPU
+        {1A7F1C0F-72C8-8983-9906-1EA379969C43}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {1A7F1C0F-72C8-8983-9906-1EA379969C43}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {1A7F1C0F-72C8-8983-9906-1EA379969C43}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {1A7F1C0F-72C8-8983-9906-1EA379969C43}.Release|Any CPU.Build.0 = Release|Any CPU
+        {ECA6C703-9C4B-5DB6-610C-37217893669E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {ECA6C703-9C4B-5DB6-610C-37217893669E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {ECA6C703-9C4B-5DB6-610C-37217893669E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {ECA6C703-9C4B-5DB6-610C-37217893669E}.Release|Any CPU.Build.0 = Release|Any CPU
+        {5AB44017-319A-FA5E-4BB7-AEE4663EA6F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {5AB44017-319A-FA5E-4BB7-AEE4663EA6F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {5AB44017-319A-FA5E-4BB7-AEE4663EA6F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {5AB44017-319A-FA5E-4BB7-AEE4663EA6F8}.Release|Any CPU.Build.0 = Release|Any CPU
+        {3023B3E0-2A3A-0DE8-37B9-FC5DEFC655A7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {3023B3E0-2A3A-0DE8-37B9-FC5DEFC655A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {3023B3E0-2A3A-0DE8-37B9-FC5DEFC655A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {3023B3E0-2A3A-0DE8-37B9-FC5DEFC655A7}.Release|Any CPU.Build.0 = Release|Any CPU
+        {29974B0C-A7B0-8CA8-AE32-99F622C89044}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {29974B0C-A7B0-8CA8-AE32-99F622C89044}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {29974B0C-A7B0-8CA8-AE32-99F622C89044}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {29974B0C-A7B0-8CA8-AE32-99F622C89044}.Release|Any CPU.Build.0 = Release|Any CPU
+        {73C26D2D-CC8B-10B3-B6AB-5B25E6859268}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {73C26D2D-CC8B-10B3-B6AB-5B25E6859268}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {73C26D2D-CC8B-10B3-B6AB-5B25E6859268}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {73C26D2D-CC8B-10B3-B6AB-5B25E6859268}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
 EndGlobal

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore/Google.Cloud.Firestore.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.9.0</Version>
+    <Version>3.10.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Firestore API.</Description>

--- a/apis/Google.Cloud.Firestore/docs/history.md
+++ b/apis/Google.Cloud.Firestore/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.10.0, released 2025-03-12
+
+### New features
+
+- Expose query planning and statistics ([commit 986bc4a](https://github.com/googleapis/google-cloud-dotnet/commit/986bc4a62b5e1c62a8e81453683f11473c0e46a5))
+
 ## Version 3.9.0, released 2024-09-26
 
 No API surface changes; just dependency updates.

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -2555,7 +2555,7 @@
       "productName": "Firestore",
       "productUrl": "https://firebase.google.com/docs/firestore/",
       "listingDescription": "Firestore high-level library",
-      "version": "3.9.0",
+      "version": "3.10.0",
       "type": "other",
       "metadataType": "GAPIC_MANUAL",
       "description": "Recommended Google client library to access the Firestore API.",
@@ -2572,7 +2572,7 @@
       "testDependencies": {
         "Google.Api.Gax.Grpc.Testing": "default",
         "Google.Api.Gax.Testing": "default",
-        "Google.Cloud.Firestore.Admin.V1": "3.11.0",
+        "Google.Cloud.Firestore.Admin.V1": "3.12.0",
         "Grpc.Core.Testing": "2.46.6",
         "System.ValueTuple": "default",
         "Xunit.Combinatorial": "default"
@@ -2593,7 +2593,7 @@
       "productName": "Firestore",
       "productUrl": "https://firebase.google.com",
       "listingDescription": "Firestore low-level API access",
-      "version": "3.9.0",
+      "version": "3.10.0",
       "type": "grpc",
       "description": "Low-level Google client library to access the Firestore API. Users are recommended to use the Google.Cloud.Firestore package instead.",
       "tags": [


### PR DESCRIPTION

Changes in Google.Cloud.Firestore version 3.10.0:

### New features

- Expose query planning and statistics ([commit 986bc4a](https://github.com/googleapis/google-cloud-dotnet/commit/986bc4a62b5e1c62a8e81453683f11473c0e46a5))

Changes in Google.Cloud.Firestore.V1 version 3.10.0:

### Documentation improvements

- Minor documentation updates to `StructuredQuery` ([commit a35c988](https://github.com/googleapis/google-cloud-dotnet/commit/a35c98889228ea0291cc7d843eabb875711d667b))
- Minor documentation changes for `distance_threshold` ([commit a35c988](https://github.com/googleapis/google-cloud-dotnet/commit/a35c98889228ea0291cc7d843eabb875711d667b))

Packages in this release:
- Release Google.Cloud.Firestore version 3.10.0
- Release Google.Cloud.Firestore.V1 version 3.10.0
