### PR TITLE
Release Google.Cloud.PubSub.V1 version 3.23.0

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.22.0</Version>
+    <Version>3.23.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.</Description>

--- a/apis/Google.Cloud.PubSub.V1/docs/history.md
+++ b/apis/Google.Cloud.PubSub.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.23.0, released 2025-03-14
+
+### New features
+
+- Add more logs on subscriber pull stream retries ([commit ff5a39b](https://github.com/googleapis/google-cloud-dotnet/commit/ff5a39b9ccc431059a63aa475b1d4f231cb19752))
+
 ## Version 3.22.0, released 2025-03-10
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -4172,7 +4172,7 @@
       "protoPath": "google/pubsub/v1",
       "productName": "Cloud Pub/Sub",
       "productUrl": "https://cloud.google.com/pubsub/",
-      "version": "3.22.0",
+      "version": "3.23.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",


### PR DESCRIPTION

Changes in this release:

### New features

- Add more logs on subscriber pull stream retries ([commit ff5a39b](https://github.com/googleapis/google-cloud-dotnet/commit/ff5a39b9ccc431059a63aa475b1d4f231cb19752))
