### PR TITLE
Release Google.Cloud.AIPlatform.V1 version 3.23.0

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.22.0</Version>
+    <Version>3.23.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Vertex AI API (v1), which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 3.23.0, released 2025-03-17
+
+### New features
+
+- Add VertexAISearch.engine option ([commit 1fe1f81](https://github.com/googleapis/google-cloud-dotnet/commit/1fe1f81406fcfa5dcde96c48aed91d6c29b3bb2e))
+- Add reranker config to RAG v1 API ([commit 2e97dd3](https://github.com/googleapis/google-cloud-dotnet/commit/2e97dd3f1fd45a81c0630a08c4e6f5289e97eaac))
+
 ## Version 3.22.0, released 2025-03-10
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -397,7 +397,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1",
-      "version": "3.22.0",
+      "version": "3.23.0",
       "type": "grpc",
       "productName": "Vertex AI",
       "productUrl": "https://cloud.google.com/vertex-ai/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add VertexAISearch.engine option ([commit 1fe1f81](https://github.com/googleapis/google-cloud-dotnet/commit/1fe1f81406fcfa5dcde96c48aed91d6c29b3bb2e))
- Add reranker config to RAG v1 API ([commit 2e97dd3](https://github.com/googleapis/google-cloud-dotnet/commit/2e97dd3f1fd45a81c0630a08c4e6f5289e97eaac))
