### PR TITLE
Release Google.Cloud.AIPlatform.V1Beta1 version 1.0.0-beta22

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta21</Version>
+    <Version>1.0.0-beta22</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Vertex AI API (v1beta), which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 1.0.0-beta22, released 2025-03-17
+
+### New features
+
+- Add VertexAISearch.engine option ([commit 93bab4b](https://github.com/googleapis/google-cloud-dotnet/commit/93bab4b9bb801aa91adac8fcf023c4b8eae28de3))
+- Add function_call.id and function_response.id ([commit ee278c3](https://github.com/googleapis/google-cloud-dotnet/commit/ee278c310686bc16f0acfff79bf0a078b6030e66))
+
 ## Version 1.0.0-beta21, released 2025-03-10
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -373,7 +373,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1Beta1",
-      "version": "1.0.0-beta21",
+      "version": "1.0.0-beta22",
       "type": "grpc",
       "productName": "Vertex AI",
       "productUrl": "https://cloud.google.com/vertex-ai/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add VertexAISearch.engine option ([commit 93bab4b](https://github.com/googleapis/google-cloud-dotnet/commit/93bab4b9bb801aa91adac8fcf023c4b8eae28de3))
- Add function_call.id and function_response.id ([commit ee278c3](https://github.com/googleapis/google-cloud-dotnet/commit/ee278c310686bc16f0acfff79bf0a078b6030e66))
