### PR TITLE
Release Google.Cloud.DataCatalog.V1 version 2.15.0

### DIFF
--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.14.0</Version>
+    <Version>2.15.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Data Catalog API. Data Catalog is a fully managed and highly scalable data discovery and metadata management service.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>

--- a/apis/Google.Cloud.DataCatalog.V1/docs/history.md
+++ b/apis/Google.Cloud.DataCatalog.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 2.15.0, released 2025-03-17
+
+### New features
+
+- Mark DataCatalog service deprecated, use Dataplex Catalog instead ([commit ae53ed3](https://github.com/googleapis/google-cloud-dotnet/commit/ae53ed3aae077115d47a53bb5ff7b41d03839efc))
+
+### Documentation improvements
+
+- Fix a few typos ([commit ae53ed3](https://github.com/googleapis/google-cloud-dotnet/commit/ae53ed3aae077115d47a53bb5ff7b41d03839efc))
+- Fix markdown reference in `TagTemplate.is_publicly_readable` comment ([commit 8c0fdf1](https://github.com/googleapis/google-cloud-dotnet/commit/8c0fdf1f233f2208e959b9a0e2613426fba4db25))
+
 ## Version 2.14.0, released 2024-12-06
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -1758,7 +1758,7 @@
       "protoPath": "google/cloud/datacatalog/v1",
       "productName": "Data Catalog",
       "productUrl": "https://cloud.google.com/data-catalog/docs",
-      "version": "2.14.0",
+      "version": "2.15.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Data Catalog API. Data Catalog is a fully managed and highly scalable data discovery and metadata management service.",
       "tags": [
@@ -1766,7 +1766,7 @@
         "metadata"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Iam.V1": "3.4.0",
         "Google.LongRunning": "3.3.0"
       },
       "shortName": "datacatalog",


### PR DESCRIPTION

Changes in this release:

### New features

- Mark DataCatalog service deprecated, use Dataplex Catalog instead ([commit ae53ed3](https://github.com/googleapis/google-cloud-dotnet/commit/ae53ed3aae077115d47a53bb5ff7b41d03839efc))

### Documentation improvements

- Fix a few typos ([commit ae53ed3](https://github.com/googleapis/google-cloud-dotnet/commit/ae53ed3aae077115d47a53bb5ff7b41d03839efc))
- Fix markdown reference in `TagTemplate.is_publicly_readable` comment ([commit 8c0fdf1](https://github.com/googleapis/google-cloud-dotnet/commit/8c0fdf1f233f2208e959b9a0e2613426fba4db25))
