### PR TITLE
Release Google.Cloud.Dataplex.V1 version 3.7.0

### DIFF
--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.csproj
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.6.0</Version>
+    <Version>3.7.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataplex API, which is used to manage the lifecycle of data lakes.</Description>

--- a/apis/Google.Cloud.Dataplex.V1/docs/history.md
+++ b/apis/Google.Cloud.Dataplex.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 3.7.0, released 2025-03-17
+
+### New features
+
+- Add custom BigQuery dataset location support in Auto Discovery ([commit 964cc9f](https://github.com/googleapis/google-cloud-dotnet/commit/964cc9f1a4da7844d38836cca289f058102a3e6f))
+- DataTaxonomyService is now deprecated ([commit 964cc9f](https://github.com/googleapis/google-cloud-dotnet/commit/964cc9f1a4da7844d38836cca289f058102a3e6f))
+
+### Documentation improvements
+
+- Update the Dataplex Catalog proto to remove the info about schema changes ([commit 964cc9f](https://github.com/googleapis/google-cloud-dotnet/commit/964cc9f1a4da7844d38836cca289f058102a3e6f))
+
 ## Version 3.6.0, released 2025-02-10
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -1843,7 +1843,7 @@
     },
     {
       "id": "Google.Cloud.Dataplex.V1",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "type": "grpc",
       "productName": "Cloud Dataplex",
       "productUrl": "https://cloud.google.com/dataplex/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add custom BigQuery dataset location support in Auto Discovery ([commit 964cc9f](https://github.com/googleapis/google-cloud-dotnet/commit/964cc9f1a4da7844d38836cca289f058102a3e6f))
- DataTaxonomyService is now deprecated ([commit 964cc9f](https://github.com/googleapis/google-cloud-dotnet/commit/964cc9f1a4da7844d38836cca289f058102a3e6f))

### Documentation improvements

- Update the Dataplex Catalog proto to remove the info about schema changes ([commit 964cc9f](https://github.com/googleapis/google-cloud-dotnet/commit/964cc9f1a4da7844d38836cca289f058102a3e6f))
