### PR TITLE
Release Google.Cloud.ManagedKafka.V1 version 1.0.0-beta04

### DIFF
--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.csproj
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Managed Service for Apache Kafka API, which lets you ingest Kafka streams directly into Google Cloud.</Description>

--- a/apis/Google.Cloud.ManagedKafka.V1/docs/history.md
+++ b/apis/Google.Cloud.ManagedKafka.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 1.0.0-beta04, released 2025-03-17
+
+### Bug fixes
+
+- An existing google.api.http annotation `http_uri` is changed for method `GetConsumerGroup` in service `ManagedKafka` ([commit 0e666c4](https://github.com/googleapis/google-cloud-dotnet/commit/0e666c4bb8ffa411264e9e2c9d38b9cbeefe5169))
+- An existing google.api.http annotation `http_uri` is changed for method `UpdateConsumerGroup` in service `ManagedKafka` ([commit 0e666c4](https://github.com/googleapis/google-cloud-dotnet/commit/0e666c4bb8ffa411264e9e2c9d38b9cbeefe5169))
+- An existing google.api.http annotation `http_uri` is changed for method `DeleteConsumerGroup` in service `ManagedKafka` ([commit 0e666c4](https://github.com/googleapis/google-cloud-dotnet/commit/0e666c4bb8ffa411264e9e2c9d38b9cbeefe5169))
+
+### Documentation improvements
+
+- A comment for field `subnet` in message `.google.cloud.managedkafka.v1.NetworkConfig` is changed ([commit 0e666c4](https://github.com/googleapis/google-cloud-dotnet/commit/0e666c4bb8ffa411264e9e2c9d38b9cbeefe5169))
+
 ## Version 1.0.0-beta03, released 2025-01-13
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -3261,7 +3261,7 @@
     },
     {
       "id": "Google.Cloud.ManagedKafka.V1",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0-beta04",
       "type": "grpc",
       "productName": "Managed Service for Apache Kafka API",
       "productUrl": "https://cloud.google.com/managed-kafka",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- An existing google.api.http annotation `http_uri` is changed for method `GetConsumerGroup` in service `ManagedKafka` ([commit 0e666c4](https://github.com/googleapis/google-cloud-dotnet/commit/0e666c4bb8ffa411264e9e2c9d38b9cbeefe5169))
- An existing google.api.http annotation `http_uri` is changed for method `UpdateConsumerGroup` in service `ManagedKafka` ([commit 0e666c4](https://github.com/googleapis/google-cloud-dotnet/commit/0e666c4bb8ffa411264e9e2c9d38b9cbeefe5169))
- An existing google.api.http annotation `http_uri` is changed for method `DeleteConsumerGroup` in service `ManagedKafka` ([commit 0e666c4](https://github.com/googleapis/google-cloud-dotnet/commit/0e666c4bb8ffa411264e9e2c9d38b9cbeefe5169))

### Documentation improvements

- A comment for field `subnet` in message `.google.cloud.managedkafka.v1.NetworkConfig` is changed ([commit 0e666c4](https://github.com/googleapis/google-cloud-dotnet/commit/0e666c4bb8ffa411264e9e2c9d38b9cbeefe5169))
