### PR TITLE
Release Google.Cloud.RecaptchaEnterprise.V1 version 2.18.0

### DIFF
--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.csproj
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.17.0</Version>
+    <Version>2.18.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud reCAPTCHA for Enterprise API v1.</Description>

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/docs/history.md
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 2.18.0, released 2025-03-17
+
+### New features
+
+- A new field `ja4` is added to message `Event` ([commit 83141fa](https://github.com/googleapis/google-cloud-dotnet/commit/83141fa2a161ab37c7194aede62e7de7525b007b))
+
+### Documentation improvements
+
+- Update documentation ([commit 83141fa](https://github.com/googleapis/google-cloud-dotnet/commit/83141fa2a161ab37c7194aede62e7de7525b007b))
+- Update docs for FraudPrevention field in CreateAssessment ([commit eda016a](https://github.com/googleapis/google-cloud-dotnet/commit/eda016ac3bddbc77eac351f17335256c37dfa544))
+- Challenge is also returned for INVISIBLE keys ([commit eda016a](https://github.com/googleapis/google-cloud-dotnet/commit/eda016ac3bddbc77eac351f17335256c37dfa544))
+- Challenge is also returned for INVISIBLE keys ([commit d71a32f](https://github.com/googleapis/google-cloud-dotnet/commit/d71a32f41f32ed69ddf2bf51bea37f2b408e09cb))
+
 ## Version 2.17.0, released 2024-11-18
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -4228,7 +4228,7 @@
       "protoPath": "google/cloud/recaptchaenterprise/v1",
       "productName": "Google Cloud reCAPTCHA Enterprise",
       "productUrl": "https://cloud.google.com/recaptcha-enterprise/",
-      "version": "2.17.0",
+      "version": "2.18.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud reCAPTCHA for Enterprise API v1.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- A new field `ja4` is added to message `Event` ([commit 83141fa](https://github.com/googleapis/google-cloud-dotnet/commit/83141fa2a161ab37c7194aede62e7de7525b007b))

### Documentation improvements

- Update documentation ([commit 83141fa](https://github.com/googleapis/google-cloud-dotnet/commit/83141fa2a161ab37c7194aede62e7de7525b007b))
- Update docs for FraudPrevention field in CreateAssessment ([commit eda016a](https://github.com/googleapis/google-cloud-dotnet/commit/eda016ac3bddbc77eac351f17335256c37dfa544))
- Challenge is also returned for INVISIBLE keys ([commit eda016a](https://github.com/googleapis/google-cloud-dotnet/commit/eda016ac3bddbc77eac351f17335256c37dfa544))
- Challenge is also returned for INVISIBLE keys ([commit d71a32f](https://github.com/googleapis/google-cloud-dotnet/commit/d71a32f41f32ed69ddf2bf51bea37f2b408e09cb))
