### PR TITLE
Release Google.Shopping.Merchant.DataSources.V1Beta version 1.0.0-beta05

### DIFF
--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.csproj
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta04</Version>
+    <Version>1.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Merchant Data Sources API (v1beta) which allows developers to programmatically manage data sources.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Shopping.Type" VersionOverride="[1.0.0-beta05, 2.0.0)" />
+    <PackageReference Include="Google.Shopping.Type" VersionOverride="[1.0.0-beta06, 2.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/docs/history.md
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.0.0-beta05, released 2025-03-17
+
+### New features
+
+- Add a new destinations field ([commit df6846f](https://github.com/googleapis/google-cloud-dotnet/commit/df6846fb9d97e6b764ad5b80f03eeefba75f00fe))
+
+### Documentation improvements
+
+- A comment for field `promotion_data_source` in message `.google.shopping.merchant.datasources.v1beta.DataSource` is changed ([commit df6846f](https://github.com/googleapis/google-cloud-dotnet/commit/df6846fb9d97e6b764ad5b80f03eeefba75f00fe))
+- A comment for field `channel` in message `.google.shopping.merchant.datasources.v1beta.PrimaryProductDataSource` is changed ([commit df6846f](https://github.com/googleapis/google-cloud-dotnet/commit/df6846fb9d97e6b764ad5b80f03eeefba75f00fe))
 ## Version 1.0.0-beta04, released 2025-01-13
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -6261,7 +6261,7 @@
     },
     {
       "id": "Google.Shopping.Merchant.DataSources.V1Beta",
-      "version": "1.0.0-beta04",
+      "version": "1.0.0-beta05",
       "type": "grpc",
       "productName": "Merchant",
       "productUrl": "https://developers.google.com/merchant/api",
@@ -6272,7 +6272,7 @@
         "datasources"
       ],
       "dependencies": {
-        "Google.Shopping.Type": "1.0.0-beta05"
+        "Google.Shopping.Type": "1.0.0-beta06"
       },
       "generator": "micro",
       "protoPath": "google/shopping/merchant/datasources/v1beta",


### PR DESCRIPTION

Changes in this release:

### New features

- Add a new destinations field ([commit df6846f](https://github.com/googleapis/google-cloud-dotnet/commit/df6846fb9d97e6b764ad5b80f03eeefba75f00fe))

### Documentation improvements

- A comment for field `promotion_data_source` in message `.google.shopping.merchant.datasources.v1beta.DataSource` is changed ([commit df6846f](https://github.com/googleapis/google-cloud-dotnet/commit/df6846fb9d97e6b764ad5b80f03eeefba75f00fe))
- A comment for field `channel` in message `.google.shopping.merchant.datasources.v1beta.PrimaryProductDataSource` is changed ([commit df6846f](https://github.com/googleapis/google-cloud-dotnet/commit/df6846fb9d97e6b764ad5b80f03eeefba75f00fe))
