### PR TITLE
Release Google.Cloud.AIPlatform.V1 version 3.24.0

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.23.0</Version>
+    <Version>3.24.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Vertex AI API (v1), which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1/docs/history.md
@@ -1,5 +1,18 @@
 # Version history
 
+## Version 3.24.0, released 2025-03-24
+
+### New features
+
+- Add import result gcs sink to the import files API ([commit b313b52](https://github.com/googleapis/google-cloud-dotnet/commit/b313b526fcd2fd8c71aa46904e1bb4ac36a2b351))
+- Add import result bq sink to the import files API ([commit b313b52](https://github.com/googleapis/google-cloud-dotnet/commit/b313b526fcd2fd8c71aa46904e1bb4ac36a2b351))
+- Add env variables and agent framework to ReasoningEngineSpec ([commit 65eb876](https://github.com/googleapis/google-cloud-dotnet/commit/65eb876885c7d19a7af9758f9588b06a93ac1385))
+
+### Documentation improvements
+
+- Update comment for `package_spec` from required to optional in `ReasoningEngineSpec`. ([commit 65eb876](https://github.com/googleapis/google-cloud-dotnet/commit/65eb876885c7d19a7af9758f9588b06a93ac1385))
+- Add `deployment_spec` and `agent_framework` field to `ReasoningEngineSpec`. ([commit 65eb876](https://github.com/googleapis/google-cloud-dotnet/commit/65eb876885c7d19a7af9758f9588b06a93ac1385))
+
 ## Version 3.23.0, released 2025-03-17
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -397,7 +397,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1",
-      "version": "3.23.0",
+      "version": "3.24.0",
       "type": "grpc",
       "productName": "Vertex AI",
       "productUrl": "https://cloud.google.com/vertex-ai/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add import result gcs sink to the import files API ([commit b313b52](https://github.com/googleapis/google-cloud-dotnet/commit/b313b526fcd2fd8c71aa46904e1bb4ac36a2b351))
- Add import result bq sink to the import files API ([commit b313b52](https://github.com/googleapis/google-cloud-dotnet/commit/b313b526fcd2fd8c71aa46904e1bb4ac36a2b351))
- Add env variables and agent framework to ReasoningEngineSpec ([commit 65eb876](https://github.com/googleapis/google-cloud-dotnet/commit/65eb876885c7d19a7af9758f9588b06a93ac1385))

### Documentation improvements

- Update comment for `package_spec` from required to optional in `ReasoningEngineSpec`. ([commit 65eb876](https://github.com/googleapis/google-cloud-dotnet/commit/65eb876885c7d19a7af9758f9588b06a93ac1385))
- Add `deployment_spec` and `agent_framework` field to `ReasoningEngineSpec`. ([commit 65eb876](https://github.com/googleapis/google-cloud-dotnet/commit/65eb876885c7d19a7af9758f9588b06a93ac1385))
