### PR TITLE
Release Google.Cloud.Dlp.V2 version 4.17.0

### DIFF
--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.csproj
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.16.0</Version>
+    <Version>4.17.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Data Loss Prevention API, which provides methods for detection of privacy-sensitive fragments in text, images, and Google Cloud Platform storage repositories.</Description>

--- a/apis/Google.Cloud.Dlp.V2/docs/history.md
+++ b/apis/Google.Cloud.Dlp.V2/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 4.17.0, released 2025-03-24
+
+### New features
+
+- Add sample findings for data profiles ([commit 12adc9a](https://github.com/googleapis/google-cloud-dotnet/commit/12adc9a057697f098ae8d0dd7469c4db88f84378))
+- List tags on resources for data profiles ([commit 12adc9a](https://github.com/googleapis/google-cloud-dotnet/commit/12adc9a057697f098ae8d0dd7469c4db88f84378))
+
+### Documentation improvements
+
+- Updated documentation for various fields and messages ([commit 12adc9a](https://github.com/googleapis/google-cloud-dotnet/commit/12adc9a057697f098ae8d0dd7469c4db88f84378))
+
 ## Version 4.16.0, released 2025-02-25
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -2263,7 +2263,7 @@
       "protoPath": "google/privacy/dlp/v2",
       "productName": "Google Cloud Data Loss Prevention",
       "productUrl": "https://cloud.google.com/dlp/",
-      "version": "4.16.0",
+      "version": "4.17.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Data Loss Prevention API, which provides methods for detection of privacy-sensitive fragments in text, images, and Google Cloud Platform storage repositories.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

### New features

- Add sample findings for data profiles ([commit 12adc9a](https://github.com/googleapis/google-cloud-dotnet/commit/12adc9a057697f098ae8d0dd7469c4db88f84378))
- List tags on resources for data profiles ([commit 12adc9a](https://github.com/googleapis/google-cloud-dotnet/commit/12adc9a057697f098ae8d0dd7469c4db88f84378))

### Documentation improvements

- Updated documentation for various fields and messages ([commit 12adc9a](https://github.com/googleapis/google-cloud-dotnet/commit/12adc9a057697f098ae8d0dd7469c4db88f84378))
