### PR TITLE
Release Google.Cloud.ManagedKafka.V1 version 1.0.0-beta05

### DIFF
--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.csproj
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta04</Version>
+    <Version>1.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Managed Service for Apache Kafka API, which lets you ingest Kafka streams directly into Google Cloud.</Description>

--- a/apis/Google.Cloud.ManagedKafka.V1/docs/history.md
+++ b/apis/Google.Cloud.ManagedKafka.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta05, released 2025-03-24
+
+### New features
+
+- Add Managed Kafka Connect API ([commit fba13dc](https://github.com/googleapis/google-cloud-dotnet/commit/fba13dc09aa7a6619359550c4b13992f63b0cdc9))
+
 ## Version 1.0.0-beta04, released 2025-03-17
 
 ### Bug fixes

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -3261,7 +3261,7 @@
     },
     {
       "id": "Google.Cloud.ManagedKafka.V1",
-      "version": "1.0.0-beta04",
+      "version": "1.0.0-beta05",
       "type": "grpc",
       "productName": "Managed Service for Apache Kafka API",
       "productUrl": "https://cloud.google.com/managed-kafka",


### PR DESCRIPTION

Changes in this release:

### New features

- Add Managed Kafka Connect API ([commit fba13dc](https://github.com/googleapis/google-cloud-dotnet/commit/fba13dc09aa7a6619359550c4b13992f63b0cdc9))
