### PR TITLE
Release Google.Cloud.NetworkConnectivity.V1 version 2.10.0

### DIFF
--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.csproj
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.9.0</Version>
+    <Version>2.10.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Network Connectivity API, which provides access to Network Connectivity Center.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.3.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />

--- a/apis/Google.Cloud.NetworkConnectivity.V1/docs/history.md
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.10.0, released 2025-03-24
+
+### New features
+
+- Add Network Connectivity Center APIs for PSC service automation ([commit 54430f6](https://github.com/googleapis/google-cloud-dotnet/commit/54430f658a32f62adc8cc08135dbc76f5d5d67d1))
+
+### Documentation improvements
+
+- Update some documentation. ([commit 54430f6](https://github.com/googleapis/google-cloud-dotnet/commit/54430f658a32f62adc8cc08135dbc76f5d5d67d1))
+
 ## Version 2.9.0, released 2024-12-06
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -3533,7 +3533,7 @@
     },
     {
       "id": "Google.Cloud.NetworkConnectivity.V1",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "type": "grpc",
       "productName": "Network Connectivity",
       "productUrl": "https://cloud.google.com/network-connectivity/docs/",
@@ -3544,7 +3544,7 @@
         "vpc"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Iam.V1": "3.4.0",
         "Google.Cloud.Location": "2.3.0",
         "Google.LongRunning": "3.3.0"
       },


### PR DESCRIPTION

Changes in this release:

### New features

- Add Network Connectivity Center APIs for PSC service automation ([commit 54430f6](https://github.com/googleapis/google-cloud-dotnet/commit/54430f658a32f62adc8cc08135dbc76f5d5d67d1))

### Documentation improvements

- Update some documentation. ([commit 54430f6](https://github.com/googleapis/google-cloud-dotnet/commit/54430f658a32f62adc8cc08135dbc76f5d5d67d1))
