### PR TITLE
Release Google.Cloud.Workflows.V1 version 2.6.0

### DIFF
--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.csproj
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Workflows API v1.</Description>
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.3.0, 3.0.0)" />
     <PackageReference Include="Google.Cloud.Workflows.Common.V1" VersionOverride="[2.4.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" VersionOverride="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Workflows.V1/docs/history.md
+++ b/apis/Google.Cloud.Workflows.V1/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+## Version 2.6.0, released 2025-03-24
+
+### New features
+
+- Add ListWorkflowRevisions method ([commit 27ae085](https://github.com/googleapis/google-cloud-dotnet/commit/27ae085a5970d2c82ebe93efb31ddbafceafa382))
+- Add ExecutionHistoryLevel to Workflow ([commit 27ae085](https://github.com/googleapis/google-cloud-dotnet/commit/27ae085a5970d2c82ebe93efb31ddbafceafa382))
+- Add crypto key config to Workflow ([commit 27ae085](https://github.com/googleapis/google-cloud-dotnet/commit/27ae085a5970d2c82ebe93efb31ddbafceafa382))
+- Add tags to Workflow ([commit 27ae085](https://github.com/googleapis/google-cloud-dotnet/commit/27ae085a5970d2c82ebe93efb31ddbafceafa382))
+- Add ExecutionHistoryLevel enum ([commit 27ae085](https://github.com/googleapis/google-cloud-dotnet/commit/27ae085a5970d2c82ebe93efb31ddbafceafa382))
+
+### Documentation improvements
+
+- Update Workflow some standard field docs ([commit 27ae085](https://github.com/googleapis/google-cloud-dotnet/commit/27ae085a5970d2c82ebe93efb31ddbafceafa382))
+
 ## Version 2.5.0, released 2024-05-14
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -5872,7 +5872,7 @@
     },
     {
       "id": "Google.Cloud.Workflows.V1",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "commonResourcesConfig": "tweaks/Google.Cloud.Workflows.Common.V1/CommonResourcesConfig.json",
       "type": "grpc",
       "productName": "Workflows",
@@ -5882,9 +5882,9 @@
         "workflows"
       ],
       "dependencies": {
-        "Google.Cloud.Location": "2.2.0",
+        "Google.Cloud.Location": "2.3.0",
         "Google.Cloud.Workflows.Common.V1": "2.4.0",
-        "Google.LongRunning": "3.2.0"
+        "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/workflows/v1",


### PR DESCRIPTION

Changes in this release:

### New features

- Add ListWorkflowRevisions method ([commit 27ae085](https://github.com/googleapis/google-cloud-dotnet/commit/27ae085a5970d2c82ebe93efb31ddbafceafa382))
- Add ExecutionHistoryLevel to Workflow ([commit 27ae085](https://github.com/googleapis/google-cloud-dotnet/commit/27ae085a5970d2c82ebe93efb31ddbafceafa382))
- Add crypto key config to Workflow ([commit 27ae085](https://github.com/googleapis/google-cloud-dotnet/commit/27ae085a5970d2c82ebe93efb31ddbafceafa382))
- Add tags to Workflow ([commit 27ae085](https://github.com/googleapis/google-cloud-dotnet/commit/27ae085a5970d2c82ebe93efb31ddbafceafa382))
- Add ExecutionHistoryLevel enum ([commit 27ae085](https://github.com/googleapis/google-cloud-dotnet/commit/27ae085a5970d2c82ebe93efb31ddbafceafa382))

### Documentation improvements

- Update Workflow some standard field docs ([commit 27ae085](https://github.com/googleapis/google-cloud-dotnet/commit/27ae085a5970d2c82ebe93efb31ddbafceafa382))
