### PR TITLE
feat(storage): add MoveObject method for HNS-enabled buckets

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/MoveObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/MoveObjectTest.cs
@@ -56,9 +56,8 @@ public class MoveObjectTest
         Assert.NotEqual(actual.TimeStorageClassUpdatedRaw, expected.TimeStorageClassUpdatedRaw);
         if (_fixture.Client.GetBucket(_fixture.HnsBucket).Autoclass != null)
         {
-            if (expected != null)
+            if (_fixture.Client.GetBucket(_fixture.HnsBucket).Autoclass.Enabled == true)
             {
-                Assert.Equal(expected.StorageClass, actual.StorageClass);
                 Assert.Equal(StorageClasses.Standard, expected.StorageClass);
             }
         }
@@ -93,7 +92,7 @@ public class MoveObjectTest
         Assert.DoesNotContain(objects, obj => obj.Name == actual.Name && obj.Generation == actual.Generation);
     }
 
-    // Prevent moving the source object to the destination object using bad preconditions (wrong source generation) set.
+    // Prevent moving the source object to the destination object using bad preconditions (wrong destination generation) set.
     [Fact]
     public async Task PreventMoveObject_With_Wrong_GenerationAsync()
     {

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/MoveObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/MoveObjectTest.cs
@@ -38,12 +38,10 @@ public class MoveObjectTest
     {
         _fixture = fixture;
         _bucket = _fixture.HnsBucket;
-        _name1 = IdGenerator.FromGuid();
-        _name2 = IdGenerator.FromGuid();
-        _contentType1 = "application/octet-stream";
-        _contentType2 = "application/x-replaced";
-        _source1 = GenerateData(100);
-        _source2 = GenerateData(50);
+        _originName = IdGenerator.FromGuid();
+        _destinationName = IdGenerator.FromGuid();
+        _contentType = "application/octet-stream";
+        _data = GenerateData(100);
     }
 
     // Moves an object within a hierarchical namespace enabled bucket.

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/MoveObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/MoveObjectTest.cs
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Apis.Storage.v1.Data;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 using static Google.Cloud.Storage.V1.IntegrationTests.TestHelpers;
@@ -36,7 +34,7 @@ public class MoveObjectTest
         _fixture = fixture;
     }
 
-    // Moves the source object to the destination object within a bucket with hierarchical namespace enabled.
+    // Moves the object within a bucket with hierarchical namespace enabled.
     [Fact]
     public async Task MoveObjectDefaultAsync()
     {

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/MoveObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/MoveObjectTest.cs
@@ -88,14 +88,12 @@ public class MoveObjectTest
     [Fact]
     public async Task MoveObjectAsync_GenerationMissmatch_Fails()
     {
-        var actual = await _fixture.Client.UploadObjectAsync(_bucket, _name1, _contentType1, _source1);
-        await _fixture.Client.UploadObjectAsync(_bucket, _name2, _contentType2, _source2);
-        var exception = Assert.Throws<GoogleApiException>(() => _fixture.Client.MoveObject(_bucket, actual.Name, _name2,
-            new MoveObjectOptions { IfGenerationMatch = 0 }));
+        await _fixture.Client.UploadObjectAsync(_bucket, _originName, _contentType, _data);
+
+        var exception = await Assert.ThrowsAsync<GoogleApiException>(() => _fixture.Client.MoveObjectAsync(
+            _bucket, _originName, _destinationName,
+            new MoveObjectOptions { IfGenerationMatch = 0 }));            
         Assert.Equal(HttpStatusCode.PreconditionFailed, exception.HttpStatusCode);
-        var objects = _fixture.Client.ListObjects(_bucket).ToList();
-        // Assert that the source object is not deleted and destination object is not overwritten.
-        Assert.Contains(objects, obj => obj.Name == actual.Name && obj.Generation == actual.Generation);
     }
 
     // Prevent moving the source object to the destination object using bad preconditions (wrong source metageneration) set.

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/MoveObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/MoveObjectTest.cs
@@ -1,0 +1,47 @@
+// Copyright 2025 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.ClientTesting;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Threading.Tasks;
+using Xunit;
+using static Google.Cloud.Storage.V1.IntegrationTests.TestHelpers;
+using Object = Google.Apis.Storage.v1.Data.Object;
+
+namespace Google.Cloud.Storage.V1.IntegrationTests;
+
+[Collection(nameof(StorageFixture))]
+public class MoveObjectTest
+{
+    private readonly StorageFixture _fixture;
+
+    public MoveObjectTest(StorageFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task MoveObjectAsync()
+    {
+        await _fixture.Client.MoveObjectAsync(
+            _fixture.HnsBucket, _fixture.SmallThenLargeObject,
+            _fixture.LargeObject);
+        using (var stream = new MemoryStream())
+        {
+            await _fixture.Client.DownloadObjectAsync(_fixture.HnsBucket, _fixture.LargeObject, stream);
+            Assert.Equal(_fixture.LargeContent, stream.ToArray());
+        }
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/MoveObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/MoveObjectTest.cs
@@ -34,36 +34,17 @@ public class MoveObjectTest
         _fixture = fixture;
     }
 
-    // Moves the object within a bucket with hierarchical namespace enabled.
+    // Moves an object within a hierarchical namespace enabled bucket.
     [Fact]
-    public async Task MoveObjectDefaultAsync()
+    public async Task MoveObjectAsync()
     {
         var actual = await _fixture.Client.GetObjectAsync(_fixture.HnsBucket, _fixture.SmallThenLargeObject);
         _fixture.Client.UploadObject(_fixture.HnsBucket, LargeNewObject, "text/plain", new MemoryStream(_fixture.LargeContent));
         var expected = await _fixture.Client.MoveObjectAsync(_fixture.HnsBucket, _fixture.SmallThenLargeObject, LargeNewObject);
         using var stream = new MemoryStream();
         await _fixture.Client.DownloadObjectAsync(_fixture.HnsBucket, LargeNewObject, stream);
+        // Assert that the content of the destination object is the same as the source object.
         Assert.Equal(_fixture.LargeContent, stream.ToArray());
-        // Assert that the generation of the destination object is different from the source object indicating a new object at destination is created.
-        Assert.NotEqual(actual.Generation, expected.Generation);
-        // Assert that the id of the destination object is different from the source object indicating a new object at destination is created.
-        Assert.NotEqual(actual.Id, expected.Id);
-        Assert.NotEqual(actual.TimeCreatedRaw, expected.TimeCreatedRaw);
-        Assert.NotEqual(actual.TimeFinalizedRaw, expected.TimeFinalizedRaw);
-        Assert.NotEqual(actual.UpdatedRaw, expected.UpdatedRaw);
-        Assert.NotEqual(actual.TimeStorageClassUpdatedRaw, expected.TimeStorageClassUpdatedRaw);
-        if (_fixture.Client.GetBucket(_fixture.HnsBucket).Autoclass != null)
-        {
-            if (_fixture.Client.GetBucket(_fixture.HnsBucket).Autoclass.Enabled == true)
-            {
-                Assert.Equal(StorageClasses.Standard, expected.StorageClass);
-            }
-        }
-        else
-        {
-            Assert.Equal(expected.StorageClass, actual.StorageClass);
-        }
-
         var objects = _fixture.Client.ListObjects(_fixture.HnsBucket).ToList();
         // Assert that the destination object exists after the move.
         Assert.Contains(objects, obj => obj.Name == expected.Name && obj.Generation == expected.Generation);
@@ -71,7 +52,7 @@ public class MoveObjectTest
         Assert.DoesNotContain(objects, obj => obj.Name == actual.Name && obj.Generation == actual.Generation);
     }
 
-    // Move the object to a folders and subfolders by creating folders and subfolders if necessary.
+    // Move an object to a folders and subfolders by creating folders and subfolders if necessary.
     [Fact]
     public async Task MoveObjectToDirectorySubDirectoryAsync()
     {
@@ -80,10 +61,15 @@ public class MoveObjectTest
         var expected = await _fixture.Client.MoveObjectAsync(_fixture.HnsBucket, _fixture.SmallObject, $"folder/subfolder/" + SmallNewObject);
         using var stream = new MemoryStream();
         await _fixture.Client.DownloadObjectAsync(_fixture.HnsBucket, $"folder/subfolder/" + SmallNewObject, stream);
+        // Assert that the content of the destination object is the same as the source object.
         Assert.Equal(_fixture.SmallContent, stream.ToArray());
         // Assert that the generation of the destination object is different from the source object indicating a new object at destination is created.
         Assert.NotEqual(actual.Generation, expected.Generation);
-        var objects = _fixture.Client.ListObjects(_fixture.HnsBucket).ToList();
+        var options = new ListObjectsOptions
+        {
+            MatchGlob = "folder/subfolder/*.txt"
+        };
+        var objects = _fixture.Client.ListObjects(_fixture.HnsBucket, null, options).ToList();
         // Assert that the destination object exists after the move.
         Assert.Contains(objects, obj => obj.Name == expected.Name && obj.Generation == expected.Generation);
         // Assert that the source object does not exist after the move.
@@ -94,9 +80,8 @@ public class MoveObjectTest
     [Fact]
     public async Task PreventMoveObject_With_Wrong_GenerationAsync()
     {
-        var bucketUploadedObject = _fixture.Client.UploadObject(_fixture.HnsBucket, "file.txt", null, GenerateData(128));
-        var actual = await _fixture.Client.GetObjectAsync(_fixture.HnsBucket, bucketUploadedObject.Name);
-        var exception = Assert.Throws<GoogleApiException>(() => _fixture.Client.MoveObject(_fixture.HnsBucket, bucketUploadedObject.Name, _fixture.SmallObject,
+        var actual = await _fixture.Client.UploadObjectAsync(_fixture.HnsBucket, "file.txt", null, GenerateData(128));
+        var exception = Assert.Throws<GoogleApiException>(() => _fixture.Client.MoveObject(_fixture.HnsBucket, actual.Name, _fixture.SmallObject,
             new MoveObjectOptions { IfGenerationMatch = 0 }));
         Assert.Equal(HttpStatusCode.PreconditionFailed, exception.HttpStatusCode);
         var objects = _fixture.Client.ListObjects(_fixture.HnsBucket).ToList();
@@ -108,9 +93,8 @@ public class MoveObjectTest
     [Fact]
     public async Task PreventMoveObject_With_Wrong_SourceMetaGenerationAsync()
     {
-        var bucketUploadedObject = _fixture.Client.UploadObject(_fixture.HnsBucket, "sourceFile.txt", null, GenerateData(128));
-        var actual = await _fixture.Client.GetObjectAsync(_fixture.HnsBucket, bucketUploadedObject.Name);
-        var exception = Assert.Throws<GoogleApiException>(() => _fixture.Client.MoveObject(_fixture.HnsBucket, bucketUploadedObject.Name, _fixture.SmallObject,
+        var actual = await _fixture.Client.UploadObjectAsync(_fixture.HnsBucket, "sourceFile.txt", null, GenerateData(128));
+        var exception = Assert.Throws<GoogleApiException>(() => _fixture.Client.MoveObject(_fixture.HnsBucket, actual.Name, _fixture.SmallObject,
             new MoveObjectOptions { IfSourceMetagenerationMatch = 0 }));
         Assert.Equal(HttpStatusCode.PreconditionFailed, exception.HttpStatusCode);
         var objects = _fixture.Client.ListObjects(_fixture.HnsBucket).ToList();
@@ -118,20 +102,93 @@ public class MoveObjectTest
         Assert.Contains(objects, obj => obj.Name == actual.Name && obj.Generation == actual.Generation);
     }
 
-    // Move the source object to the destination object using correct preconditions (source metageneration and generation match) set.
+    // Move the source object to the destination object using correct preconditions (source metageneration and source generation match) set.
     [Fact]
     public async Task MoveObject_With_Correct_PreconditionsAsync()
     {
-        var bucketUploadedObject = _fixture.Client.UploadObject(_fixture.HnsBucket, "sourceTestFile.txt", null, GenerateData(128));
-        var actual = await _fixture.Client.GetObjectAsync(_fixture.HnsBucket, bucketUploadedObject.Name);
+        var actual = _fixture.Client.UploadObject(_fixture.HnsBucket, "sourceTestFile.txt", null, GenerateData(128));
         _fixture.Client.UploadObject(_fixture.HnsBucket, SmallThenLargeObject, "text/plain",
             new MemoryStream(_fixture.LargeContent));
-        var expected = _fixture.Client.MoveObject(_fixture.HnsBucket, bucketUploadedObject.Name, SmallThenLargeObject,
+        var expected = await _fixture.Client.MoveObjectAsync(_fixture.HnsBucket, actual.Name, SmallThenLargeObject,
             new MoveObjectOptions { IfSourceMetagenerationMatch = actual.Metageneration, IfSourceGenerationMatch = actual.Generation });
         var objects = _fixture.Client.ListObjects(_fixture.HnsBucket).ToList();
         // Assert that the destination object exists after the move.
         Assert.Contains(objects, obj => obj.Name == expected.Name && obj.Generation == expected.Generation);
         // Assert that the source object does not exist after the move.
         Assert.DoesNotContain(objects, obj => obj.Name == actual.Name && obj.Generation == actual.Generation);
+    }
+
+    [Fact]
+    public async Task MetadataReturned()
+    {
+        var actual = await _fixture.Client.UploadObjectAsync(_fixture.HnsBucket, "sourceMeta.txt", "text/plain", GenerateData(128));
+        var destUploadedObject = await _fixture.Client.UploadObjectAsync(_fixture.HnsBucket, "destMeta.txt", "text/plain",
+            new MemoryStream(_fixture.LargeContent));
+        var expected = _fixture.Client.MoveObject(_fixture.HnsBucket, actual.Name, destUploadedObject.Name);
+
+        // Assert that the generation of the destination object is different from the source object indicating a new object at destination is created.
+        Assert.NotEqual(actual.Generation, expected.Generation);
+        // Assert that the id of the destination object is different from the source object indicating a new object at destination is created.
+        Assert.NotEqual(actual.Id, expected.Id);
+        // Just test the values we expect to be updated and not equal after move operation is performed.
+        Assert.NotEqual(actual.TimeCreatedRaw, expected.TimeCreatedRaw);
+        Assert.NotEqual(actual.TimeFinalizedRaw, expected.TimeFinalizedRaw);
+        Assert.NotEqual(actual.UpdatedRaw, expected.UpdatedRaw);
+        Assert.NotEqual(actual.TimeStorageClassUpdatedRaw, expected.TimeStorageClassUpdatedRaw);
+        // Assert that the storage class of the destination object is set to Standard if Autoclass is enabled otherwise no change in storage class.
+        if (_fixture.Client.GetBucket(_fixture.HnsBucket).Autoclass != null)
+        {
+            if (_fixture.Client.GetBucket(_fixture.HnsBucket).Autoclass.Enabled == true)
+            {
+                Assert.Equal(StorageClasses.Standard, expected.StorageClass);
+            }
+        }
+        else
+        {
+            Assert.Equal(expected.StorageClass, actual.StorageClass);
+        }
+    }
+
+    [Fact]
+    public void MoveObjectFromInvalidBucket()
+    {
+        var exception = Assert.Throws<GoogleApiException>(() => _fixture.Client.MoveObject("!!!", _fixture.LargeObject, _fixture.SmallObject));
+        Assert.Equal(HttpStatusCode.NotFound, exception.HttpStatusCode);
+    }
+
+    [Fact]
+    public void MoveObjectWithInvalidSourceObject()
+    {
+        var exception = Assert.Throws<GoogleApiException>(() => _fixture.Client.MoveObject(_fixture.HnsBucket, "!!!", _fixture.SmallObject));
+        Assert.Equal(HttpStatusCode.NotFound, exception.HttpStatusCode);
+    }
+
+    // The move operation can only be performed for HNS-enabled buckets (can change in the future).
+    [Fact]
+    public void MoveObjectFromNonHnsBucket()
+    {
+        var exception = Assert.Throws<GoogleApiException>(() => _fixture.Client.MoveObject(_fixture.ReadBucket, _fixture.LargeObject, _fixture.SmallObject));
+        Assert.Equal(HttpStatusCode.Conflict, exception.HttpStatusCode);
+    }
+
+    // The move operation can only be performed with different source and destination object id.
+    [Fact]
+    public void MoveObjectWithSameObjectId()
+    {
+        var exception = Assert.Throws<GoogleApiException>(() => _fixture.Client.MoveObject(_fixture.HnsBucket, _fixture.SmallObject, _fixture.SmallObject));
+        Assert.Equal(HttpStatusCode.BadRequest, exception.HttpStatusCode);
+    }
+
+    // Move operation can be performed on live objects only.
+    [Fact]
+    public void MoveObjectWithSoftDeletedObject()
+    {
+        var sourceUploadedObject = _fixture.Client.UploadObject(_fixture.HnsBucket, "sourcelive.txt", "text/plain", GenerateData(128));
+        _fixture.Client.DeleteObject(_fixture.HnsBucket, sourceUploadedObject.Name);
+        var actual = _fixture.Client.GetObject(_fixture.HnsBucket, sourceUploadedObject.Name, new GetObjectOptions { SoftDeletedOnly = true, Generation = sourceUploadedObject.Generation });
+        var destUploadedObject = _fixture.Client.UploadObject(_fixture.HnsBucket, "dest.txt", "text/plain",
+            new MemoryStream(_fixture.LargeContent));
+        var exception = Assert.Throws<GoogleApiException>(() => _fixture.Client.MoveObject(_fixture.HnsBucket, actual.Name, destUploadedObject.Name));
+        Assert.Equal(HttpStatusCode.NotFound, exception.HttpStatusCode);
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/MoveObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/MoveObjectTest.cs
@@ -107,19 +107,21 @@ public class MoveObjectTest
         Assert.Equal(HttpStatusCode.PreconditionFailed, exception.HttpStatusCode);
     }
 
-    // Move the source object to the destination object using correct preconditions (source metageneration and source generation match) set.
     [Fact]
-    public async Task MoveObject_With_Correct_PreconditionsAsync()
+    public async Task MoveObjectAsync_PreconditionsMatch()
     {
-        var actual = await _fixture.Client.UploadObjectAsync(_bucket, _name1, _contentType1, _source1);
-        _fixture.Client.UploadObject(_bucket, _name2, _contentType2, _source2);
-        var expected = await _fixture.Client.MoveObjectAsync(_bucket, actual.Name, _name2,
-            new MoveObjectOptions { IfSourceMetagenerationMatch = actual.Metageneration, IfSourceGenerationMatch = actual.Generation });
-        var objects = _fixture.Client.ListObjects(_bucket).ToList();
-        // Assert that the destination object exists after the move.
-        Assert.Contains(objects, obj => obj.Name == expected.Name && obj.Generation == expected.Generation);
-        // Assert that the source object does not exist after the move.
-        Assert.DoesNotContain(objects, obj => obj.Name == actual.Name && obj.Generation == actual.Generation);
+        var origin = await _fixture.Client.UploadObjectAsync(_bucket, _originName, _contentType, _data);
+
+        await _fixture.Client.MoveObjectAsync(
+            _bucket, _originName, _destinationName,
+            new MoveObjectOptions
+            {
+                IfSourceMetagenerationMatch = origin.Metageneration,
+                IfSourceGenerationMatch = origin.Generation
+            });
+        var objects = _fixture.Client.ListObjects(_bucket);
+
+        Assert.Contains(objects, obj => obj.Name == expected.Name);
     }
 
     [Fact]

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/MoveObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/MoveObjectTest.cs
@@ -27,12 +27,10 @@ public class MoveObjectTest
 {
     private readonly StorageFixture _fixture;
     private readonly string _bucket;
-    private readonly string _name1;
-    private readonly string _name2;
-    private readonly string _contentType1;
-    private readonly string _contentType2;
-    private readonly MemoryStream _source1;
-    private readonly MemoryStream _source2;
+    private readonly string _originName;
+    private readonly string _destinationName;
+    private readonly string _contentType;
+    private readonly MemoryStream _data;
 
     public MoveObjectTest(StorageFixture fixture)
     {
@@ -44,63 +42,38 @@ public class MoveObjectTest
         _data = GenerateData(100);
     }
 
-    // Moves an object within a hierarchical namespace enabled bucket.
     [Fact]
     public async Task MoveObjectAsync()
     {
         await _fixture.Client.UploadObjectAsync(_bucket, _originName, _contentType, _data);
-        
+
         await _fixture.Client.MoveObjectAsync(_bucket, _originName, _destinationName);
-        
-        var objects = _fixture.Client.ListObjects(_bucket);        
+
+        var objects = _fixture.Client.ListObjects(_bucket);
         Assert.DoesNotContain(objects, obj => obj.Name == _originName);
         Assert.Contains(objects, obj => obj.Name == _destinationName);
-        
+
         using var stream = new MemoryStream();
         await _fixture.Client.DownloadObjectAsync(_bucket, _destinationName, stream);
         Assert.Equal(_data.ToArray(), stream.ToArray());
     }
 
-    // Move an object to a folders and subfolders by creating folders and subfolders if necessary.
     [Fact]
-    public async Task MoveObjectToDirectorySubDirectoryAsync()
-    {
-        var actual = await _fixture.Client.UploadObjectAsync(_bucket, _name1, _contentType1, _source1);
-        _fixture.Client.UploadObject(_bucket, _name2, _contentType2, _source2);
-        var expected = await _fixture.Client.MoveObjectAsync(_bucket, _name1, $"folder/subfolder/" + _name2);
-        using var stream = new MemoryStream();
-        await _fixture.Client.DownloadObjectAsync(_bucket, $"folder/subfolder/" + _name2, stream);
-        // Assert that the content of the destination object is the same as the source object.
-        Assert.Equal(_source1.ToArray(), stream.ToArray());
-        // Assert that the generation of the destination object is different from the source object indicating a new object at destination is created.
-        Assert.NotEqual(actual.Generation, expected.Generation);
-        var options = new ListObjectsOptions
-        {
-            MatchGlob = "folder/subfolder/*"
-        };
-        var objects = _fixture.Client.ListObjects(_bucket, null, options).ToList();
-        // Assert that the destination object exists after the move.
-        Assert.Contains(objects, obj => obj.Name == expected.Name && obj.Generation == expected.Generation);
-        // Assert that the source object does not exist after the move.
-        Assert.DoesNotContain(objects, obj => obj.Name == actual.Name && obj.Generation == actual.Generation);
-    }
-
-    [Fact]
-    public async Task MoveObjectAsync_GenerationMissmatch_Fails()
+    public async Task MoveObjectAsync_GenerationMismatch_Fails()
     {
         await _fixture.Client.UploadObjectAsync(_bucket, _originName, _contentType, _data);
 
         var exception = await Assert.ThrowsAsync<GoogleApiException>(() => _fixture.Client.MoveObjectAsync(
             _bucket, _originName, _destinationName,
-            new MoveObjectOptions { IfGenerationMatch = 0 }));            
+            new MoveObjectOptions { IfSourceGenerationMatch = 1 }));
         Assert.Equal(HttpStatusCode.PreconditionFailed, exception.HttpStatusCode);
     }
 
     [Fact]
-    public async Task MoveObjectAsync_MetaGenerationMissmatch_Fails()
+    public async Task MoveObjectAsync_MetaGenerationMismatch_Fails()
     {
         await _fixture.Client.UploadObjectAsync(_bucket, _originName, _contentType, _data);
-        
+
         var exception = await Assert.ThrowsAsync<GoogleApiException>(() => _fixture.Client.MoveObjectAsync(
             _bucket, _originName, _destinationName,
             new MoveObjectOptions { IfSourceMetagenerationMatch = 0 }));
@@ -121,84 +94,6 @@ public class MoveObjectTest
             });
         var objects = _fixture.Client.ListObjects(_bucket);
 
-        Assert.Contains(objects, obj => obj.Name == expected.Name);
-    }
-
-    [Fact]
-    public async Task MetadataReturned()
-    {
-        var actual = await _fixture.Client.UploadObjectAsync(_bucket, _name1, _contentType1, _source1);
-        var uploadedObject = await _fixture.Client.UploadObjectAsync(_bucket, _name2, _contentType2, _source2);
-        var expected = _fixture.Client.MoveObject(_bucket, actual.Name, uploadedObject.Name);
-
-        // Assert that the generation of the destination object is different from the source object indicating a new object at destination is created.
-        Assert.NotEqual(actual.Generation, expected.Generation);
-        // Assert that the id of the destination object is different from the source object indicating a new object at destination is created.
-        Assert.NotEqual(actual.Id, expected.Id);
-        // Just test the values we expect to be updated and not equal after move operation is performed.
-        Assert.NotEqual(actual.TimeCreatedRaw, expected.TimeCreatedRaw);
-        Assert.NotEqual(actual.TimeFinalizedRaw, expected.TimeFinalizedRaw);
-        Assert.NotEqual(actual.UpdatedRaw, expected.UpdatedRaw);
-        Assert.NotEqual(actual.TimeStorageClassUpdatedRaw, expected.TimeStorageClassUpdatedRaw);
-        // Assert that the storage class of the destination object is set to Standard if Autoclass is enabled otherwise no change in storage class.
-        if (_fixture.Client.GetBucket(_bucket).Autoclass != null)
-        {
-            if (_fixture.Client.GetBucket(_bucket).Autoclass.Enabled == true)
-            {
-                Assert.Equal(StorageClasses.Standard, expected.StorageClass);
-            }
-        }
-        else
-        {
-            Assert.Equal(expected.StorageClass, actual.StorageClass);
-        }
-    }
-
-    [Fact]
-    public void MoveObjectFromInvalidBucket()
-    {
-        _fixture.Client.UploadObject(_bucket, _name1, _contentType1, _source1);
-        _fixture.Client.UploadObject(_bucket, _name2, _contentType2, _source2);
-        var exception = Assert.Throws<GoogleApiException>(() => _fixture.Client.MoveObject("!!!", _name1, _name2));
-        Assert.Equal(HttpStatusCode.NotFound, exception.HttpStatusCode);
-    }
-
-    [Fact]
-    public void MoveObjectWithInvalidSourceObject()
-    {
-        _fixture.Client.UploadObject(_bucket, _name1, _contentType1, _source1);
-        var exception = Assert.Throws<GoogleApiException>(() => _fixture.Client.MoveObject(_bucket, "!!!", _name1));
-        Assert.Equal(HttpStatusCode.NotFound, exception.HttpStatusCode);
-    }
-
-    // The move operation can only be performed for HNS-enabled buckets (can change in the future).
-    [Fact]
-    public void MoveObjectFromNonHnsBucket()
-    {
-        _fixture.Client.UploadObject(_bucket, _name1, _contentType1, _source1);
-        _fixture.Client.UploadObject(_bucket, _name2, _contentType2, _source2);
-        var exception = Assert.Throws<GoogleApiException>(() => _fixture.Client.MoveObject(_fixture.ReadBucket, _name1, _name2));
-        Assert.Equal(HttpStatusCode.Conflict, exception.HttpStatusCode);
-    }
-
-    // The move operation can only be performed with different source and destination object id.
-    [Fact]
-    public void MoveObjectWithSameObjectId()
-    {
-        _fixture.Client.UploadObject(_bucket, _name1, _contentType1, _source1);
-        var exception = Assert.Throws<GoogleApiException>(() => _fixture.Client.MoveObject(_bucket, _name1, _name1));
-        Assert.Equal(HttpStatusCode.BadRequest, exception.HttpStatusCode);
-    }
-
-    // Move operation can be performed on live objects only.
-    [Fact]
-    public void MoveObjectWithSoftDeletedObject()
-    {
-        var sourceUploadedObject = _fixture.Client.UploadObject(_bucket, _name1, _contentType1, _source1);
-        _fixture.Client.DeleteObject(_bucket, sourceUploadedObject.Name);
-        var actual = _fixture.Client.GetObject(_bucket, sourceUploadedObject.Name, new GetObjectOptions { SoftDeletedOnly = true, Generation = sourceUploadedObject.Generation });
-        var destinationUploadedObject = _fixture.Client.UploadObject(_bucket, _name2, _contentType2, _source2);
-        var exception = Assert.Throws<GoogleApiException>(() => _fixture.Client.MoveObject(_bucket, actual.Name, destinationUploadedObject.Name));
-        Assert.Equal(HttpStatusCode.NotFound, exception.HttpStatusCode);
+        Assert.Contains(objects, obj => obj.Name == _destinationName);
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/MoveObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/MoveObjectTest.cs
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Cloud.ClientTesting;
 using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
+using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using Xunit;
-using static Google.Cloud.Storage.V1.IntegrationTests.TestHelpers;
-using Object = Google.Apis.Storage.v1.Data.Object;
 
 namespace Google.Cloud.Storage.V1.IntegrationTests;
 
@@ -32,16 +30,57 @@ public class MoveObjectTest
         _fixture = fixture;
     }
 
+    // Moves the source object to the destination object within a bucket with hierarchical namespace enabled.
     [Fact]
     public async Task MoveObjectAsync()
     {
+        var actual = await _fixture.Client.GetObjectAsync(_fixture.HnsBucket, _fixture.SmallThenLargeObject);
         await _fixture.Client.MoveObjectAsync(
             _fixture.HnsBucket, _fixture.SmallThenLargeObject,
             _fixture.LargeObject);
-        using (var stream = new MemoryStream())
-        {
-            await _fixture.Client.DownloadObjectAsync(_fixture.HnsBucket, _fixture.LargeObject, stream);
-            Assert.Equal(_fixture.LargeContent, stream.ToArray());
-        }
+        using var stream = new MemoryStream();
+        var expected = await _fixture.Client.DownloadObjectAsync(_fixture.HnsBucket, _fixture.LargeObject, stream);
+        Assert.Equal(_fixture.LargeContent, stream.ToArray());
+        // Assert that the generation of the destination object is different from the source object indicating a new object at destination is created.
+        Assert.NotEqual(actual.Generation, expected.Generation);
+        var objects = _fixture.Client.ListObjects(_fixture.HnsBucket).ToList();
+        // Assert that the destination object exists after the move.
+        Assert.Contains(objects, obj => obj.Name == expected.Name && obj.Generation == expected.Generation);
+        // Assert that the source object does not exist after the move.
+        Assert.DoesNotContain(objects, obj => obj.Name == actual.Name && obj.Generation == actual.Generation);
+    }
+
+    // Move the object to a folders and subfolders by creating folders and subfolders if necessary.
+    [Fact]
+    public async Task MoveObjectToDirectorySubDirectoryAsync()
+    {
+        var actual = await _fixture.Client.GetObjectAsync(_fixture.HnsBucket, _fixture.SmallObject);
+        await _fixture.Client.MoveObjectAsync(
+            _fixture.HnsBucket, _fixture.SmallObject,
+            $"folder/subfolder/" + _fixture.SmallThenLargeObject);
+        using var stream = new MemoryStream();
+        var expected = await _fixture.Client.DownloadObjectAsync(_fixture.HnsBucket, $"folder/subfolder/" + _fixture.SmallThenLargeObject, stream);
+        Assert.Equal(_fixture.SmallContent, stream.ToArray());
+        // Assert that the generation of the destination object is different from the source object indicating a new object at destination is created.
+        Assert.NotEqual(actual.Generation, expected.Generation);
+        var objects = _fixture.Client.ListObjects(_fixture.HnsBucket).ToList();
+        // Assert that the destination object exists after the move.
+        Assert.Contains(objects, obj => obj.Name == expected.Name && obj.Generation == expected.Generation);
+        // Assert that the source object does not exist after the move.
+        Assert.DoesNotContain(objects, obj => obj.Name == actual.Name && obj.Generation == actual.Generation);
+    }
+
+    // Prevent overwriting of an existing destination object using preconditions.
+    [Fact]
+    public async Task PreventMoveObjectWithPreconditionsAsync()
+    {
+        var actual = await _fixture.Client.GetObjectAsync(_fixture.HnsBucket, _fixture.SmallThenLargeObject);
+        var exception = Assert.Throws<GoogleApiException>(() => _fixture.Client.MoveObject(
+            _fixture.HnsBucket, _fixture.SmallThenLargeObject, "small_then_large.txt",
+            new MoveObjectOptions { IfGenerationMatch = 0 }));
+        Assert.Equal(HttpStatusCode.BadRequest, exception.HttpStatusCode);
+        var objects = _fixture.Client.ListObjects(_fixture.HnsBucket).ToList();
+        // Assert that the source object is not deleted and destination object is not overwritten.
+        Assert.Contains(objects, obj => obj.Name == actual.Name && obj.Generation == actual.Generation);
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/MoveObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/MoveObjectTest.cs
@@ -85,9 +85,8 @@ public class MoveObjectTest
         Assert.DoesNotContain(objects, obj => obj.Name == actual.Name && obj.Generation == actual.Generation);
     }
 
-    // Prevent moving the source object to the destination object using bad preconditions (wrong destination generation) set.
     [Fact]
-    public async Task PreventMoveObject_With_Wrong_GenerationAsync()
+    public async Task MoveObjectAsync_GenerationMissmatch_Fails()
     {
         var actual = await _fixture.Client.UploadObjectAsync(_bucket, _name1, _contentType1, _source1);
         await _fixture.Client.UploadObjectAsync(_bucket, _name2, _contentType2, _source2);

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/MoveObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/MoveObjectTest.cs
@@ -96,17 +96,15 @@ public class MoveObjectTest
         Assert.Equal(HttpStatusCode.PreconditionFailed, exception.HttpStatusCode);
     }
 
-    // Prevent moving the source object to the destination object using bad preconditions (wrong source metageneration) set.
     [Fact]
-    public async Task PreventMoveObject_With_Wrong_SourceMetaGenerationAsync()
+    public async Task MoveObjectAsync_MetaGenerationMissmatch_Fails()
     {
-        var actual = await _fixture.Client.UploadObjectAsync(_bucket, _name1, _contentType1, _source1);
-        var exception = Assert.Throws<GoogleApiException>(() => _fixture.Client.MoveObject(_bucket, actual.Name, _name2,
+        await _fixture.Client.UploadObjectAsync(_bucket, _originName, _contentType, _data);
+        
+        var exception = await Assert.ThrowsAsync<GoogleApiException>(() => _fixture.Client.MoveObjectAsync(
+            _bucket, _originName, _destinationName,
             new MoveObjectOptions { IfSourceMetagenerationMatch = 0 }));
         Assert.Equal(HttpStatusCode.PreconditionFailed, exception.HttpStatusCode);
-        var objects = _fixture.Client.ListObjects(_bucket).ToList();
-        // Assert that the source object is not deleted and destination object is not overwritten.
-        Assert.Contains(objects, obj => obj.Name == actual.Name && obj.Generation == actual.Generation);
     }
 
     // Move the source object to the destination object using correct preconditions (source metageneration and source generation match) set.

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/MoveObjectTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/MoveObjectTest.cs
@@ -48,18 +48,17 @@ public class MoveObjectTest
     [Fact]
     public async Task MoveObjectAsync()
     {
-        var actual = await _fixture.Client.UploadObjectAsync(_bucket, _name1, _contentType1, _source1);
-        _fixture.Client.UploadObject(_bucket, _name2, _contentType2, _source2);
-        var expected = await _fixture.Client.MoveObjectAsync(_bucket, actual.Name, _name2);
+        await _fixture.Client.UploadObjectAsync(_bucket, _originName, _contentType, _data);
+        
+        await _fixture.Client.MoveObjectAsync(_bucket, _originName, _destinationName);
+        
+        var objects = _fixture.Client.ListObjects(_bucket);        
+        Assert.DoesNotContain(objects, obj => obj.Name == _originName);
+        Assert.Contains(objects, obj => obj.Name == _destinationName);
+        
         using var stream = new MemoryStream();
-        await _fixture.Client.DownloadObjectAsync(_bucket, _name2, stream);
-        // Assert that the content of the destination object is the same as the source object.
-        Assert.Equal(_source1.ToArray(), stream.ToArray());
-        var objects = _fixture.Client.ListObjects(_bucket).ToList();
-        // Assert that the destination object exists after the move.
-        Assert.Contains(objects, obj => obj.Name == expected.Name && obj.Generation == expected.Generation);
-        // Assert that the source object does not exist after the move.
-        Assert.DoesNotContain(objects, obj => obj.Name == actual.Name && obj.Generation == actual.Generation);
+        await _fixture.Client.DownloadObjectAsync(_bucket, _destinationName, stream);
+        Assert.Equal(_data.ToArray(), stream.ToArray());
     }
 
     // Move an object to a folders and subfolders by creating folders and subfolders if necessary.

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/StorageFixture.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/StorageFixture.cs
@@ -287,6 +287,11 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
                     HierarchicalNamespace = new Bucket.HierarchicalNamespaceData { Enabled = true }
                 });
             Client.UploadObject(name, SmallThenLargeObject, "text/plain", new MemoryStream(LargeContent));
+            Client.UploadObject(name, SmallObject, "text/plain", new MemoryStream(SmallContent));
+            foreach (var nameoObjectsInFolder in s_objectsInFolders)
+            {
+                Client.UploadObject(name, nameoObjectsInFolder, "text/plain", new MemoryStream(SmallContent));
+            }
 
             SleepAfterBucketCreateDelete();
             RegisterBucketToDelete(name);

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/StorageFixture.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/StorageFixture.cs
@@ -172,6 +172,7 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             CreateBucket(LabelsTestBucket, multiVersion: false);
             CreateBucket(InitiallyEmptyBucket, multiVersion: false);
             CreateBucket(SoftDeleteBucket, multiVersion: false, softDelete: true);
+            CreateAndPopulateHnsBucket(HnsBucket);
 
             RequesterPaysClient = CreateRequesterPaysClient();
             if (RequesterPaysClient != null)

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/StorageFixture.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/StorageFixture.cs
@@ -281,11 +281,11 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
         private void CreateAndPopulateHnsBucket()
         {
             CreateBucket(HnsBucket, multiVersion: false, hnsEnabled: true);
-            Client.UploadObject(name, SmallThenLargeObject, "text/plain", new MemoryStream(LargeContent));
-            Client.UploadObject(name, SmallObject, "text/plain", new MemoryStream(SmallContent));
+            Client.UploadObject(HnsBucket, SmallThenLargeObject, "text/plain", new MemoryStream(LargeContent));
+            Client.UploadObject(HnsBucket, SmallObject, "text/plain", new MemoryStream(SmallContent));
             foreach (var nameoObjectsInFolder in s_objectsInFolders)
             {
-                Client.UploadObject(name, nameoObjectsInFolder, "text/plain", new MemoryStream(SmallContent));
+                Client.UploadObject(HnsBucket, nameoObjectsInFolder, "text/plain", new MemoryStream(SmallContent));
             }
         }
 

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/StorageFixture.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/StorageFixture.cs
@@ -172,7 +172,6 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             CreateBucket(LabelsTestBucket, multiVersion: false);
             CreateBucket(InitiallyEmptyBucket, multiVersion: false);
             CreateBucket(SoftDeleteBucket, multiVersion: false, softDelete: true);
-            CreateAndPopulateHnsBucket(HnsBucket);
 
             RequesterPaysClient = CreateRequesterPaysClient();
             if (RequesterPaysClient != null)

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/StorageFixture.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/StorageFixture.cs
@@ -64,7 +64,7 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
         /// <summary>
         /// Name of a bucket with hierarchical namespace enabled
         /// </summary>
-        public string HnsBucket => BucketPrefix + "hns";
+        public string HnsBucket => BucketPrefix + "-hns";
 
         /// <summary>
         /// A small amount of content. Do not mutate the array.

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/StorageFixture.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.IntegrationTests/StorageFixture.cs
@@ -172,7 +172,7 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
             CreateBucket(LabelsTestBucket, multiVersion: false);
             CreateBucket(InitiallyEmptyBucket, multiVersion: false);
             CreateBucket(SoftDeleteBucket, multiVersion: false, softDelete: true);
-            CreateAndPopulateHnsBucket();
+            CreateBucket(HnsBucket, multiVersion: false, hnsEnabled: true);
 
             RequesterPaysClient = CreateRequesterPaysClient();
             if (RequesterPaysClient != null)
@@ -276,17 +276,6 @@ namespace Google.Cloud.Storage.V1.IntegrationTests
                 RegisterBucketToDelete(name);
             }
             return bucket;
-        }
-
-        private void CreateAndPopulateHnsBucket()
-        {
-            CreateBucket(HnsBucket, multiVersion: false, hnsEnabled: true);
-            Client.UploadObject(HnsBucket, SmallThenLargeObject, "text/plain", new MemoryStream(LargeContent));
-            Client.UploadObject(HnsBucket, SmallObject, "text/plain", new MemoryStream(SmallContent));
-            foreach (var nameoObjectsInFolder in s_objectsInFolders)
-            {
-                Client.UploadObject(HnsBucket, nameoObjectsInFolder, "text/plain", new MemoryStream(SmallContent));
-            }
         }
 
         internal string GenerateBucketName() => IdGenerator.FromGuid(prefix: BucketPrefix, separator: "", maxLength: 63);

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/MoveObjectOptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/MoveObjectOptionsTest.cs
@@ -17,6 +17,7 @@ using Xunit;
 using static Google.Apis.Storage.v1.ObjectsResource;
 
 namespace Google.Cloud.Storage.V1.Tests;
+
 public class MoveObjectOptionsTest
 {
     [Fact]

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/MoveObjectOptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/MoveObjectOptionsTest.cs
@@ -1,0 +1,110 @@
+// Copyright 2025 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Xunit;
+using static Google.Apis.Storage.v1.ObjectsResource;
+
+namespace Google.Cloud.Storage.V1.Tests;
+public class MoveObjectOptionsTest
+{
+    [Fact]
+    public void ModifyRequest_DefaultOptions()
+    {
+        var request = new MoveRequest(null, "sourceBucket", "sourceObject", "destObject");
+        var options = new MoveObjectOptions();
+        options.ModifyRequest(request);
+        Assert.Null(request.IfGenerationMatch);
+        Assert.Null(request.IfGenerationNotMatch);
+        Assert.Null(request.IfMetagenerationMatch);
+        Assert.Null(request.IfMetagenerationNotMatch);
+        Assert.Null(request.IfSourceGenerationMatch);
+        Assert.Null(request.IfSourceGenerationNotMatch);
+        Assert.Null(request.IfSourceMetagenerationMatch);
+        Assert.Null(request.IfSourceMetagenerationNotMatch);
+        Assert.Null(request.UserProject);
+    }
+
+    [Fact]
+    public void ModifyRequest_AllOptions_PositiveMatch()
+    {
+        var request = new MoveRequest(null, "sourceBucket", "sourceObject", "destObject");
+        var options = new MoveObjectOptions
+        {
+            IfGenerationMatch = 1L,
+            IfMetagenerationMatch = 2L,
+            IfSourceGenerationMatch = 3L,
+            IfSourceMetagenerationMatch = 4L,
+            UserProject = "proj"
+        };
+        options.ModifyRequest(request);
+        Assert.Equal(1L, request.IfGenerationMatch);
+        Assert.Null(request.IfGenerationNotMatch);
+        Assert.Equal(2L, request.IfMetagenerationMatch);
+        Assert.Null(request.IfMetagenerationNotMatch);
+        Assert.Equal(3L, request.IfSourceGenerationMatch);
+        Assert.Null(request.IfSourceGenerationNotMatch);
+        Assert.Equal(4L, request.IfSourceMetagenerationMatch);
+        Assert.Null(request.IfSourceMetagenerationNotMatch);
+        Assert.Equal("proj", request.UserProject);
+    }
+
+    [Fact]
+    public void ModifyRequest_AllOptions_NegativeMatch()
+    {
+        var request = new MoveRequest(null, "sourceBucket", "sourceObject", "destObject");
+        var options = new MoveObjectOptions
+        {
+            IfGenerationNotMatch = 1L,
+            IfMetagenerationNotMatch = 2L,
+            IfSourceGenerationNotMatch = 3L,
+            IfSourceMetagenerationNotMatch = 4L,
+        };
+        options.ModifyRequest(request);
+        Assert.Null(request.IfGenerationMatch);
+        Assert.Equal(1L, request.IfGenerationNotMatch);
+        Assert.Null(request.IfMetagenerationMatch);
+        Assert.Equal(2L, request.IfMetagenerationNotMatch);
+        Assert.Null(request.IfSourceGenerationMatch);
+        Assert.Equal(3L, request.IfSourceGenerationNotMatch);
+        Assert.Null(request.IfSourceMetagenerationMatch);
+        Assert.Equal(4L, request.IfSourceMetagenerationNotMatch);
+    }
+
+    [Fact]
+    public void ModifyRequest_MatchNotMatchConflicts()
+    {
+        var request = new MoveRequest(null, "sourceBucket", "sourceObject", "destObject");
+        Assert.Throws<ArgumentException>(() =>
+        {
+            var options = new MoveObjectOptions { IfGenerationMatch = 1L, IfGenerationNotMatch = 2L };
+            options.ModifyRequest(request);
+        });
+        Assert.Throws<ArgumentException>(() =>
+        {
+            var options = new MoveObjectOptions { IfMetagenerationMatch = 1L, IfMetagenerationNotMatch = 2L };
+            options.ModifyRequest(request);
+        });
+        Assert.Throws<ArgumentException>(() =>
+        {
+            var options = new MoveObjectOptions { IfSourceGenerationMatch = 1L, IfSourceGenerationNotMatch = 2L };
+            options.ModifyRequest(request);
+        });
+        Assert.Throws<ArgumentException>(() =>
+        {
+            var options = new MoveObjectOptions { IfSourceMetagenerationMatch = 1L, IfSourceMetagenerationNotMatch = 2L };
+            options.ModifyRequest(request);
+        });
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Rest" />
-    <PackageReference Include="Google.Apis.Storage.v1" VersionOverride="[1.68.0.3604, 2.0.0.0)" />
+    <PackageReference Include="Google.Apis.Storage.v1" VersionOverride="[1.69.0.3707, 2.0.0.0)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="StorageClient.*.cs">

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/MoveObjectOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/MoveObjectOptions.cs
@@ -1,0 +1,162 @@
+// Copyright 2025 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using static Google.Apis.Storage.v1.ObjectsResource;
+using Object = Google.Apis.Storage.v1.Data.Object;
+
+namespace Google.Cloud.Storage.V1;
+
+/// <summary>
+/// Options for <c>MoveObject</c> operations.
+/// </summary>
+public sealed class MoveObjectOptions
+{
+
+    /// <summary>
+    /// Precondition for moving: the object is only moved if the existing destination object's
+    /// generation matches the given value.
+    /// </summary>
+    public long? IfGenerationMatch { get; set; }
+
+    /// <summary>
+    /// Precondition for moving: the object is only moved if the existing destination object's
+    /// generation does not match the given value.
+    /// </summary>
+    public long? IfGenerationNotMatch { get; set; }
+
+    /// <summary>
+    /// Precondition for moving: the object is only moved if the existing destination object's
+    /// meta-generation matches the given value.
+    /// </summary>
+    public long? IfMetagenerationMatch { get; set; }
+
+    /// <summary>
+    /// Precondition for moving: the object is only moved if the existing destination object's
+    /// meta-generation does not match the given value.
+    /// </summary>
+    public long? IfMetagenerationNotMatch { get; set; }
+
+    /// <summary>
+    /// Precondition for moving: the object is only moved if the source object's
+    /// generation matches the given value.
+    /// </summary>
+    public long? IfSourceGenerationMatch { get; set; }
+
+    /// <summary>
+    /// Precondition for moving: the object is only moved if the source object's
+    /// generation does not match the given value.
+    /// </summary>
+    public long? IfSourceGenerationNotMatch { get; set; }
+
+    /// <summary>
+    /// Precondition for moving: the object is only moved if the source object's
+    /// meta-generation matches the given value.
+    /// </summary>
+    public long? IfSourceMetagenerationMatch { get; set; }
+
+    /// <summary>
+    /// Precondition for moving: the object is only moved if the source object's
+    /// meta-generation does not match the given value.
+    /// </summary>
+    public long? IfSourceMetagenerationNotMatch { get; set; }
+
+    /// <summary>
+    /// Additional object metadata for the new object. This can be used to specify the storage
+    /// class of the new object, the content type etc. If this property is not set, the existing
+    /// object metadata will be used unchanged.
+    /// </summary>
+    public Object ExtraMetadata { get; set; }
+
+    /// <summary>
+    /// The encryption key to use for this operation. If this property is null, the <see cref="StorageClient.EncryptionKey"/>
+    /// will be used instead. Use <see cref="EncryptionKey.None"/> to remove encryption headers from this request.
+    /// </summary>
+    public EncryptionKey EncryptionKey { get; set; }
+
+    /// <summary>
+    /// The encryption key to use for the source of the copy. If this property is null, the <see cref="StorageClient.EncryptionKey"/>
+    /// will be used instead. Use <see cref="EncryptionKey.None"/> if the source is not encrypted.
+    /// </summary>
+    public EncryptionKey SourceEncryptionKey { get; set; }
+
+    /// <summary>
+    /// If set, this is the ID of the project which will be billed for the request.
+    /// The caller must have suitable permissions for the project being billed.
+    /// </summary>
+    public string UserProject { get; set; }
+
+    /// <summary>
+    /// Options to pass custom retry configuration for each API request.
+    /// </summary>
+    public RetryOptions RetryOptions { get; set; }
+
+    internal void ModifyRequest(MoveRequest request)
+    {
+        // Note the use of ArgumentException here, as this will basically be the result of invalid
+        // options being passed to a public method.
+        if (IfGenerationMatch != null && IfGenerationNotMatch != null)
+        {
+            throw new ArgumentException($"Cannot specify {nameof(IfGenerationMatch)} and {nameof(IfGenerationNotMatch)} in the same options", "options");
+        }
+        if (IfMetagenerationMatch != null && IfMetagenerationNotMatch != null)
+        {
+            throw new ArgumentException($"Cannot specify {nameof(IfMetagenerationMatch)} and {nameof(IfMetagenerationNotMatch)} in the same options", "options");
+        }
+        if (IfSourceGenerationMatch != null && IfSourceGenerationNotMatch != null)
+        {
+            throw new ArgumentException($"Cannot specify {nameof(IfSourceGenerationMatch)} and {nameof(IfSourceGenerationNotMatch)} in the same options", "options");
+        }
+        if (IfSourceMetagenerationMatch != null && IfSourceMetagenerationNotMatch != null)
+        {
+            throw new ArgumentException($"Cannot specify {nameof(IfSourceMetagenerationMatch)} and {nameof(IfSourceMetagenerationNotMatch)} in the same options", "options");
+        }
+        if (IfGenerationMatch != null)
+        {
+            request.IfGenerationMatch = IfGenerationMatch;
+        }
+        if (IfGenerationNotMatch != null)
+        {
+            request.IfGenerationNotMatch = IfGenerationNotMatch;
+        }
+        if (IfMetagenerationMatch != null)
+        {
+            request.IfMetagenerationMatch = IfMetagenerationMatch;
+        }
+        if (IfMetagenerationNotMatch != null)
+        {
+            request.IfMetagenerationNotMatch = IfMetagenerationNotMatch;
+        }
+        if (IfSourceGenerationMatch != null)
+        {
+            request.IfSourceGenerationMatch = IfSourceGenerationMatch;
+        }
+        if (IfSourceGenerationNotMatch != null)
+        {
+            request.IfSourceGenerationNotMatch = IfSourceGenerationNotMatch;
+        }
+        if (IfSourceMetagenerationMatch != null)
+        {
+            request.IfSourceMetagenerationMatch = IfSourceMetagenerationMatch;
+        }
+        if (IfSourceMetagenerationNotMatch != null)
+        {
+            request.IfSourceMetagenerationNotMatch = IfSourceMetagenerationNotMatch;
+        }
+        if (UserProject != null)
+        {
+            request.UserProject = UserProject;
+        }
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/MoveObjectOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/MoveObjectOptions.cs
@@ -72,13 +72,6 @@ public sealed class MoveObjectOptions
     public long? IfSourceMetagenerationNotMatch { get; set; }
 
     /// <summary>
-    /// Additional object metadata for the new object. This can be used to specify the storage
-    /// class of the new object, the content type etc. If this property is not set, the existing
-    /// object metadata will be used unchanged.
-    /// </summary>
-    public Object ExtraMetadata { get; set; }
-
-    /// <summary>
     /// If set, this is the ID of the project which will be billed for the request.
     /// The caller must have suitable permissions for the project being billed.
     /// </summary>

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/MoveObjectOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/MoveObjectOptions.cs
@@ -23,7 +23,6 @@ namespace Google.Cloud.Storage.V1;
 /// </summary>
 public sealed class MoveObjectOptions
 {
-
     /// <summary>
     /// Precondition for moving: the object is only moved if the existing destination object's
     /// generation matches the given value.
@@ -78,18 +77,6 @@ public sealed class MoveObjectOptions
     /// object metadata will be used unchanged.
     /// </summary>
     public Object ExtraMetadata { get; set; }
-
-    /// <summary>
-    /// The encryption key to use for this operation. If this property is null, the <see cref="StorageClient.EncryptionKey"/>
-    /// will be used instead. Use <see cref="EncryptionKey.None"/> to remove encryption headers from this request.
-    /// </summary>
-    public EncryptionKey EncryptionKey { get; set; }
-
-    /// <summary>
-    /// The encryption key to use for the source of the copy. If this property is null, the <see cref="StorageClient.EncryptionKey"/>
-    /// will be used instead. Use <see cref="EncryptionKey.None"/> if the source is not encrypted.
-    /// </summary>
-    public EncryptionKey SourceEncryptionKey { get; set; }
 
     /// <summary>
     /// If set, this is the ID of the project which will be billed for the request.

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.MoveObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.MoveObject.cs
@@ -1,0 +1,63 @@
+// Copyright 2025 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Object = Google.Apis.Storage.v1.Data.Object;
+
+namespace Google.Cloud.Storage.V1;
+public abstract partial class StorageClient
+{
+    /// <summary>
+    /// Moves an object within a bucket with hierarchical namespace enabled. This method uses the
+    /// <c>moveObject</c> underlying API operation for more flexibility and reliability.
+    /// </summary>
+    /// <param name="sourceBucket">Name of the bucket containing the object you want to move. Must not be null.</param>
+    /// <param name="sourceObjectName">The name of the source object to move within the bucket. Must not be null.</param>
+    /// <param name="destinationObjectName">The name of the new object to move within the bucket. Must not be null.</param>
+    /// <param name="options">Additional options for the move operation. May be null, in which case appropriate
+    /// defaults will be used.</param>
+    /// <returns>The <see cref="Object"/> representation of the new storage object resulting from the move.</returns>
+    public virtual Object MoveObject(
+        string sourceBucket,
+        string sourceObjectName,
+        string destinationObjectName,
+        MoveObjectOptions options = null)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Moves an object within a bucket with hierarchical namespace enabled. This method uses the
+    /// <c>moveObject</c> underlying API operation for more flexibility and reliability.
+    /// </summary>
+    /// <param name="sourceBucket">Name of the bucket containing the object you want to move. Must not be null.</param>
+    /// <param name="sourceObjectName">The name of the source object to move within the bucket. Must not be null.</param>
+    /// <param name="destinationObjectName">The name of the new object to move within the bucket. Must not be null.</param>
+    /// <param name="options">Additional options for the copy operation. May be null, in which case appropriate
+    /// defaults will be used.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>A task representing the asynchronous operation, with a result returning the
+    /// <see cref="Object"/> representation of the new storage object resulting from the move.</returns>
+    public virtual Task<Object> MoveObjectAsync(
+        string sourceBucket,
+        string sourceObjectName,
+        string destinationObjectName = null,
+        MoveObjectOptions options = null,
+        CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.MoveObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.MoveObject.cs
@@ -44,7 +44,7 @@ public abstract partial class StorageClient
     /// Moves an object within a bucket with hierarchical namespace enabled. This method uses the
     /// <c>moveObject</c> underlying API operation for more flexibility and reliability.
     /// </summary>
-    /// <param name="sourceBucket">Name of the bucket containing the object you want to move. Must not be null.</param>
+    /// <param name="sourceBucket">Name of the bucket containing the object to move. Must not be null.</param>
     /// <param name="sourceObjectName">The name of the source object to move within the bucket. Must not be null.</param>
     /// <param name="destinationObjectName">The name of the new object to move within the bucket. Must not be null.</param>
     /// <param name="options">Additional options for the move operation. May be null, in which case appropriate

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.MoveObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.MoveObject.cs
@@ -25,7 +25,7 @@ public abstract partial class StorageClient
     /// Moves an object within a bucket with hierarchical namespace enabled. This method uses the
     /// <c>moveObject</c> underlying API operation for more flexibility and reliability.
     /// </summary>
-    /// <param name="sourceBucket">Name of the bucket containing the object you want to move. Must not be null.</param>
+    /// <param name="sourceBucket">Name of the bucket containing the object to move. Must not be null.</param>
     /// <param name="sourceObjectName">The name of the source object to move within the bucket. Must not be null.</param>
     /// <param name="destinationObjectName">The name of the new object to move to within the bucket. Must not be null.</param>
     /// <param name="options">Additional options for the move operation. May be null, in which case appropriate

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.MoveObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.MoveObject.cs
@@ -46,7 +46,7 @@ public abstract partial class StorageClient
     /// </summary>
     /// <param name="sourceBucket">Name of the bucket containing the object to move. Must not be null.</param>
     /// <param name="sourceObjectName">The name of the source object to move within the bucket. Must not be null.</param>
-    /// <param name="destinationObjectName">The name of the new object to move within the bucket. Must not be null.</param>
+    /// <param name="destinationObjectName">The name of the new object to move to within the bucket. Must not be null.</param>
     /// <param name="options">Additional options for the move operation. May be null, in which case appropriate
     /// defaults will be used.</param>
     /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.MoveObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.MoveObject.cs
@@ -27,7 +27,7 @@ public abstract partial class StorageClient
     /// </summary>
     /// <param name="sourceBucket">Name of the bucket containing the object you want to move. Must not be null.</param>
     /// <param name="sourceObjectName">The name of the source object to move within the bucket. Must not be null.</param>
-    /// <param name="destinationObjectName">The name of the new object to move within the bucket. Must not be null.</param>
+    /// <param name="destinationObjectName">The name of the new object to move to within the bucket. Must not be null.</param>
     /// <param name="options">Additional options for the move operation. May be null, in which case appropriate
     /// defaults will be used.</param>
     /// <returns>The <see cref="Object"/> representation of the new storage object resulting from the move.</returns>

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.MoveObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.MoveObject.cs
@@ -47,7 +47,7 @@ public abstract partial class StorageClient
     /// <param name="sourceBucket">Name of the bucket containing the object you want to move. Must not be null.</param>
     /// <param name="sourceObjectName">The name of the source object to move within the bucket. Must not be null.</param>
     /// <param name="destinationObjectName">The name of the new object to move within the bucket. Must not be null.</param>
-    /// <param name="options">Additional options for the copy operation. May be null, in which case appropriate
+    /// <param name="options">Additional options for the move operation. May be null, in which case appropriate
     /// defaults will be used.</param>
     /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
     /// <returns>A task representing the asynchronous operation, with a result returning the

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.MoveObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.MoveObject.cs
@@ -18,6 +18,7 @@ using System.Threading.Tasks;
 using Object = Google.Apis.Storage.v1.Data.Object;
 
 namespace Google.Cloud.Storage.V1;
+
 public abstract partial class StorageClient
 {
     /// <summary>

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.MoveObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClient.MoveObject.cs
@@ -55,7 +55,7 @@ public abstract partial class StorageClient
     public virtual Task<Object> MoveObjectAsync(
         string sourceBucket,
         string sourceObjectName,
-        string destinationObjectName = null,
+        string destinationObjectName,
         MoveObjectOptions options = null,
         CancellationToken cancellationToken = default)
     {

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.MoveObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.MoveObject.cs
@@ -61,7 +61,6 @@ public sealed partial class StorageClientImpl : StorageClient
         options?.ModifyRequest(request);
         RetryOptions retryOptions = options?.RetryOptions ?? RetryOptions.MaybeIdempotent(options?.IfGenerationMatch);
         MarkAsRetriable(request, retryOptions);
-        request.ModifyRequest += (options?.SourceEncryptionKey ?? EncryptionKey).ModifyRequest;
         return request;
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.MoveObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.MoveObject.cs
@@ -56,7 +56,6 @@ public sealed partial class StorageClientImpl : StorageClient
         GaxPreconditions.CheckNotNull(sourceBucket, nameof(sourceBucket));
         GaxPreconditions.CheckNotNull(sourceObjectName, nameof(sourceObjectName));
         GaxPreconditions.CheckNotNull(destinationObjectName, nameof(destinationObjectName));
-        Object obj = options?.ExtraMetadata ?? new Object();
         var request = Service.Objects.Move(sourceBucket, sourceObjectName, destinationObjectName);
         options?.ModifyRequest(request);
         RetryOptions retryOptions = options?.RetryOptions ?? RetryOptions.MaybeIdempotent(options?.IfGenerationMatch);

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.MoveObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.MoveObject.cs
@@ -1,0 +1,66 @@
+// Copyright 2025 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Apis.Storage.v1;
+using System.Threading;
+using System.Threading.Tasks;
+using Object = Google.Apis.Storage.v1.Data.Object;
+
+namespace Google.Cloud.Storage.V1;
+public sealed partial class StorageClientImpl : StorageClient
+{
+    /// <inheritdoc />
+    public override Object MoveObject(
+        string sourceBucket,
+        string sourceObjectName,
+        string destinationObjectName,
+        MoveObjectOptions options = null)
+    {
+        var request = CreateMoveObjectRequest(sourceBucket, sourceObjectName, destinationObjectName, options);
+        var response =  request.Execute();
+        return response;
+    }
+
+    /// <inheritdoc />
+    public override async Task<Object> MoveObjectAsync(
+        string sourceBucket,
+        string sourceObjectName,
+        string destinationObjectName,
+        MoveObjectOptions options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var request = CreateMoveObjectRequest(sourceBucket, sourceObjectName, destinationObjectName, options);
+        var response = await request.ExecuteAsync(cancellationToken).ConfigureAwait(false);
+        return response;
+    }
+
+    private ObjectsResource.MoveRequest CreateMoveObjectRequest(
+        string sourceBucket,
+        string sourceObjectName,
+        string destinationObjectName,
+        MoveObjectOptions options)
+    {
+        GaxPreconditions.CheckNotNull(sourceBucket, nameof(sourceBucket));
+        GaxPreconditions.CheckNotNull(sourceObjectName, nameof(sourceObjectName));
+        GaxPreconditions.CheckNotNull(destinationObjectName, nameof(destinationObjectName));
+        Object obj = options?.ExtraMetadata ?? new Object();
+        var request = Service.Objects.Move(sourceBucket, sourceObjectName, destinationObjectName);
+        options?.ModifyRequest(request);
+        RetryOptions retryOptions = options?.RetryOptions ?? RetryOptions.MaybeIdempotent(options?.IfGenerationMatch);
+        MarkAsRetriable(request, retryOptions);
+        request.ModifyRequest += (options?.SourceEncryptionKey ?? EncryptionKey).ModifyRequest;
+        return request;
+    }
+}

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.MoveObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.MoveObject.cs
@@ -29,7 +29,7 @@ public sealed partial class StorageClientImpl : StorageClient
         MoveObjectOptions options = null)
     {
         var request = CreateMoveObjectRequest(sourceBucket, sourceObjectName, destinationObjectName, options);
-        var response =  request.Execute();
+        var response = request.Execute();
         return response;
     }
 

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.MoveObject.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/StorageClientImpl.MoveObject.cs
@@ -19,6 +19,7 @@ using System.Threading.Tasks;
 using Object = Google.Apis.Storage.v1.Data.Object;
 
 namespace Google.Cloud.Storage.V1;
+
 public sealed partial class StorageClientImpl : StorageClient
 {
     /// <inheritdoc />

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -5249,7 +5249,7 @@
       "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
       "dependencies": {
         "Google.Api.Gax.Rest": "default",
-        "Google.Apis.Storage.v1": "1.68.0.3604"
+        "Google.Apis.Storage.v1": "1.69.0.3707"
       },
       "testDependencies": {
         "Google.Api.Gax.Testing": "default",


### PR DESCRIPTION
Moves an object within a bucket with hierarchical namespace enabled. This method uses the moveObject underlying API operation for more flexibility and reliability.