### PR TITLE
Release Google.Cloud.AIPlatform.V1 version 3.25.0

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.24.0</Version>
+    <Version>3.25.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Vertex AI API (v1), which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1/docs/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## Version 3.25.0, released 2025-03-31
+
+### New features
+
+- Add page spans in retrieved contexts from Vertex RAG Engine in aiplatform v1 ([commit a14589e](https://github.com/googleapis/google-cloud-dotnet/commit/a14589e0d698d55b0ec3ce487077315b92acf961))
+- Add support for Vertex AI Search engine ([commit 27dd031](https://github.com/googleapis/google-cloud-dotnet/commit/27dd031f9239a8318f57be843f8838c354f275a5))
+- Enable force deletion in ReasoningEngine ([commit e0d55af](https://github.com/googleapis/google-cloud-dotnet/commit/e0d55af4c335ee74cd667b67cc5671cd7d793302))
+
 ## Version 3.24.0, released 2025-03-24
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -397,7 +397,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1",
-      "version": "3.24.0",
+      "version": "3.25.0",
       "type": "grpc",
       "productName": "Vertex AI",
       "productUrl": "https://cloud.google.com/vertex-ai/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add page spans in retrieved contexts from Vertex RAG Engine in aiplatform v1 ([commit a14589e](https://github.com/googleapis/google-cloud-dotnet/commit/a14589e0d698d55b0ec3ce487077315b92acf961))
- Add support for Vertex AI Search engine ([commit 27dd031](https://github.com/googleapis/google-cloud-dotnet/commit/27dd031f9239a8318f57be843f8838c354f275a5))
- Enable force deletion in ReasoningEngine ([commit e0d55af](https://github.com/googleapis/google-cloud-dotnet/commit/e0d55af4c335ee74cd667b67cc5671cd7d793302))
