### PR TITLE
Release Google.Cloud.AppHub.V1 version 1.1.0

### DIFF
--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.csproj
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the App Hub API, which simplifies the process of building, running, and managing applications on Google Cloud.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.3.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />

--- a/apis/Google.Cloud.AppHub.V1/docs/history.md
+++ b/apis/Google.Cloud.AppHub.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.1.0, released 2025-03-31
+
+### New features
+
+- Add enum `Type.GLOBAL` ([commit 56e4ccf](https://github.com/googleapis/google-cloud-dotnet/commit/56e4ccf059df7c79f254c454d26bcd8d5d37ffcd))
+
+### Documentation improvements
+
+- Misc comment updates, formatting ([commit 56e4ccf](https://github.com/googleapis/google-cloud-dotnet/commit/56e4ccf059df7c79f254c454d26bcd8d5d37ffcd))
+
 ## Version 1.0.0, released 2024-12-05
 
 No API surface changes; just dependency updates and promotion to GA.

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -558,7 +558,7 @@
     },
     {
       "id": "Google.Cloud.AppHub.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "App Hub",
       "productUrl": "https://cloud.google.com/app-hub/docs/overview",
@@ -568,7 +568,7 @@
         "management"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Iam.V1": "3.4.0",
         "Google.Cloud.Location": "2.3.0",
         "Google.LongRunning": "3.3.0"
       },


### PR DESCRIPTION

Changes in this release:

### New features

- Add enum `Type.GLOBAL` ([commit 56e4ccf](https://github.com/googleapis/google-cloud-dotnet/commit/56e4ccf059df7c79f254c454d26bcd8d5d37ffcd))

### Documentation improvements

- Misc comment updates, formatting ([commit 56e4ccf](https://github.com/googleapis/google-cloud-dotnet/commit/56e4ccf059df7c79f254c454d26bcd8d5d37ffcd))
