### PR TITLE
Release Google.Cloud.BigQuery.AnalyticsHub.V1 version 1.8.0

### DIFF
--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.7.0</Version>
+    <Version>1.8.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Analytics Hub, which allows users to exchange data and analytics assets securely and efficiently.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.8.0, released 2025-03-31
+
+### New features
+
+- Support new feature Sharing Cloud Pubsub Streams via AH (GA) and Subscriber Email logging feature ([commit 9ea4972](https://github.com/googleapis/google-cloud-dotnet/commit/9ea4972f40a5e91bd602204c0afacbab980baef4))
+
 ## Version 1.7.0, released 2024-07-08
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -923,7 +923,7 @@
     },
     {
       "id": "Google.Cloud.BigQuery.AnalyticsHub.V1",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "type": "grpc",
       "productName": "Analytics Hub",
       "productUrl": "https://cloud.google.com/analytics-hub",
@@ -933,7 +933,7 @@
         "analytics"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Iam.V1": "3.4.0",
         "Google.LongRunning": "3.3.0"
       },
       "generator": "micro",


### PR DESCRIPTION

Changes in this release:

### New features

- Support new feature Sharing Cloud Pubsub Streams via AH (GA) and Subscriber Email logging feature ([commit 9ea4972](https://github.com/googleapis/google-cloud-dotnet/commit/9ea4972f40a5e91bd602204c0afacbab980baef4))
