### PR TITLE
Release Google.Cloud.Datastream.V1 version 2.10.0

### DIFF
--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.csproj
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.9.0</Version>
+    <Version>2.10.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Datastream API (v1), which allows you to synchronize data across heterogeneous databases and applications reliably, and with minimal latency and downtime.</Description>

--- a/apis/Google.Cloud.Datastream.V1/docs/history.md
+++ b/apis/Google.Cloud.Datastream.V1/docs/history.md
@@ -1,5 +1,22 @@
 # Version history
 
+## Version 2.10.0, released 2025-03-31
+
+### New features
+
+- A new field `secret_manager_stored_password` is added to multiple messages ([commit 448570d](https://github.com/googleapis/google-cloud-dotnet/commit/448570daf7dc678a89cfdd889c0db001deba2dfd))
+- A new messages related to `SalesforceProfile` are added ([commit 448570d](https://github.com/googleapis/google-cloud-dotnet/commit/448570daf7dc678a89cfdd889c0db001deba2dfd))
+- A new message `BlmtConfig` is added ([commit 448570d](https://github.com/googleapis/google-cloud-dotnet/commit/448570daf7dc678a89cfdd889c0db001deba2dfd))
+- A new field `blmt_config` is added to message `.google.cloud.datastream.v1.BigQueryDestinationConfig` ([commit 448570d](https://github.com/googleapis/google-cloud-dotnet/commit/448570daf7dc678a89cfdd889c0db001deba2dfd))
+- A new field `satisfies_pzs` is added to multiple messages. ([commit 448570d](https://github.com/googleapis/google-cloud-dotnet/commit/448570daf7dc678a89cfdd889c0db001deba2dfd))
+- A new field `satisfies_pzi` is added to multiple messages. ([commit 448570d](https://github.com/googleapis/google-cloud-dotnet/commit/448570daf7dc678a89cfdd889c0db001deba2dfd))
+- A new message `MysqlGtidPosition` is added ([commit 448570d](https://github.com/googleapis/google-cloud-dotnet/commit/448570daf7dc678a89cfdd889c0db001deba2dfd))
+- A new field `mysql_gtid_position` is added to message `.google.cloud.datastream.v1.CdcStrategy` ([commit 448570d](https://github.com/googleapis/google-cloud-dotnet/commit/448570daf7dc678a89cfdd889c0db001deba2dfd))
+
+### Documentation improvements
+
+- Documentation improvements and changes for multiple fields ([commit 448570d](https://github.com/googleapis/google-cloud-dotnet/commit/448570daf7dc678a89cfdd889c0db001deba2dfd))
+
 ## Version 2.9.0, released 2025-01-27
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -1943,7 +1943,7 @@
     },
     {
       "id": "Google.Cloud.Datastream.V1",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "type": "grpc",
       "productName": "DataStream",
       "productUrl": "https://cloud.google.com/datastream/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- A new field `secret_manager_stored_password` is added to multiple messages ([commit 448570d](https://github.com/googleapis/google-cloud-dotnet/commit/448570daf7dc678a89cfdd889c0db001deba2dfd))
- A new messages related to `SalesforceProfile` are added ([commit 448570d](https://github.com/googleapis/google-cloud-dotnet/commit/448570daf7dc678a89cfdd889c0db001deba2dfd))
- A new message `BlmtConfig` is added ([commit 448570d](https://github.com/googleapis/google-cloud-dotnet/commit/448570daf7dc678a89cfdd889c0db001deba2dfd))
- A new field `blmt_config` is added to message `.google.cloud.datastream.v1.BigQueryDestinationConfig` ([commit 448570d](https://github.com/googleapis/google-cloud-dotnet/commit/448570daf7dc678a89cfdd889c0db001deba2dfd))
- A new field `satisfies_pzs` is added to multiple messages. ([commit 448570d](https://github.com/googleapis/google-cloud-dotnet/commit/448570daf7dc678a89cfdd889c0db001deba2dfd))
- A new field `satisfies_pzi` is added to multiple messages. ([commit 448570d](https://github.com/googleapis/google-cloud-dotnet/commit/448570daf7dc678a89cfdd889c0db001deba2dfd))
- A new message `MysqlGtidPosition` is added ([commit 448570d](https://github.com/googleapis/google-cloud-dotnet/commit/448570daf7dc678a89cfdd889c0db001deba2dfd))
- A new field `mysql_gtid_position` is added to message `.google.cloud.datastream.v1.CdcStrategy` ([commit 448570d](https://github.com/googleapis/google-cloud-dotnet/commit/448570daf7dc678a89cfdd889c0db001deba2dfd))

### Documentation improvements

- Documentation improvements and changes for multiple fields ([commit 448570d](https://github.com/googleapis/google-cloud-dotnet/commit/448570daf7dc678a89cfdd889c0db001deba2dfd))
