### PR TITLE
Release Google.Cloud.PubSub.V1 version 3.24.0

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.23.0</Version>
+    <Version>3.24.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.</Description>

--- a/apis/Google.Cloud.PubSub.V1/docs/history.md
+++ b/apis/Google.Cloud.PubSub.V1/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+## Version 3.24.0, released 2025-03-31
+
+### Documentation improvements
+
+- Update documentation for JavaScriptUDF to indicate that the `message_id` metadata field is optional instead of required ([commit 8127313](https://github.com/googleapis/google-cloud-dotnet/commit/8127313c8128619f5526c37b578a17b37bac0f1d))
 ## Version 3.23.0, released 2025-03-14
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -4172,7 +4172,7 @@
       "protoPath": "google/pubsub/v1",
       "productName": "Cloud Pub/Sub",
       "productUrl": "https://cloud.google.com/pubsub/",
-      "version": "3.23.0",
+      "version": "3.24.0",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
       "description": "Recommended Google client library to access the Google Cloud Pub/Sub API, which provides reliable, many-to-many, asynchronous messaging between applications.",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Update documentation for JavaScriptUDF to indicate that the `message_id` metadata field is optional instead of required ([commit 8127313](https://github.com/googleapis/google-cloud-dotnet/commit/8127313c8128619f5526c37b578a17b37bac0f1d))
