### PR TITLE
tools: Accommodate libraries which haven't been generated yet.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -77,12 +77,7 @@ then
     do
       if [[ ! "$api" =~ $apiregex ]]
       then
-        if [[ -d "apis/$api" ]]
-        then
-          filteredapis+=($api)
-        else
-          echo "Skipping missing API $api; recently deleted?"
-        fi
+        filteredapis+=($api)
       fi
     done
   else
@@ -90,12 +85,7 @@ then
     do    
       if [[ "$api" =~ $apiregex ]]
       then
-        if [[ -d "apis/$api" ]]
-        then
-          filteredapis+=($api)
-        else
-          echo "Skipping missing API $api; recently deleted?"
-        fi
+        filteredapis+=($api)
       fi
     done
   fi
@@ -128,6 +118,12 @@ for api in ${apis[*]}
 do
   [[ -d "$api" ]] && apidir=$api || apidir=apis/$api
 
+  if [[ ! -d "$apidir" ]]
+  then
+    log_build_action "Skipping missing API $api; may be configured but not generated, or recently deleted"
+    continue
+  fi
+  
   log_build_action "Building $apidir"
   dotnet build -nologo -clp:NoSummary -v quiet -c Release $apidir
   

--- a/tools/Google.Cloud.Tools.ReleaseManager/CreateClientsCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/CreateClientsCommand.cs
@@ -42,6 +42,12 @@ public class CreateClientsCommand : CommandBase
             Console.WriteLine($"{id} is not a GAPIC-generated API; skipping client creation test.");
             return 0;
         }
+        var apiLayout = RootLayout.CreateRepositoryApiLayout(id);
+        if (!Directory.Exists(apiLayout.SourceDirectory))
+        {
+            Console.WriteLine($"{id} has no source directory; skipping client creation test.");
+            return 0;
+        }
 
         var assembly = PublishAndLoadAssembly(id);
         CreateClients(assembly, id);


### PR DESCRIPTION
Fixes b/408125891

Note that the *removals* in build.sh are because we now skip in just a single place.