### PR TITLE
tools: Effectively ignore ungenerated libraries in some cases

### DIFF
--- a/apis/Google.Maps.AreaInsights.V1/Google.Maps.AreaInsights.V1/Google.Maps.AreaInsights.V1.csproj
+++ b/apis/Google.Maps.AreaInsights.V1/Google.Maps.AreaInsights.V1/Google.Maps.AreaInsights.V1.csproj
@@ -4,7 +4,7 @@
     <Version>1.0.0-beta01</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Description>Recommended Google client library to access the Google Maps Places Insights API, provides an easy way to understand the density and distribution of places in a specific area.</Description>
+    <Description>Recommended Google client library to access the Google Maps Places Insights API, which provides an easy way to understand the density and distribution of places in a specific area.</Description>
     <PackageTags>maps;insights;places;Google;Cloud</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/tools/Google.Cloud.Tools.Common/ApiMetadata.cs
+++ b/tools/Google.Cloud.Tools.Common/ApiMetadata.cs
@@ -16,6 +16,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 
@@ -104,9 +105,9 @@ namespace Google.Cloud.Tools.Common
         /// <summary>
         /// The resolved description to use in listing descriptions, using the first of<see cref="ListingDescription"/>,
         /// <see cref="ProductName"/>, <see cref="Description"/> to be populated.
-        ///Note that NuGet descriptions are usually full sentences, ending in a period.
-        // The product name or brief description is usually a sentence fragment, so if we *do*
-        // use the full description, we trim any trailing periods.
+        /// Note that NuGet descriptions are usually full sentences, ending in a period.
+        /// The product name or brief description is usually a sentence fragment, so if we *do*
+        /// use the full description, we trim any trailing periods.
         /// </summary>
         [JsonIgnore]
         public string EffectiveListingDescription => ListingDescription ?? ProductName ?? Description.TrimEnd('.');
@@ -217,6 +218,23 @@ namespace Google.Cloud.Tools.Common
         /// </summary>
         /// <param name="package">The name of the package, e.g. Google.Cloud.Storage.V1</param>
         public static bool IsCloudPackage(string package) => package.StartsWith("Google.Cloud.") || PseudoCloudPackages.Contains(package);
+
+        /// <summary>
+        /// Indicates whether this API has source code, relative to the given <see cref="RootLayout">.
+        /// This assumes there is a suitable "generator output" directory - which is the case for either
+        /// a generation-specific layout or one for a layout with the whole repository available.
+        /// </summary>
+        public bool HasSource(RootLayout rootLayout) => HasSource(rootLayout.CreateGeneratorApiLayout(this));
+
+        /// <summary>
+        /// Indicates whether this API has source code, relative to the given <see cref="RepositoryApiLayout">.
+        /// </summary>
+        public bool HasSource(RepositoryApiLayout repoLayout) => Directory.Exists(repoLayout.SourceDirectory);
+
+        /// <summary>
+        /// Indicates whether this API has source code, relative to the given <see cref="GeneratorApiLayout">.
+        /// </summary>
+        public bool HasSource(GeneratorApiLayout generatorLayout) => Directory.Exists(generatorLayout.SourceDirectory);
 
         /// <summary>
         /// Whether or not to include the common resources proto when generating. This is true for

--- a/tools/Google.Cloud.Tools.Common/RootLayout.cs
+++ b/tools/Google.Cloud.Tools.Common/RootLayout.cs
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
-using System.Text;
 
 namespace Google.Cloud.Tools.Common;
 


### PR DESCRIPTION
We don't need to take account of as-yet-ungenerated libraries when generating README.md or renovate.json, or API-specific files - it's better to wait until those libraries are first generated, and take the change at that point.

Fixes b/408125812