### PR TITLE
tests: Add smoke test for Google.Cloud.DeviceStreaming.V1

### DIFF
--- a/apis/Google.Cloud.DeviceStreaming.V1/smoketests.json
+++ b/apis/Google.Cloud.DeviceStreaming.V1/smoketests.json
@@ -1,0 +1,9 @@
+[
+  {
+    "method": "ListDeviceSessions",
+    "client": "DirectAccessServiceClient",
+    "arguments": {
+      "parent": "projects/${PROJECT_ID}"
+    }
+  }
+]


### PR DESCRIPTION
(We'll need to enable the API on CI projects of course.)