### PR TITLE
feat: Introduce a new environment variable for local Librarian testing

### DIFF
--- a/generator-input/pipeline-config.json
+++ b/generator-input/pipeline-config.json
@@ -9,6 +9,9 @@
         {
           "name": "FIRESTORE_TEST_PROJECT",
           "secretName": "firestore-test-project"
+        },
+        {
+          "name": "INTEGRATION_TEST_SERVICE_ACCOUNT_JSON"
         }
       ]
     }


### PR DESCRIPTION
If INTEGRATION_TEST_SERVICE_ACCOUNT_JSON is set, then the integration-test-library command will set up a service account file with the content of the environment variable. This is not intended for normal Librarian usage, where integration tests are only run for releasing, but it helps for Librarian/container testing.

The following command makes the JSON content available as a single line.

```sh
export INTEGRATION_TEST_SERVICE_ACCOUNT_JSON=$(cat $GOOGLE_APPLICATION_CREDENTIALS | sed -z 's/\n/ /g')
```

Fixes b/409731843