### PR TITLE
Release Google.Cloud.ArtifactRegistry.V1 version 2.10.0

### DIFF
--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.csproj
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.9.0</Version>
+    <Version>2.10.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Artifact Registry API v1, which stores and manages build artifacts in a scalable and integrated service built on Google infrastructure.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.3.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />

--- a/apis/Google.Cloud.ArtifactRegistry.V1/docs/history.md
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.10.0, released 2025-04-14
+
+### New features
+
+- Add the GoModule and KfpArtifact resources ([commit 1ea561f](https://github.com/googleapis/google-cloud-dotnet/commit/1ea561f2551a266b7d5842398e87a9642a672fb4))
+
+### Documentation improvements
+
+- Remove the restriction of the maximum numbers of versions that can be deleted in one BatchDeleteVersions call ([commit 1ea561f](https://github.com/googleapis/google-cloud-dotnet/commit/1ea561f2551a266b7d5842398e87a9642a672fb4))
+
 ## Version 2.9.0, released 2024-10-29
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -582,7 +582,7 @@
     },
     {
       "id": "Google.Cloud.ArtifactRegistry.V1",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "type": "grpc",
       "productName": "Artifact Registry",
       "productUrl": "https://cloud.google.com/artifact-registry",
@@ -593,7 +593,7 @@
         "containers"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Iam.V1": "3.4.0",
         "Google.Cloud.Location": "2.3.0",
         "Google.LongRunning": "3.3.0"
       },


### PR DESCRIPTION

Changes in this release:

### New features

- Add the GoModule and KfpArtifact resources ([commit 1ea561f](https://github.com/googleapis/google-cloud-dotnet/commit/1ea561f2551a266b7d5842398e87a9642a672fb4))

### Documentation improvements

- Remove the restriction of the maximum numbers of versions that can be deleted in one BatchDeleteVersions call ([commit 1ea561f](https://github.com/googleapis/google-cloud-dotnet/commit/1ea561f2551a266b7d5842398e87a9642a672fb4))
