### PR TITLE
Release Google.Cloud.Dataplex.V1 version 3.8.0

### DIFF
--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.csproj
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.7.0</Version>
+    <Version>3.8.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Dataplex API, which is used to manage the lifecycle of data lakes.</Description>

--- a/apis/Google.Cloud.Dataplex.V1/docs/history.md
+++ b/apis/Google.Cloud.Dataplex.V1/docs/history.md
@@ -1,5 +1,23 @@
 # Version history
 
+## Version 3.8.0, released 2025-04-14
+
+### New features
+
+- Add Data Discovery result statistics ([commit 8501d35](https://github.com/googleapis/google-cloud-dotnet/commit/8501d35b9f45a3bda71372cfe3a12b7c8846dfeb))
+- Removing internal visibility labels for cmek public preview ([commit 8501d35](https://github.com/googleapis/google-cloud-dotnet/commit/8501d35b9f45a3bda71372cfe3a12b7c8846dfeb))
+- A new message `ExportJobResult` is added ([commit 8501d35](https://github.com/googleapis/google-cloud-dotnet/commit/8501d35b9f45a3bda71372cfe3a12b7c8846dfeb))
+- A new message `ExportJobSpec` is added ([commit 8501d35](https://github.com/googleapis/google-cloud-dotnet/commit/8501d35b9f45a3bda71372cfe3a12b7c8846dfeb))
+- A new value `EXPORT` is added to enum `Type` ([commit 8501d35](https://github.com/googleapis/google-cloud-dotnet/commit/8501d35b9f45a3bda71372cfe3a12b7c8846dfeb))
+- A new field `export_spec` is added to message `.google.cloud.dataplex.v1.MetadataJob` ([commit 8501d35](https://github.com/googleapis/google-cloud-dotnet/commit/8501d35b9f45a3bda71372cfe3a12b7c8846dfeb))
+- A new field `export_result` is added to message `.google.cloud.dataplex.v1.MetadataJob` ([commit 8501d35](https://github.com/googleapis/google-cloud-dotnet/commit/8501d35b9f45a3bda71372cfe3a12b7c8846dfeb))
+- Add Data Discovery result statistics ([commit 2bb3767](https://github.com/googleapis/google-cloud-dotnet/commit/2bb37671fc8c313a68bddaf7ed6aace3e2751f30))
+- Add EntryLinkEvent for logs ([commit 2bb3767](https://github.com/googleapis/google-cloud-dotnet/commit/2bb37671fc8c313a68bddaf7ed6aace3e2751f30))
+
+### Documentation improvements
+
+- Minor formatting changes ([commit 8501d35](https://github.com/googleapis/google-cloud-dotnet/commit/8501d35b9f45a3bda71372cfe3a12b7c8846dfeb))
+
 ## Version 3.7.0, released 2025-03-17
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -1865,7 +1865,7 @@
     },
     {
       "id": "Google.Cloud.Dataplex.V1",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "type": "grpc",
       "productName": "Cloud Dataplex",
       "productUrl": "https://cloud.google.com/dataplex/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add Data Discovery result statistics ([commit 8501d35](https://github.com/googleapis/google-cloud-dotnet/commit/8501d35b9f45a3bda71372cfe3a12b7c8846dfeb))
- Removing internal visibility labels for cmek public preview ([commit 8501d35](https://github.com/googleapis/google-cloud-dotnet/commit/8501d35b9f45a3bda71372cfe3a12b7c8846dfeb))
- A new message `ExportJobResult` is added ([commit 8501d35](https://github.com/googleapis/google-cloud-dotnet/commit/8501d35b9f45a3bda71372cfe3a12b7c8846dfeb))
- A new message `ExportJobSpec` is added ([commit 8501d35](https://github.com/googleapis/google-cloud-dotnet/commit/8501d35b9f45a3bda71372cfe3a12b7c8846dfeb))
- A new value `EXPORT` is added to enum `Type` ([commit 8501d35](https://github.com/googleapis/google-cloud-dotnet/commit/8501d35b9f45a3bda71372cfe3a12b7c8846dfeb))
- A new field `export_spec` is added to message `.google.cloud.dataplex.v1.MetadataJob` ([commit 8501d35](https://github.com/googleapis/google-cloud-dotnet/commit/8501d35b9f45a3bda71372cfe3a12b7c8846dfeb))
- A new field `export_result` is added to message `.google.cloud.dataplex.v1.MetadataJob` ([commit 8501d35](https://github.com/googleapis/google-cloud-dotnet/commit/8501d35b9f45a3bda71372cfe3a12b7c8846dfeb))
- Add Data Discovery result statistics ([commit 2bb3767](https://github.com/googleapis/google-cloud-dotnet/commit/2bb37671fc8c313a68bddaf7ed6aace3e2751f30))
- Add EntryLinkEvent for logs ([commit 2bb3767](https://github.com/googleapis/google-cloud-dotnet/commit/2bb37671fc8c313a68bddaf7ed6aace3e2751f30))

### Documentation improvements

- Minor formatting changes ([commit 8501d35](https://github.com/googleapis/google-cloud-dotnet/commit/8501d35b9f45a3bda71372cfe3a12b7c8846dfeb))
