### PR TITLE
Release Google.Cloud.Firestore.Admin.V1 version 3.13.0

### DIFF
--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.csproj
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.12.0</Version>
+    <Version>3.13.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Firestore Admin API.</Description>

--- a/apis/Google.Cloud.Firestore.Admin.V1/docs/history.md
+++ b/apis/Google.Cloud.Firestore.Admin.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 3.13.0, released 2025-04-14
+
+### New features
+
+- New Firestore index modes and Database Editions ([commit 5592a07](https://github.com/googleapis/google-cloud-dotnet/commit/5592a0700f8219ae3ef20c04c01c685be2c0acb6))
+- Add the UserCreds API ([commit a8687d8](https://github.com/googleapis/google-cloud-dotnet/commit/a8687d8c865a9bd98d6400252c2611ccae46d8a8))
+
 ## Version 3.12.0, released 2025-01-27
 
 ### Bug fixes

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -2576,7 +2576,7 @@
       "listingDescription": "Firestore Administration (e.g. index management)",
       "productName": "Firestore Admin",
       "productUrl": "https://firebase.google.com",
-      "version": "3.12.0",
+      "version": "3.13.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Firestore Admin API.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- New Firestore index modes and Database Editions ([commit 5592a07](https://github.com/googleapis/google-cloud-dotnet/commit/5592a0700f8219ae3ef20c04c01c685be2c0acb6))
- Add the UserCreds API ([commit a8687d8](https://github.com/googleapis/google-cloud-dotnet/commit/a8687d8c865a9bd98d6400252c2611ccae46d8a8))
