### PR TITLE
Release Google.Cloud.Iap.V1 version 2.8.0

### DIFF
--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.csproj
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.7.0</Version>
+    <Version>2.8.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud IAP API, which controls access to cloud applications running on Google Cloud Platform.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.4.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Iap.V1/docs/history.md
+++ b/apis/Google.Cloud.Iap.V1/docs/history.md
@@ -1,5 +1,38 @@
 # Version history
 
+## Version 2.8.0, released 2025-04-14
+
+### New features
+
+- Identity-aware Proxy (IAP) released a feature `Use IAP with Workforce Identity Federation`(https://cloud.google.com/iap/docs/use-workforce-identity-federation) at Feb 7, 2025. Two settings field are newly introduced in the feature release: `workforce_identity_settings` and `identity_sources` ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
+
+### Documentation improvements
+
+- A comment for field `name` in message `.google.cloud.iap.v1.TunnelDestGroup` is changed ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
+- A comment for field `cidrs` in message `.google.cloud.iap.v1.TunnelDestGroup` is changed ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
+- A comment for field `fqdns` in message `.google.cloud.iap.v1.TunnelDestGroup` is changed ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
+- Mark `access_settings` in message `.google.cloud.iap.v1.IapSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
+- Mark `application_settings` in message `.google.cloud.iap.v1.IapSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
+- Mark `gcip_settings` in message `.google.cloud.iap.v1.AccessSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
+- Mark `cors_settings` in message `.google.cloud.iap.v1.AccessSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
+- Mark `oauth_settings` in message `.google.cloud.iap.v1.AccessSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
+- Mark `reauth_settings` in message `.google.cloud.iap.v1.AccessSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
+- Mark `allowed_domains_settings` in message `.google.cloud.iap.v1.AccessSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
+- Mark `tenant_ids` in message `.google.cloud.iap.v1.GcipSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
+- Mark `programmatic_clients` in message `.google.cloud.iap.v1.OAuthSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
+- A comment for enum `PolicyType` is changed ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
+- Mark `method` in message `.google.cloud.iap.v1.ReauthSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
+- Mark `max_age` in message `.google.cloud.iap.v1.ReauthSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
+- Mark `policy_type` in message `.google.cloud.iap.v1.ReauthSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
+- Mark `enable` in message `.google.cloud.iap.v1.AllowedDomainsSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
+- Mark `domains` in message `.google.cloud.iap.v1.AllowedDomainsSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
+- Mark `csm_settings` in message `.google.cloud.iap.v1.ApplicationSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
+- Mark `access_denied_page_settings` in message `.google.cloud.iap.v1.ApplicationSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
+- Mark `attribute_propagation_settings` in message `.google.cloud.iap.v1.ApplicationSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
+- Mark `expression` in message `.google.cloud.iap.v1.AttributePropagationSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
+- Mark `output_credentials` in message `.google.cloud.iap.v1.AttributePropagationSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
+- Mark `enable` in message `.google.cloud.iap.v1.AttributePropagationSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
+
 ## Version 2.7.0, released 2024-05-14
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -3037,7 +3037,7 @@
     },
     {
       "id": "Google.Cloud.Iap.V1",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "type": "grpc",
       "productName": "Cloud Identity-Aware Proxy",
       "productUrl": "https://cloud.google.com/iap/docs/",
@@ -3048,7 +3048,7 @@
         "access"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.2.0"
+        "Google.Cloud.Iam.V1": "3.4.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/iap/v1",


### PR DESCRIPTION

Changes in this release:

### New features

- Identity-aware Proxy (IAP) released a feature `Use IAP with Workforce Identity Federation`(https://cloud.google.com/iap/docs/use-workforce-identity-federation) at Feb 7, 2025. Two settings field are newly introduced in the feature release: `workforce_identity_settings` and `identity_sources` ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))

### Documentation improvements

- A comment for field `name` in message `.google.cloud.iap.v1.TunnelDestGroup` is changed ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
- A comment for field `cidrs` in message `.google.cloud.iap.v1.TunnelDestGroup` is changed ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
- A comment for field `fqdns` in message `.google.cloud.iap.v1.TunnelDestGroup` is changed ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
- Mark `access_settings` in message `.google.cloud.iap.v1.IapSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
- Mark `application_settings` in message `.google.cloud.iap.v1.IapSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
- Mark `gcip_settings` in message `.google.cloud.iap.v1.AccessSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
- Mark `cors_settings` in message `.google.cloud.iap.v1.AccessSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
- Mark `oauth_settings` in message `.google.cloud.iap.v1.AccessSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
- Mark `reauth_settings` in message `.google.cloud.iap.v1.AccessSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
- Mark `allowed_domains_settings` in message `.google.cloud.iap.v1.AccessSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
- Mark `tenant_ids` in message `.google.cloud.iap.v1.GcipSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
- Mark `programmatic_clients` in message `.google.cloud.iap.v1.OAuthSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
- A comment for enum `PolicyType` is changed ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
- Mark `method` in message `.google.cloud.iap.v1.ReauthSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
- Mark `max_age` in message `.google.cloud.iap.v1.ReauthSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
- Mark `policy_type` in message `.google.cloud.iap.v1.ReauthSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
- Mark `enable` in message `.google.cloud.iap.v1.AllowedDomainsSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
- Mark `domains` in message `.google.cloud.iap.v1.AllowedDomainsSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
- Mark `csm_settings` in message `.google.cloud.iap.v1.ApplicationSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
- Mark `access_denied_page_settings` in message `.google.cloud.iap.v1.ApplicationSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
- Mark `attribute_propagation_settings` in message `.google.cloud.iap.v1.ApplicationSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
- Mark `expression` in message `.google.cloud.iap.v1.AttributePropagationSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
- Mark `output_credentials` in message `.google.cloud.iap.v1.AttributePropagationSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
- Mark `enable` in message `.google.cloud.iap.v1.AttributePropagationSettings` as optional ([commit 176a5d4](https://github.com/googleapis/google-cloud-dotnet/commit/176a5d4219c80331664486163755841f86f98cb7))
