### PR TITLE
Release Google.Cloud.OracleDatabase.V1 version 1.3.0

### DIFF
--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.csproj
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Oracle Database@Google Cloud API which provides a set of APIs to manage Oracle database services, such as Exadata and Autonomous Databases.</Description>

--- a/apis/Google.Cloud.OracleDatabase.V1/docs/history.md
+++ b/apis/Google.Cloud.OracleDatabase.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.3.0, released 2025-04-14
+
+### New features
+
+- Add new AutonomousDatabase RPCs ([commit 408e3de](https://github.com/googleapis/google-cloud-dotnet/commit/408e3de85d24ad530b6e7f4d2fb83c33f4557603))
+
+### Documentation improvements
+
+- The network and cidr fields of AutonomousDatabase are now marked optional ([commit 31b7812](https://github.com/googleapis/google-cloud-dotnet/commit/31b78129e6076c0eb20683cb9a767f2133053a0e))
+
 ## Version 1.2.0, released 2025-03-17
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -3841,7 +3841,7 @@
     },
     {
       "id": "Google.Cloud.OracleDatabase.V1",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "type": "grpc",
       "productName": "Oracle Database@Google Cloud",
       "productUrl": "https://cloud.google.com/oracle/database/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Add new AutonomousDatabase RPCs ([commit 408e3de](https://github.com/googleapis/google-cloud-dotnet/commit/408e3de85d24ad530b6e7f4d2fb83c33f4557603))

### Documentation improvements

- The network and cidr fields of AutonomousDatabase are now marked optional ([commit 31b7812](https://github.com/googleapis/google-cloud-dotnet/commit/31b78129e6076c0eb20683cb9a767f2133053a0e))
