### PR TITLE
Release Google.Cloud.Speech.V1P1Beta1 version 3.0.0-beta09

### DIFF
--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.csproj
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-beta08</Version>
+    <Version>3.0.0-beta09</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google client library to access the Google Cloud Speech API version v1p1beta1 with upcoming features.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.LongRunning" VersionOverride="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Speech.V1P1Beta1/docs/history.md
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+## Version 3.0.0-beta09, released 2025-04-14
+
+### New features
+
+- Expose google.cloud.location.Locations API ([commit ed6c6aa](https://github.com/googleapis/google-cloud-dotnet/commit/ed6c6aadcf10ec1c43f7104d3278d2ccef6a1d1d))
+- Add new fields to CustomClass and PhraseSet.Phrase messages ([commit ed6c6aa](https://github.com/googleapis/google-cloud-dotnet/commit/ed6c6aadcf10ec1c43f7104d3278d2ccef6a1d1d))
+- Add ALAW support to RecognitionConfig ([commit ed6c6aa](https://github.com/googleapis/google-cloud-dotnet/commit/ed6c6aadcf10ec1c43f7104d3278d2ccef6a1d1d))
+- Make transcript_normalization field optional ([commit ed6c6aa](https://github.com/googleapis/google-cloud-dotnet/commit/ed6c6aadcf10ec1c43f7104d3278d2ccef6a1d1d))
+- Deprecating speaker_tag (int) for speaker_label (string) ([commit ed6c6aa](https://github.com/googleapis/google-cloud-dotnet/commit/ed6c6aadcf10ec1c43f7104d3278d2ccef6a1d1d))
+
+### Documentation improvements
+
+- Miscellaneous clarifications ([commit ed6c6aa](https://github.com/googleapis/google-cloud-dotnet/commit/ed6c6aadcf10ec1c43f7104d3278d2ccef6a1d1d))
+
 ## Version 3.0.0-beta08, released 2024-05-14
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -5175,7 +5175,7 @@
       "protoPath": "google/cloud/speech/v1p1beta1",
       "productName": "Google Cloud Speech",
       "productUrl": "https://cloud.google.com/speech",
-      "version": "3.0.0-beta08",
+      "version": "3.0.0-beta09",
       "releaseLevelOverride": "preview",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",
@@ -5184,7 +5184,7 @@
         "Speech"
       ],
       "dependencies": {
-        "Google.LongRunning": "3.2.0"
+        "Google.LongRunning": "3.3.0"
       },
       "shortName": "speech",
       "serviceConfigFile": "speech_v1p1beta1.yaml",


### PR DESCRIPTION

Changes in this release:

### New features

- Expose google.cloud.location.Locations API ([commit ed6c6aa](https://github.com/googleapis/google-cloud-dotnet/commit/ed6c6aadcf10ec1c43f7104d3278d2ccef6a1d1d))
- Add new fields to CustomClass and PhraseSet.Phrase messages ([commit ed6c6aa](https://github.com/googleapis/google-cloud-dotnet/commit/ed6c6aadcf10ec1c43f7104d3278d2ccef6a1d1d))
- Add ALAW support to RecognitionConfig ([commit ed6c6aa](https://github.com/googleapis/google-cloud-dotnet/commit/ed6c6aadcf10ec1c43f7104d3278d2ccef6a1d1d))
- Make transcript_normalization field optional ([commit ed6c6aa](https://github.com/googleapis/google-cloud-dotnet/commit/ed6c6aadcf10ec1c43f7104d3278d2ccef6a1d1d))
- Deprecating speaker_tag (int) for speaker_label (string) ([commit ed6c6aa](https://github.com/googleapis/google-cloud-dotnet/commit/ed6c6aadcf10ec1c43f7104d3278d2ccef6a1d1d))

### Documentation improvements

- Miscellaneous clarifications ([commit ed6c6aa](https://github.com/googleapis/google-cloud-dotnet/commit/ed6c6aadcf10ec1c43f7104d3278d2ccef6a1d1d))
