### PR TITLE
Release Google.Cloud.WebRisk.V1 version 2.7.0

### DIFF
--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.csproj
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Web Risk API v1, which lets client applications check URLs against Google's constantly updated lists of unsafe web resources.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.LongRunning" VersionOverride="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.WebRisk.V1/docs/history.md
+++ b/apis/Google.Cloud.WebRisk.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 2.7.0, released 2025-04-14
+
+### New features
+
+- A new method_signature `parent,submission` is added to method `SubmitUri` in service `WebRiskService` ([commit d695498](https://github.com/googleapis/google-cloud-dotnet/commit/d6954985d10fd306d76e443a495c3a28e1bfb7cc))
+
+### Documentation improvements
+
+- A comment for message `ThreatInfo` is changed ([commit d695498](https://github.com/googleapis/google-cloud-dotnet/commit/d6954985d10fd306d76e443a495c3a28e1bfb7cc))
+- A comment for message `SubmitUriMetadata` is changed ([commit d695498](https://github.com/googleapis/google-cloud-dotnet/commit/d6954985d10fd306d76e443a495c3a28e1bfb7cc))
+
 ## Version 2.6.0, released 2024-05-14
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -5881,7 +5881,7 @@
       "protoPath": "google/cloud/webrisk/v1",
       "productName": "Google Cloud Web Risk",
       "productUrl": "https://cloud.google.com/web-risk/",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Web Risk API v1, which lets client applications check URLs against Google's constantly updated lists of unsafe web resources.",
       "tags": [
@@ -5893,7 +5893,7 @@
         "url"
       ],
       "dependencies": {
-        "Google.LongRunning": "3.2.0"
+        "Google.LongRunning": "3.3.0"
       },
       "shortName": "webrisk",
       "serviceConfigFile": "webrisk_v1.yaml",


### PR DESCRIPTION

Changes in this release:

### New features

- A new method_signature `parent,submission` is added to method `SubmitUri` in service `WebRiskService` ([commit d695498](https://github.com/googleapis/google-cloud-dotnet/commit/d6954985d10fd306d76e443a495c3a28e1bfb7cc))

### Documentation improvements

- A comment for message `ThreatInfo` is changed ([commit d695498](https://github.com/googleapis/google-cloud-dotnet/commit/d6954985d10fd306d76e443a495c3a28e1bfb7cc))
- A comment for message `SubmitUriMetadata` is changed ([commit d695498](https://github.com/googleapis/google-cloud-dotnet/commit/d6954985d10fd306d76e443a495c3a28e1bfb7cc))
