### PR TITLE
Release Google.Shopping.Css.V1 version 1.0.0-beta07

### DIFF
--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/Google.Shopping.Css.V1.csproj
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/Google.Shopping.Css.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta06</Version>
+    <Version>1.0.0-beta07</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Shopping CSS API, which allows you to programmatically manage your Comparison Shopping Service (CSS) account data at scale.</Description>

--- a/apis/Google.Shopping.Css.V1/docs/history.md
+++ b/apis/Google.Shopping.Css.V1/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 1.0.0-beta07, released 2025-04-14
+
+### New features
+
+- Introduce QuotaService for CSS API ([commit 7969a13](https://github.com/googleapis/google-cloud-dotnet/commit/7969a13a6f0cdd19962976b9c9a0a8bb99db8c29))
+
+### Documentation improvements
+
+- A comment for field `name` in message `.google.shopping.css.v1.CssProductInput` is changed ([commit 7969a13](https://github.com/googleapis/google-cloud-dotnet/commit/7969a13a6f0cdd19962976b9c9a0a8bb99db8c29))
+- A comment for field `name` in message `.google.shopping.css.v1.DeleteCssProductInputRequest` is changed ([commit 7969a13](https://github.com/googleapis/google-cloud-dotnet/commit/7969a13a6f0cdd19962976b9c9a0a8bb99db8c29))
+- Added a clarifying note to the description of the parent field in the Account resource ([commit 95a25d1](https://github.com/googleapis/google-cloud-dotnet/commit/95a25d1e19375b1f1ceb45308d1aba704b746a97))
+
 ## Version 1.0.0-beta06, released 2025-01-06
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -6381,7 +6381,7 @@
     },
     {
       "id": "Google.Shopping.Css.V1",
-      "version": "1.0.0-beta06",
+      "version": "1.0.0-beta07",
       "type": "grpc",
       "productName": "CSS",
       "productUrl": "https://developers.google.com/comparison-shopping-services/api",


### PR DESCRIPTION

Changes in this release:

### New features

- Introduce QuotaService for CSS API ([commit 7969a13](https://github.com/googleapis/google-cloud-dotnet/commit/7969a13a6f0cdd19962976b9c9a0a8bb99db8c29))

### Documentation improvements

- A comment for field `name` in message `.google.shopping.css.v1.CssProductInput` is changed ([commit 7969a13](https://github.com/googleapis/google-cloud-dotnet/commit/7969a13a6f0cdd19962976b9c9a0a8bb99db8c29))
- A comment for field `name` in message `.google.shopping.css.v1.DeleteCssProductInputRequest` is changed ([commit 7969a13](https://github.com/googleapis/google-cloud-dotnet/commit/7969a13a6f0cdd19962976b9c9a0a8bb99db8c29))
- Added a clarifying note to the description of the parent field in the Account resource ([commit 95a25d1](https://github.com/googleapis/google-cloud-dotnet/commit/95a25d1e19375b1f1ceb45308d1aba704b746a97))
