### PR TITLE
Release diagnostics libraries version 5.3.0

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.csproj
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.2.0</Version>
+    <Version>5.3.0</Version>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries for ASP.NET Core 3.</Description>

--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/docs/history.md
@@ -1,5 +1,9 @@
 # Version history
 
+## Version 5.3.0, released 2025-04-14
+
+No API surface changes; just dependency updates.
+
 ## Version 5.2.0, released 2024-03-05
 
 No API surface changes; just dependency updates.

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.2.0</Version>
+    <Version>5.3.0</Version>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components.</Description>
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Logging.V2" VersionOverride="[4.3.0, 5.0.0)" />
-    <PackageReference Include="Google.Cloud.Trace.V1" VersionOverride="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Logging.V2" VersionOverride="[4.4.0, 5.0.0)" />
+    <PackageReference Include="Google.Cloud.Trace.V1" VersionOverride="[3.4.0, 4.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Http" VersionOverride="6.0.0" />
     <PackageReference Include="System.Diagnostics.StackTrace" VersionOverride="4.3.0" />
   </ItemGroup>

--- a/apis/Google.Cloud.Diagnostics.Common/docs/history.md
+++ b/apis/Google.Cloud.Diagnostics.Common/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 5.3.0, released 2025-04-14
+
+### New features
+
+- Change netstandard2.1 target to netstandard2.0 ([commit cba7759](https://github.com/googleapis/google-cloud-dotnet/commit/cba77591907c4a4594a184466534ee9e258bb5ef))
+- Remove unnecessary net462 target from Google.Cloud.Diagnostics.Common. ([commit 4a7ba3e](https://github.com/googleapis/google-cloud-dotnet/commit/4a7ba3ef66af9702ea3f583bc247a6a1e02a0339))
+
 ## Version 5.2.0, released 2024-03-05
 
 No API surface changes; just dependency updates.

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -2126,7 +2126,7 @@
     },
     {
       "id": "Google.Cloud.Diagnostics.AspNetCore3",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "type": "other",
       "metadataType": "INTEGRATION",
       "targetFrameworks": "netcoreapp3.1",
@@ -2155,7 +2155,7 @@
     },
     {
       "id": "Google.Cloud.Diagnostics.Common",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "targetFrameworks": "netstandard2.0",
       "type": "other",
       "description": "Google Cloud Logging, Trace and Error Reporting Instrumentation Libraries Common Components.",
@@ -2169,8 +2169,8 @@
       ],
       "dependencies": {
         "Google.Api.Gax.Grpc": "default",
-        "Google.Cloud.Logging.V2": "4.3.0",
-        "Google.Cloud.Trace.V1": "3.3.0",
+        "Google.Cloud.Logging.V2": "4.4.0",
+        "Google.Cloud.Trace.V1": "3.4.0",
         "Microsoft.Extensions.Http": "6.0.0",
         "System.Diagnostics.StackTrace": "4.3.0"
       },


### PR DESCRIPTION

Changes in Google.Cloud.Diagnostics.AspNetCore3 version 5.3.0:

No API surface changes; just dependency updates.

Changes in Google.Cloud.Diagnostics.Common version 5.3.0:

### New features

- Change netstandard2.1 target to netstandard2.0 ([commit cba7759](https://github.com/googleapis/google-cloud-dotnet/commit/cba77591907c4a4594a184466534ee9e258bb5ef))
- Remove unnecessary net462 target from Google.Cloud.Diagnostics.Common. ([commit 4a7ba3e](https://github.com/googleapis/google-cloud-dotnet/commit/4a7ba3ef66af9702ea3f583bc247a6a1e02a0339))

Packages in this release:
- Release Google.Cloud.Diagnostics.AspNetCore3 version 5.3.0
- Release Google.Cloud.Diagnostics.Common version 5.3.0
