### PR TITLE
Release Spanner libraries version 5.0.0

### DIFF
--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.0.0-beta06</Version>
+    <Version>5.0.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Spanner Database Admin API.</Description>

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.0.0-beta06</Version>
+    <Version>5.0.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Spanner Instance Admin API.</Description>

--- a/apis/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1.csproj
+++ b/apis/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.0.0-beta06</Version>
+    <Version>5.0.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Common resource names used by all Spanner V1 APIs</Description>

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.csproj
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.0.0-beta06</Version>
+    <Version>5.0.0</Version>
     <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Google ADO.NET Provider for Google Cloud Spanner.</Description>

--- a/apis/Google.Cloud.Spanner.Data/docs/history.md
+++ b/apis/Google.Cloud.Spanner.Data/docs/history.md
@@ -1,5 +1,31 @@
 # Version history
 
+## Version 5.0.0, released 2025-04-16
+
+### New features
+
+Note: V5.0.0 contains all the new features added in previous beta versions V5.0.0-beta0x.
+Here, we highlight those that introduced breaking changes with respect to previous stable versions V4.x.x.
+
+- Transactions support SpannerTransactionCreationOptions and SpannerTransactionOptions.
+  BREAKING CHANGE: SpannerConection methods that open a transaction, like BeginTransacion, Open and RunWithRetriableTransaction sets of methods now
+accept both option types as parameter, while some of the previously existing methods have been deprecated and will be removed on the next major version.
+- After a successfull commit or rollback, the transaction is disposed.
+  BREAKING CHANGE: Attempting to use a disposed transaction will result in a client side error. See the Google.Cloud.Spanner.Data.SpannerTransaction.DisposeBehavior documentation for more information.
+- Add support for FLOAT32
+  BREAKING CHANGE: The default mapping for values of CLR type decimal was FLOAT64 and it is now Numeric.
+The default mapping for values of CLR type float was FLOAT64 and it is now FLOAT32.
+- Support inline transactions.
+  BREAKING CHANGE: In supporting inline transactions the main breaking change is behavioral: transactions are not prewarmed, instead they are acquired
+as needed, mainly through inlining transaction creation in the first command that attempts to use a transaction. The method
+`Google.Cloud.Spanner.V1.PooledSession.WithFreshTransactionOrNewAsync` has been removed, as a transaction is not created by the session until command execution.
+Use instead `Google.Cloud.Spanner.V1.PooledSession.RefreshedOrNewAsync` which returns a new PooledSession instance that either represents the same
+session but with no transaction associated to it or a newly acquired session. Since transactions are not prewarmed, the session pool does not need
+to distinguish between read-only and read-write session/transaction pairs. In the statistics classes that may be used for diagnostic purposes all
+properties distinguishing between read-only and read-write statistics have been removed. Similarly, `Google.Cloud.Spanner.V1.SessionPoolOptions.WriteSessionsFraction`
+has bee removed.
+- BREAKING CHANGE: Remove Obsolete code that had been introduced before v5.0.0-beta01.
+
 ## Version 5.0.0-beta06, released 2025-04-14
 
 ### New features
@@ -206,7 +232,7 @@ as needed, mainly through inlining transaction creation in the first command tha
 Use instead `Google.Cloud.Spanner.V1.PooledSession.RefreshedOrNewAsync` which returns a new PooledSession instance that either represents the same
 session but with no transaction associated to it or a newly acquired session. Since transactions are not prewarmed, the session pool does not need
 to distinguish between read-only and read-write session/transaction pairs. In the statistics classes that may be used for diagnostic purposes all
-properties distinguising between read-only and read-write statistics have been removed. Similarly, `Google.Cloud.Spanner.V1.SessionPoolOptions.WriteSessionsFraction`
+properties distinguishing between read-only and read-write statistics have been removed. Similarly, `Google.Cloud.Spanner.V1.SessionPoolOptions.WriteSessionsFraction`
 has bee removed.
 
 ## Version 4.6.0, released 2023-06-26

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.csproj
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.0.0-beta06</Version>
+    <Version>5.0.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Low-level Google client library to access the Google Cloud Spanner API. The ADO.NET provider (Google.Cloud.Spanner.Data) which depends on this package is generally preferred for Spanner access.</Description>

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -5015,7 +5015,7 @@
       "protoPath": "google/spanner/admin/database/v1",
       "productName": "Google Cloud Spanner Database Administration",
       "productUrl": "https://cloud.google.com/spanner/",
-      "version": "5.0.0-beta06",
+      "version": "5.0.0",
       "commonResourcesConfig": "tweaks/Google.Cloud.Spanner.Common.V1/CommonResourcesConfig.json",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Spanner Database Admin API.",
@@ -5043,7 +5043,7 @@
       "protoPath": "google/spanner/admin/instance/v1",
       "productName": "Google Cloud Spanner Instance Administration",
       "productUrl": "https://cloud.google.com/spanner/",
-      "version": "5.0.0-beta06",
+      "version": "5.0.0",
       "commonResourcesConfig": "tweaks/Google.Cloud.Spanner.Common.V1/CommonResourcesConfig.json",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Spanner Instance Admin API.",
@@ -5068,7 +5068,7 @@
     {
       "id": "Google.Cloud.Spanner.Data",
       "targetFrameworks": "netstandard2.1;net462",
-      "version": "5.0.0-beta06",
+      "version": "5.0.0",
       "type": "other",
       "metadataType": "INTEGRATION",
       "description": "Google ADO.NET Provider for Google Cloud Spanner.",
@@ -5104,7 +5104,7 @@
     {
       "id": "Google.Cloud.Spanner.Common.V1",
       "type": "other",
-      "version": "5.0.0-beta06",
+      "version": "5.0.0",
       "description": "Common resource names used by all Spanner V1 APIs",
       "tags": [
         "Spanner"
@@ -5120,7 +5120,7 @@
       "protoPath": "google/spanner/v1",
       "productName": "Google Cloud Spanner",
       "productUrl": "https://cloud.google.com/spanner/",
-      "version": "5.0.0-beta06",
+      "version": "5.0.0",
       "commonResourcesConfig": "tweaks/Google.Cloud.Spanner.Common.V1/CommonResourcesConfig.json",
       "type": "grpc",
       "metadataType": "GAPIC_COMBO",


### PR DESCRIPTION
Changes in Google.Cloud.Spanner.Data version 5.0.0:

### New features

Note: V5.0.0 contains all the new features added in previous beta versions V5.0.0-beta0x. Here, we highlight those that introduced breaking changes with respect to previous stable versions V4.x.x.

- Transactions support SpannerTransactionCreationOptions and SpannerTransactionOptions. BREAKING CHANGE: SpannerConection methods that open a transaction, like BeginTransacion, Open and RunWithRetriableTransaction sets of methods now accept both option types as parameter, while some of the previously existing methods have been deprecated and will be removed on the next major version.
- After a successfull commit or rollback, the transaction is disposed. BREAKING CHANGE: Attempting to use a disposed transaction will result in a client side error. See the Google.Cloud.Spanner.Data.SpannerTransaction.DisposeBehavior documentation for more information.
- Add support for FLOAT32 BREAKING CHANGE: The default mapping for values of CLR type decimal was FLOAT64 and it is now Numeric. The default mapping for values of CLR type float was FLOAT64 and it is now FLOAT32.
- Support inline transactions. BREAKING CHANGE: In supporting inline transactions the main breaking change is behavioral: transactions are not prewarmed, instead they are acquired as needed, mainly through inlining transaction creation in the first command that attempts to use a transaction. The method `Google.Cloud.Spanner.V1.PooledSession.WithFreshTransactionOrNewAsync` has been removed, as a transaction is not created by the session until command execution. Use instead `Google.Cloud.Spanner.V1.PooledSession.RefreshedOrNewAsync` which returns a new PooledSession instance that either represents the same session but with no transaction associated to it or a newly acquired session. Since transactions are not prewarmed, the session pool does not need to distinguish between read-only and read-write session/transaction pairs. In the statistics classes that may be used for diagnostic purposes all properties distinguishing between read-only and read-write statistics have been removed. Similarly, `Google.Cloud.Spanner.V1.SessionPoolOptions.WriteSessionsFraction` has bee removed.
- BREAKING CHANGE: Remove Obsolete code that had been introduced before v5.0.0-beta01.

Packages in this release:
- Release Google.Cloud.Spanner.Admin.Database.V1 version 5.0.0
- Release Google.Cloud.Spanner.Admin.Instance.V1 version 5.0.0
- Release Google.Cloud.Spanner.Common.V1 version 5.0.0
- Release Google.Cloud.Spanner.Data version 5.0.0
- Release Google.Cloud.Spanner.V1 version 5.0.0