### PR TITLE
chore: Update release scripts to not clone the repo at a given commit.

### DIFF
--- a/buildrelease.sh
+++ b/buildrelease.sh
@@ -1,22 +1,14 @@
 #!/bin/bash
 
-# Script to perform a release build for all APIs tagged at
-# a specific commit. A single argument is required: the commit to use.
-
-# The repo is cloned into a fresh "releasebuild" directory.
+# Script to perform a release build for all APIs tagged at HEAD.
 
 set -e
 
-# Additional arguments:
+# Optional arguments:
 # --rebuild_docs: Just build the projects and docs, don't create nuget packages.
-#                 Also, use the latest to pick up new docs changes rather than
-#                 the commit of the tag.
 # --skip_tests: Skip the integration tests
-# --ssh: Use SSH to clone GitHub repos
 rebuild_docs=false
 run_tests=true
-clone_path_prefix="https://github.com/"
-commit=
 while (( "$#" )); do
   if [[ "$1" == "--rebuild_docs" ]]
   then
@@ -24,46 +16,26 @@ while (( "$#" )); do
   elif [[ "$1" == "--skip_tests" ]]
   then
     run_tests=false
-  elif [[ "$1" == "--ssh" ]]
-  then
-    clone_path_prefix="git@github.com:"
   else
-    commit=$1
+    echo "Incorrect arguments."
+  exit 1
   fi
   shift
 done
 
-if [ -z "$commit" ]
-then
-  echo "Please specify a commit hash"
-  exit 1
-fi
-
 # Do everything from the repository root for sanity.
 cd $(dirname $0)
-
-rm -rf releasebuild
-git clone ${clone_path_prefix}googleapis/google-cloud-dotnet.git releasebuild -c core.autocrlf=input --recursive
-
-cd releasebuild
 
 # Make sure the package is deterministic. We don't do this for local builds,
 # but it makes debugging work more reliably for PDBs in packages.
 export DeterministicSourcePaths=true
 
-if [[ "$rebuild_docs" = true ]]
-then
-  git checkout main
-else
-  git checkout $commit
-fi
-
-# Turn the multi-line output of git tag --points-at into space-separated list of projects
-projects=$(git tag --points-at $commit | sed 's/-.*//g' | awk -vORS=\  '{print $1}' | sed 's/ $//')
+# Turn the multi-line output of git tag into space-separated list of projects
+projects=$(git tag --points-at HEAD | sed 's/-.*//g' | awk -vORS=\  '{print $1}' | sed 's/ $//')
 
 if [ -z "$projects" ]
 then
-  echo "No tags found for commit $commit"
+  echo "No tags found for commit $(git rev-parse HEAD)"
   exit 1
 fi
 
@@ -80,9 +52,7 @@ fi
 
 ./build.sh $projects
 
-# Build LRO and IAM to make docs simpler. We always build the docs from "current" even if there's
-# a different package reference version... which means it's *possible* they'll be inaccurate,
-# but it's simpler than getting it perfectly correct.
+# Build LRO and IAM to make docs simpler.
 ./build.sh Google.LongRunning Google.Cloud.Iam.V1
 
 # Retry integration tests up to 3 times as they can sometimes


### PR DESCRIPTION
Instead, releases happen in place.