### PR TITLE
Release Google.Shopping.Merchant.Lfp.V1Beta version 1.0.0-beta03

### DIFF
--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.csproj
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta02</Version>
+    <Version>1.0.0-beta03</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Merchant Local Feeds Partnership (LFP) API (v1beta), which allows developers to programmatically manage their LFP resources.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Shopping.Type" VersionOverride="[1.0.0-beta05, 2.0.0)" />
+    <PackageReference Include="Google.Shopping.Type" VersionOverride="[1.0.0-beta06, 2.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/docs/history.md
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/docs/history.md
@@ -1,5 +1,21 @@
 # Version history
 
+## Version 1.0.0-beta03, released 2025-04-22
+
+### New features
+
+- Add GetLfpMerchantState method ([commit 1c15144](https://github.com/googleapis/google-cloud-dotnet/commit/1c15144da133dc7cbfb94edb11ab6893d45c7b69))
+
+### Documentation improvements
+
+- Change in wording : feed specification -> data specification ([commit db5030c](https://github.com/googleapis/google-cloud-dotnet/commit/db5030cfb68431dfa0aa62f9ccea20b2fd1c99f3))
+- A comment for field `availability` in message `.google.shopping.merchant.lfp.v1beta.LfpInventory` is changed ([commit db5030c](https://github.com/googleapis/google-cloud-dotnet/commit/db5030cfb68431dfa0aa62f9ccea20b2fd1c99f3))
+- A comment for field `pickup_method` in message `.google.shopping.merchant.lfp.v1beta.LfpInventory` is changed ([commit db5030c](https://github.com/googleapis/google-cloud-dotnet/commit/db5030cfb68431dfa0aa62f9ccea20b2fd1c99f3))
+- A comment for field `pickup_sla` in message `.google.shopping.merchant.lfp.v1beta.LfpInventory` is changed ([commit db5030c](https://github.com/googleapis/google-cloud-dotnet/commit/db5030cfb68431dfa0aa62f9ccea20b2fd1c99f3))
+- A comment for message `LfpStore` is changed ([commit db5030c](https://github.com/googleapis/google-cloud-dotnet/commit/db5030cfb68431dfa0aa62f9ccea20b2fd1c99f3))
+- A comment for enum `StoreMatchingState` is changed ([commit db5030c](https://github.com/googleapis/google-cloud-dotnet/commit/db5030cfb68431dfa0aa62f9ccea20b2fd1c99f3))
+- A comment for field `matching_state` in message `.google.shopping.merchant.lfp.v1beta.LfpStore` is changed ([commit db5030c](https://github.com/googleapis/google-cloud-dotnet/commit/db5030cfb68431dfa0aa62f9ccea20b2fd1c99f3))
+
 ## Version 1.0.0-beta02, released 2024-05-08
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -6517,7 +6517,7 @@
     },
     {
       "id": "Google.Shopping.Merchant.Lfp.V1Beta",
-      "version": "1.0.0-beta02",
+      "version": "1.0.0-beta03",
       "type": "grpc",
       "productName": "Merchant",
       "productUrl": "https://developers.google.com/merchant/api",
@@ -6529,7 +6529,7 @@
         "partnership"
       ],
       "dependencies": {
-        "Google.Shopping.Type": "1.0.0-beta05"
+        "Google.Shopping.Type": "1.0.0-beta06"
       },
       "generator": "micro",
       "protoPath": "google/shopping/merchant/lfp/v1beta",


### PR DESCRIPTION

Changes in this release:

### New features

- Add GetLfpMerchantState method ([commit 1c15144](https://github.com/googleapis/google-cloud-dotnet/commit/1c15144da133dc7cbfb94edb11ab6893d45c7b69))

### Documentation improvements

- Change in wording : feed specification -> data specification ([commit db5030c](https://github.com/googleapis/google-cloud-dotnet/commit/db5030cfb68431dfa0aa62f9ccea20b2fd1c99f3))
- A comment for field `availability` in message `.google.shopping.merchant.lfp.v1beta.LfpInventory` is changed ([commit db5030c](https://github.com/googleapis/google-cloud-dotnet/commit/db5030cfb68431dfa0aa62f9ccea20b2fd1c99f3))
- A comment for field `pickup_method` in message `.google.shopping.merchant.lfp.v1beta.LfpInventory` is changed ([commit db5030c](https://github.com/googleapis/google-cloud-dotnet/commit/db5030cfb68431dfa0aa62f9ccea20b2fd1c99f3))
- A comment for field `pickup_sla` in message `.google.shopping.merchant.lfp.v1beta.LfpInventory` is changed ([commit db5030c](https://github.com/googleapis/google-cloud-dotnet/commit/db5030cfb68431dfa0aa62f9ccea20b2fd1c99f3))
- A comment for message `LfpStore` is changed ([commit db5030c](https://github.com/googleapis/google-cloud-dotnet/commit/db5030cfb68431dfa0aa62f9ccea20b2fd1c99f3))
- A comment for enum `StoreMatchingState` is changed ([commit db5030c](https://github.com/googleapis/google-cloud-dotnet/commit/db5030cfb68431dfa0aa62f9ccea20b2fd1c99f3))
- A comment for field `matching_state` in message `.google.shopping.merchant.lfp.v1beta.LfpStore` is changed ([commit db5030c](https://github.com/googleapis/google-cloud-dotnet/commit/db5030cfb68431dfa0aa62f9ccea20b2fd1c99f3))
