### PR TITLE
Release Google.Analytics.Admin.V1Alpha version 2.0.0-alpha23

### DIFF
--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-alpha22</Version>
+    <Version>2.0.0-alpha23</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Analytics Admin API (v1alpha)</Description>

--- a/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
+++ b/apis/Google.Analytics.Admin.V1Alpha/docs/history.md
@@ -1,5 +1,29 @@
 # Version history
 
+## Version 2.0.0-alpha23, released 2025-04-23
+
+### Bug fixes
+
+- **BREAKING CHANGE** Change an existing value KEY_EVENT = 32 to KEY_EVENT = 30 in enum `ChangeHistoryResourceType`. ([commit 429adae](https://github.com/googleapis/google-cloud-dotnet/commit/429adaec6d69ba6a4ab415fb18b86a18472d1917))
+- **BREAKING CHANGE** Rename an existing field `key_event` to `reporting_data_annotation` in `ChangeHistoryChange`. ([commit 429adae](https://github.com/googleapis/google-cloud-dotnet/commit/429adaec6d69ba6a4ab415fb18b86a18472d1917))
+
+### New features
+
+- Add the `CreateReportingDataAnnotation` method ([commit 429adae](https://github.com/googleapis/google-cloud-dotnet/commit/429adaec6d69ba6a4ab415fb18b86a18472d1917))
+- Add the `GetReportingDataAnnotation` method ([commit 429adae](https://github.com/googleapis/google-cloud-dotnet/commit/429adaec6d69ba6a4ab415fb18b86a18472d1917))
+- Add the `ListReportingDataAnnotations` method ([commit 429adae](https://github.com/googleapis/google-cloud-dotnet/commit/429adaec6d69ba6a4ab415fb18b86a18472d1917))
+- Add the `UpdateReportingDataAnnotation` method ([commit 429adae](https://github.com/googleapis/google-cloud-dotnet/commit/429adaec6d69ba6a4ab415fb18b86a18472d1917))
+- Add the `DeleteReportingDataAnnotation` method ([commit 429adae](https://github.com/googleapis/google-cloud-dotnet/commit/429adaec6d69ba6a4ab415fb18b86a18472d1917))
+- Add the `SubmitUserDeletion` method ([commit 429adae](https://github.com/googleapis/google-cloud-dotnet/commit/429adaec6d69ba6a4ab415fb18b86a18472d1917))
+- Add the `REPORTING_DATA_ANNOTATION` resource type to the `ChangeHistoryResourceType` enum ([commit 429adae](https://github.com/googleapis/google-cloud-dotnet/commit/429adaec6d69ba6a4ab415fb18b86a18472d1917))
+- Add the `ReportingDataAnnotation` type ([commit 429adae](https://github.com/googleapis/google-cloud-dotnet/commit/429adaec6d69ba6a4ab415fb18b86a18472d1917))
+- Add `key_event`, `reporting_data_annotation` fields to the `ChangeHistoryResource` resource ([commit 429adae](https://github.com/googleapis/google-cloud-dotnet/commit/429adaec6d69ba6a4ab415fb18b86a18472d1917))
+
+### Documentation improvements
+
+- Announce the deprecation of the `sharing_with_google_any_sales_enabled` field of the `DataSharingSettings` type ([commit 429adae](https://github.com/googleapis/google-cloud-dotnet/commit/429adaec6d69ba6a4ab415fb18b86a18472d1917))
+- Update the documentation of `sharing_with_google_support_enabled`, `sharing_with_google_assigned_sales_enabled`, 'sharing_with_google_products_enabled', 'sharing_with_others_enabled' fields of the `DataSharingSettings` type ([commit 429adae](https://github.com/googleapis/google-cloud-dotnet/commit/429adaec6d69ba6a4ab415fb18b86a18472d1917))
+
 ## Version 2.0.0-alpha22, released 2025-03-10
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -46,7 +46,7 @@
     },
     {
       "id": "Google.Analytics.Admin.V1Alpha",
-      "version": "2.0.0-alpha22",
+      "version": "2.0.0-alpha23",
       "type": "grpc",
       "productName": "Analytics Admin",
       "productUrl": "https://developers.google.com/analytics",


### PR DESCRIPTION

Changes in this release:

### Bug fixes

- **BREAKING CHANGE** Change an existing value KEY_EVENT = 32 to KEY_EVENT = 30 in enum `ChangeHistoryResourceType`. ([commit 429adae](https://github.com/googleapis/google-cloud-dotnet/commit/429adaec6d69ba6a4ab415fb18b86a18472d1917))
- **BREAKING CHANGE** Rename an existing field `key_event` to `reporting_data_annotation` in `ChangeHistoryChange`. ([commit 429adae](https://github.com/googleapis/google-cloud-dotnet/commit/429adaec6d69ba6a4ab415fb18b86a18472d1917))

### New features

- Add the `CreateReportingDataAnnotation` method ([commit 429adae](https://github.com/googleapis/google-cloud-dotnet/commit/429adaec6d69ba6a4ab415fb18b86a18472d1917))
- Add the `GetReportingDataAnnotation` method ([commit 429adae](https://github.com/googleapis/google-cloud-dotnet/commit/429adaec6d69ba6a4ab415fb18b86a18472d1917))
- Add the `ListReportingDataAnnotations` method ([commit 429adae](https://github.com/googleapis/google-cloud-dotnet/commit/429adaec6d69ba6a4ab415fb18b86a18472d1917))
- Add the `UpdateReportingDataAnnotation` method ([commit 429adae](https://github.com/googleapis/google-cloud-dotnet/commit/429adaec6d69ba6a4ab415fb18b86a18472d1917))
- Add the `DeleteReportingDataAnnotation` method ([commit 429adae](https://github.com/googleapis/google-cloud-dotnet/commit/429adaec6d69ba6a4ab415fb18b86a18472d1917))
- Add the `SubmitUserDeletion` method ([commit 429adae](https://github.com/googleapis/google-cloud-dotnet/commit/429adaec6d69ba6a4ab415fb18b86a18472d1917))
- Add the `REPORTING_DATA_ANNOTATION` resource type to the `ChangeHistoryResourceType` enum ([commit 429adae](https://github.com/googleapis/google-cloud-dotnet/commit/429adaec6d69ba6a4ab415fb18b86a18472d1917))
- Add the `ReportingDataAnnotation` type ([commit 429adae](https://github.com/googleapis/google-cloud-dotnet/commit/429adaec6d69ba6a4ab415fb18b86a18472d1917))
- Add `key_event`, `reporting_data_annotation` fields to the `ChangeHistoryResource` resource ([commit 429adae](https://github.com/googleapis/google-cloud-dotnet/commit/429adaec6d69ba6a4ab415fb18b86a18472d1917))

### Documentation improvements

- Announce the deprecation of the `sharing_with_google_any_sales_enabled` field of the `DataSharingSettings` type ([commit 429adae](https://github.com/googleapis/google-cloud-dotnet/commit/429adaec6d69ba6a4ab415fb18b86a18472d1917))
- Update the documentation of `sharing_with_google_support_enabled`, `sharing_with_google_assigned_sales_enabled`, 'sharing_with_google_products_enabled', 'sharing_with_others_enabled' fields of the `DataSharingSettings` type ([commit 429adae](https://github.com/googleapis/google-cloud-dotnet/commit/429adaec6d69ba6a4ab415fb18b86a18472d1917))
