### PR TITLE
Release Google.Cloud.Compute.V1 version 3.9.0

### DIFF
--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.8.0</Version>
+    <Version>3.9.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Compute Engine API.</Description>

--- a/apis/Google.Cloud.Compute.V1/docs/history.md
+++ b/apis/Google.Cloud.Compute.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.9.0, released 2025-04-23
+
+### New features
+
+- Update Compute Engine API to revision 20250415 ([commit e91d81f](https://github.com/googleapis/google-cloud-dotnet/commit/e91d81fa071d24323bb24b8eb939e8b0193da2ad))
+
 ## Version 3.8.0, released 2025-03-31
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -1588,7 +1588,7 @@
     },
     {
       "id": "Google.Cloud.Compute.V1",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "type": "regapic",
       "productName": "Compute Engine",
       "productUrl": "https://cloud.google.com/compute",


### PR DESCRIPTION

Changes in this release:

### New features

- Update Compute Engine API to revision 20250415 ([commit e91d81f](https://github.com/googleapis/google-cloud-dotnet/commit/e91d81fa071d24323bb24b8eb939e8b0193da2ad))
