### PR TITLE
Release Google.Cloud.DataCatalog.V1 version 2.16.0

### DIFF
--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.15.0</Version>
+    <Version>2.16.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Data Catalog API. Data Catalog is a fully managed and highly scalable data discovery and metadata management service.</Description>

--- a/apis/Google.Cloud.DataCatalog.V1/docs/history.md
+++ b/apis/Google.Cloud.DataCatalog.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.16.0, released 2025-04-23
+
+### New features
+
+- Add field `template_migration_enabled_time` to `.google.cloud.datacatalog.v1.MigrationConfig` ([commit 73c0722](https://github.com/googleapis/google-cloud-dotnet/commit/73c0722ef48ffe5c3ed668a1176ee153abfd98c7))
+
+### Documentation improvements
+
+- A comment for field `sql_resource` in message `.google.cloud.datacatalog.v1.LookupEntryRequest` is changed ([commit cb21a9f](https://github.com/googleapis/google-cloud-dotnet/commit/cb21a9f0d4751fa0d03f3b2f1020a0b900b56fb7))
+
 ## Version 2.15.0, released 2025-03-17
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -1780,7 +1780,7 @@
       "protoPath": "google/cloud/datacatalog/v1",
       "productName": "Data Catalog",
       "productUrl": "https://cloud.google.com/data-catalog/docs",
-      "version": "2.15.0",
+      "version": "2.16.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Data Catalog API. Data Catalog is a fully managed and highly scalable data discovery and metadata management service.",
       "tags": [


### PR DESCRIPTION

Changes in this release:

### New features

- Add field `template_migration_enabled_time` to `.google.cloud.datacatalog.v1.MigrationConfig` ([commit 73c0722](https://github.com/googleapis/google-cloud-dotnet/commit/73c0722ef48ffe5c3ed668a1176ee153abfd98c7))

### Documentation improvements

- A comment for field `sql_resource` in message `.google.cloud.datacatalog.v1.LookupEntryRequest` is changed ([commit cb21a9f](https://github.com/googleapis/google-cloud-dotnet/commit/cb21a9f0d4751fa0d03f3b2f1020a0b900b56fb7))
