### PR TITLE
Release Google.Cloud.DocumentAI.V1 version 3.20.0

### DIFF
--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.19.0</Version>
+    <Version>3.20.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Document AI API (v1), which is a service to parse structured information from unstructured or semi-structured documents using state-of-the-art Google AI such as natural language, computer vision, translation, and AutoML.</Description>

--- a/apis/Google.Cloud.DocumentAI.V1/docs/history.md
+++ b/apis/Google.Cloud.DocumentAI.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.20.0, released 2025-04-23
+
+### New features
+
+- Added a field for enabling returning images and bounding boxes from layout parser processor ([commit 237192a](https://github.com/googleapis/google-cloud-dotnet/commit/237192a2a612fbb9f6a09a6cc4f3726f07f96c8c))
+
 ## Version 3.19.0, released 2024-10-29
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -2327,7 +2327,7 @@
     },
     {
       "id": "Google.Cloud.DocumentAI.V1",
-      "version": "3.19.0",
+      "version": "3.20.0",
       "type": "grpc",
       "productName": "Cloud Document AI",
       "productUrl": "https://cloud.google.com/solutions/document-ai",


### PR DESCRIPTION

Changes in this release:

### New features

- Added a field for enabling returning images and bounding boxes from layout parser processor ([commit 237192a](https://github.com/googleapis/google-cloud-dotnet/commit/237192a2a612fbb9f6a09a6cc4f3726f07f96c8c))
