### PR TITLE
Release Google.Cloud.GdcHardwareManagement.V1Alpha version 1.0.0-alpha05

### DIFF
--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.csproj
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha04</Version>
+    <Version>1.0.0-alpha05</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Distributed Cloud Hardware Management API (v1alpha)</Description>

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/docs/history.md
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/docs/history.md
@@ -1,5 +1,17 @@
 # Version history
 
+## Version 1.0.0-alpha05, released 2025-04-23
+
+### New features
+
+- Accept status updates in the SignalZoneState method ([commit 7e53181](https://github.com/googleapis/google-cloud-dotnet/commit/7e5318134552ebc36ee215f64aabe7b3804a8c1e))
+- Expose the allowed hardware count for each SKU ([commit 7e53181](https://github.com/googleapis/google-cloud-dotnet/commit/7e5318134552ebc36ee215f64aabe7b3804a8c1e))
+- Add deployment type and installation dates to orders ([commit 7e53181](https://github.com/googleapis/google-cloud-dotnet/commit/7e5318134552ebc36ee215f64aabe7b3804a8c1e))
+
+### Documentation improvements
+
+- Make billing_id an output-only field ([commit 7e53181](https://github.com/googleapis/google-cloud-dotnet/commit/7e5318134552ebc36ee215f64aabe7b3804a8c1e))
+
 ## Version 1.0.0-alpha04, released 2024-11-18
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -2778,7 +2778,7 @@
     },
     {
       "id": "Google.Cloud.GdcHardwareManagement.V1Alpha",
-      "version": "1.0.0-alpha04",
+      "version": "1.0.0-alpha05",
       "type": "grpc",
       "productName": "GDC Hardware Management",
       "productUrl": "https://cloud.google.com/distributed-cloud/edge/latest/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Accept status updates in the SignalZoneState method ([commit 7e53181](https://github.com/googleapis/google-cloud-dotnet/commit/7e5318134552ebc36ee215f64aabe7b3804a8c1e))
- Expose the allowed hardware count for each SKU ([commit 7e53181](https://github.com/googleapis/google-cloud-dotnet/commit/7e5318134552ebc36ee215f64aabe7b3804a8c1e))
- Add deployment type and installation dates to orders ([commit 7e53181](https://github.com/googleapis/google-cloud-dotnet/commit/7e5318134552ebc36ee215f64aabe7b3804a8c1e))

### Documentation improvements

- Make billing_id an output-only field ([commit 7e53181](https://github.com/googleapis/google-cloud-dotnet/commit/7e5318134552ebc36ee215f64aabe7b3804a8c1e))
