### PR TITLE
Release Google.Cloud.GkeBackup.V1 version 2.7.0

### DIFF
--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.csproj
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Backup for GKE API, which is a managed Kubernetes workload backup and restore service for GKE clusters.</Description>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.3.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.3.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />

--- a/apis/Google.Cloud.GkeBackup.V1/docs/history.md
+++ b/apis/Google.Cloud.GkeBackup.V1/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+## Version 2.7.0, released 2025-04-23
+
+### New features
+
+- Adding new BackupChannel, RestoreChannel, BackupPlanBinding and RestorePlanBinding ([commit 0ae7a96](https://github.com/googleapis/google-cloud-dotnet/commit/0ae7a9678d9a731ecb4b2dd219f3b8bb05e9e97e))
+- Generation of new cross project APIs ([commit 0ae7a96](https://github.com/googleapis/google-cloud-dotnet/commit/0ae7a9678d9a731ecb4b2dd219f3b8bb05e9e97e))
+- Adding `last_successful_backup_time` field in BackupPlan ([commit 0ae7a96](https://github.com/googleapis/google-cloud-dotnet/commit/0ae7a9678d9a731ecb4b2dd219f3b8bb05e9e97e))
+- Adding `VALIDATING` enum in state field of restore.proto ([commit 0ae7a96](https://github.com/googleapis/google-cloud-dotnet/commit/0ae7a9678d9a731ecb4b2dd219f3b8bb05e9e97e))
+- Adding `CLEANED_UP` enum in state field of volume.proto ([commit 0ae7a96](https://github.com/googleapis/google-cloud-dotnet/commit/0ae7a9678d9a731ecb4b2dd219f3b8bb05e9e97e))
+
+### Documentation improvements
+
+- Minor documentation fixes ([commit 0ae7a96](https://github.com/googleapis/google-cloud-dotnet/commit/0ae7a9678d9a731ecb4b2dd219f3b8bb05e9e97e))
+
 ## Version 2.6.0, released 2024-06-04
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -2801,7 +2801,7 @@
     },
     {
       "id": "Google.Cloud.GkeBackup.V1",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "type": "grpc",
       "productName": "Backup for GKE",
       "productUrl": "https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke",
@@ -2812,7 +2812,7 @@
         "backup"
       ],
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.3.0",
+        "Google.Cloud.Iam.V1": "3.4.0",
         "Google.Cloud.Location": "2.3.0",
         "Google.LongRunning": "3.3.0"
       },


### PR DESCRIPTION

Changes in this release:

### New features

- Adding new BackupChannel, RestoreChannel, BackupPlanBinding and RestorePlanBinding ([commit 0ae7a96](https://github.com/googleapis/google-cloud-dotnet/commit/0ae7a9678d9a731ecb4b2dd219f3b8bb05e9e97e))
- Generation of new cross project APIs ([commit 0ae7a96](https://github.com/googleapis/google-cloud-dotnet/commit/0ae7a9678d9a731ecb4b2dd219f3b8bb05e9e97e))
- Adding `last_successful_backup_time` field in BackupPlan ([commit 0ae7a96](https://github.com/googleapis/google-cloud-dotnet/commit/0ae7a9678d9a731ecb4b2dd219f3b8bb05e9e97e))
- Adding `VALIDATING` enum in state field of restore.proto ([commit 0ae7a96](https://github.com/googleapis/google-cloud-dotnet/commit/0ae7a9678d9a731ecb4b2dd219f3b8bb05e9e97e))
- Adding `CLEANED_UP` enum in state field of volume.proto ([commit 0ae7a96](https://github.com/googleapis/google-cloud-dotnet/commit/0ae7a9678d9a731ecb4b2dd219f3b8bb05e9e97e))

### Documentation improvements

- Minor documentation fixes ([commit 0ae7a96](https://github.com/googleapis/google-cloud-dotnet/commit/0ae7a9678d9a731ecb4b2dd219f3b8bb05e9e97e))
