### PR TITLE
Release Google.Cloud.SecretManager.V1Beta1 version 3.0.0-beta06

### DIFF
--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.csproj
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-beta05</Version>
+    <Version>3.0.0-beta06</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Secret Manager API version v1beta1.</Description>
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.2.0, 3.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.4.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.3.0, 3.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.SecretManager.V1Beta1/docs/history.md
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/docs/history.md
@@ -1,5 +1,10 @@
 # Version history
 
+## Version 3.0.0-beta06, released 2025-04-23
+
+### Documentation improvements
+
+- Various documentation clarifications ([commit cbea91b](https://github.com/googleapis/google-cloud-dotnet/commit/cbea91b0420147c508ce9419d38b7397d032d4f3))
 ## Version 3.0.0-beta05, released 2024-05-14
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -4656,13 +4656,13 @@
       "protoPath": "google/cloud/secrets/v1beta1",
       "productName": "Secret Manager",
       "productUrl": "https://cloud.google.com/secret-manager",
-      "version": "3.0.0-beta05",
+      "version": "3.0.0-beta06",
       "releaseLevelOverride": "preview",
       "type": "grpc",
       "description": "Recommended Google client library to access the Secret Manager API version v1beta1.",
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.2.0",
-        "Google.Cloud.Location": "2.2.0"
+        "Google.Cloud.Iam.V1": "3.4.0",
+        "Google.Cloud.Location": "2.3.0"
       },
       "tags": [
         "secret",


### PR DESCRIPTION

Changes in this release:

### Documentation improvements

- Various documentation clarifications ([commit cbea91b](https://github.com/googleapis/google-cloud-dotnet/commit/cbea91b0420147c508ce9419d38b7397d032d4f3))
