### PR TITLE
chore: Add shortName fields in the API catalog for Spanner and Bigtable

### DIFF
--- a/apis/Google.Cloud.Bigtable.Common.V2/.repo-metadata.json
+++ b/apis/Google.Cloud.Bigtable.Common.V2/.repo-metadata.json
@@ -3,5 +3,6 @@
   "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Bigtable.Common.V2/latest",
   "library_type": "OTHER",
-  "language": "dotnet"
+  "language": "dotnet",
+  "api_shortname": "bigtable"
 }

--- a/apis/Google.Cloud.Spanner.Common.V1/.repo-metadata.json
+++ b/apis/Google.Cloud.Spanner.Common.V1/.repo-metadata.json
@@ -3,5 +3,6 @@
   "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Spanner.Common.V1/latest",
   "library_type": "OTHER",
-  "language": "dotnet"
+  "language": "dotnet",
+  "api_shortname": "spanner"
 }

--- a/apis/Google.Cloud.Spanner.Data/.repo-metadata.json
+++ b/apis/Google.Cloud.Spanner.Data/.repo-metadata.json
@@ -3,5 +3,6 @@
   "release_level": "stable",
   "client_documentation": "https://cloud.google.com/dotnet/docs/reference/Google.Cloud.Spanner.Data/latest",
   "library_type": "INTEGRATION",
-  "language": "dotnet"
+  "language": "dotnet",
+  "api_shortname": "spanner"
 }

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -1187,6 +1187,7 @@
       "type": "other",
       "version": "3.2.0",
       "description": "Common code used by Bigtable V2 APIs",
+      "shortName": "bigtable",
       "tags": [
         "Bigtable"
       ],
@@ -5099,6 +5100,7 @@
       "version": "5.0.0",
       "type": "other",
       "metadataType": "INTEGRATION",
+      "shortName": "spanner",
       "description": "Google ADO.NET Provider for Google Cloud Spanner.",
       "tags": [
         "Spanner",
@@ -5134,6 +5136,7 @@
       "type": "other",
       "version": "5.0.0",
       "description": "Common resource names used by all Spanner V1 APIs",
+      "shortName": "spanner",
       "tags": [
         "Spanner"
       ],


### PR DESCRIPTION
These are for libraries which aren't purely generated, but still need to be linked appropriately from docs.

Fixes b/412767523