### PR TITLE
Release Google.Cloud.Storage.V1 version 4.13.0

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>4.12.0</Version>
+    <Version>4.13.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.</Description>

--- a/apis/Google.Cloud.Storage.V1/docs/history.md
+++ b/apis/Google.Cloud.Storage.V1/docs/history.md
@@ -1,6 +1,13 @@
 # Version history
 
+## Version 4.13.0, released 2025-04-25
+
+This is effectively a re-release of 4.12.0 to fix the release
+pipeline. (There will never be a NuGet package for 4.12.0.)
+
 ## Version 4.12.0, released 2025-04-24
+
+Note: this release failed, and is replaced by 4.13.0.
 
 ### New features
 

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -5275,7 +5275,7 @@
       "id": "Google.Cloud.Storage.V1",
       "productName": "Google Cloud Storage",
       "productUrl": "https://cloud.google.com/storage/",
-      "version": "4.12.0",
+      "version": "4.13.0",
       "type": "rest",
       "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
       "dependencies": {


### PR DESCRIPTION

Changes in this release:

This is effectively a re-release of 4.12.0 to fix the release pipeline. (There will never be a NuGet package for 4.12.0.)
