### PR TITLE
Release Google.Cloud.Asset.V1 version 3.13.0

### DIFF
--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.12.0</Version>
+    <Version>3.13.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Asset Inventory API (v1).</Description>
@@ -10,11 +10,11 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.4.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.OrgPolicy.V1" VersionOverride="[3.2.0, 4.0.0)" />
-    <PackageReference Include="Google.Cloud.OsConfig.V1" VersionOverride="[2.3.0, 3.0.0)" />
-    <PackageReference Include="Google.Identity.AccessContextManager.V1" VersionOverride="[2.4.0, 3.0.0)" />
-    <PackageReference Include="Google.LongRunning" VersionOverride="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.OsConfig.V1" VersionOverride="[2.4.0, 3.0.0)" />
+    <PackageReference Include="Google.Identity.AccessContextManager.V1" VersionOverride="[2.5.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" VersionOverride="[3.3.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/apis/Google.Cloud.Asset.V1/docs/history.md
+++ b/apis/Google.Cloud.Asset.V1/docs/history.md
@@ -1,5 +1,25 @@
 # Version history
 
+## Version 3.13.0, released 2025-04-28
+
+### New features
+
+- A new message `ResourceOwners` is added ([commit f8d84ba](https://github.com/googleapis/google-cloud-dotnet/commit/f8d84babb77910cc432d74e149ea243fa4741d7d))
+- A new value `REMOVE_GRANT` is added to enum `MethodType` ([commit f8d84ba](https://github.com/googleapis/google-cloud-dotnet/commit/f8d84babb77910cc432d74e149ea243fa4741d7d))
+- A new value `GOVERN_TAGS` is added to enum `MethodType` ([commit f8d84ba](https://github.com/googleapis/google-cloud-dotnet/commit/f8d84babb77910cc432d74e149ea243fa4741d7d))
+- A new message `AssetEnrichment` is added ([commit f8d84ba](https://github.com/googleapis/google-cloud-dotnet/commit/f8d84babb77910cc432d74e149ea243fa4741d7d))
+- A new field `enrichments` is added to message `.google.cloud.asset.v1.ResourceSearchResult` ([commit f8d84ba](https://github.com/googleapis/google-cloud-dotnet/commit/f8d84babb77910cc432d74e149ea243fa4741d7d))
+
+### Documentation improvements
+
+- A comment for field `service_account_impersonation_analysis` in message `.google.cloud.asset.v1.AnalyzeIamPolicyResponse` is changed ([commit f8d84ba](https://github.com/googleapis/google-cloud-dotnet/commit/f8d84babb77910cc432d74e149ea243fa4741d7d))
+- A comment for field `consolidated_policy` in message `.google.cloud.asset.v1.AnalyzeOrgPoliciesResponse` is changed ([commit f8d84ba](https://github.com/googleapis/google-cloud-dotnet/commit/f8d84babb77910cc432d74e149ea243fa4741d7d))
+- A comment for field `policy_bundle` in message `.google.cloud.asset.v1.AnalyzeOrgPoliciesResponse` is changed ([commit f8d84ba](https://github.com/googleapis/google-cloud-dotnet/commit/f8d84babb77910cc432d74e149ea243fa4741d7d))
+- A comment for field `policy_bundle` in message `.google.cloud.asset.v1.AnalyzeOrgPolicyGovernedContainersResponse` is changed ([commit f8d84ba](https://github.com/googleapis/google-cloud-dotnet/commit/f8d84babb77910cc432d74e149ea243fa4741d7d))
+- A comment for field `policy_bundle` in message `.google.cloud.asset.v1.AnalyzeOrgPolicyGovernedAssetsResponse` is changed ([commit f8d84ba](https://github.com/googleapis/google-cloud-dotnet/commit/f8d84babb77910cc432d74e149ea243fa4741d7d))
+- A comment for field `attached_resource` in message `.google.cloud.asset.v1.EffectiveTagDetails` is changed ([commit f8d84ba](https://github.com/googleapis/google-cloud-dotnet/commit/f8d84babb77910cc432d74e149ea243fa4741d7d))
+- Comments are clarified for certain fields in messages `QueryAssetsResponse` and `ResourceSearchResult` ([commit dabdcad](https://github.com/googleapis/google-cloud-dotnet/commit/dabdcadfd6dd65693b9059d775d5919951109556))
+
 ## Version 3.12.0, released 2024-05-13
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -636,15 +636,15 @@
       "protoPath": "google/cloud/asset/v1",
       "productName": "Google Cloud Asset Inventory",
       "productUrl": "https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview",
-      "version": "3.12.0",
+      "version": "3.13.0",
       "type": "grpc",
       "description": "Recommended Google client library to access the Google Cloud Asset Inventory API (v1).",
       "dependencies": {
-        "Google.Cloud.Iam.V1": "3.2.0",
+        "Google.Cloud.Iam.V1": "3.4.0",
         "Google.Cloud.OrgPolicy.V1": "3.2.0",
-        "Google.Cloud.OsConfig.V1": "2.3.0",
-        "Google.Identity.AccessContextManager.V1": "2.4.0",
-        "Google.LongRunning": "3.2.0"
+        "Google.Cloud.OsConfig.V1": "2.4.0",
+        "Google.Identity.AccessContextManager.V1": "2.5.0",
+        "Google.LongRunning": "3.3.0"
       },
       "tags": [
         "asset",


### PR DESCRIPTION

Changes in this release:

### New features

- A new message `ResourceOwners` is added ([commit f8d84ba](https://github.com/googleapis/google-cloud-dotnet/commit/f8d84babb77910cc432d74e149ea243fa4741d7d))
- A new value `REMOVE_GRANT` is added to enum `MethodType` ([commit f8d84ba](https://github.com/googleapis/google-cloud-dotnet/commit/f8d84babb77910cc432d74e149ea243fa4741d7d))
- A new value `GOVERN_TAGS` is added to enum `MethodType` ([commit f8d84ba](https://github.com/googleapis/google-cloud-dotnet/commit/f8d84babb77910cc432d74e149ea243fa4741d7d))
- A new message `AssetEnrichment` is added ([commit f8d84ba](https://github.com/googleapis/google-cloud-dotnet/commit/f8d84babb77910cc432d74e149ea243fa4741d7d))
- A new field `enrichments` is added to message `.google.cloud.asset.v1.ResourceSearchResult` ([commit f8d84ba](https://github.com/googleapis/google-cloud-dotnet/commit/f8d84babb77910cc432d74e149ea243fa4741d7d))

### Documentation improvements

- A comment for field `service_account_impersonation_analysis` in message `.google.cloud.asset.v1.AnalyzeIamPolicyResponse` is changed ([commit f8d84ba](https://github.com/googleapis/google-cloud-dotnet/commit/f8d84babb77910cc432d74e149ea243fa4741d7d))
- A comment for field `consolidated_policy` in message `.google.cloud.asset.v1.AnalyzeOrgPoliciesResponse` is changed ([commit f8d84ba](https://github.com/googleapis/google-cloud-dotnet/commit/f8d84babb77910cc432d74e149ea243fa4741d7d))
- A comment for field `policy_bundle` in message `.google.cloud.asset.v1.AnalyzeOrgPoliciesResponse` is changed ([commit f8d84ba](https://github.com/googleapis/google-cloud-dotnet/commit/f8d84babb77910cc432d74e149ea243fa4741d7d))
- A comment for field `policy_bundle` in message `.google.cloud.asset.v1.AnalyzeOrgPolicyGovernedContainersResponse` is changed ([commit f8d84ba](https://github.com/googleapis/google-cloud-dotnet/commit/f8d84babb77910cc432d74e149ea243fa4741d7d))
- A comment for field `policy_bundle` in message `.google.cloud.asset.v1.AnalyzeOrgPolicyGovernedAssetsResponse` is changed ([commit f8d84ba](https://github.com/googleapis/google-cloud-dotnet/commit/f8d84babb77910cc432d74e149ea243fa4741d7d))
- A comment for field `attached_resource` in message `.google.cloud.asset.v1.EffectiveTagDetails` is changed ([commit f8d84ba](https://github.com/googleapis/google-cloud-dotnet/commit/f8d84babb77910cc432d74e149ea243fa4741d7d))
- Comments are clarified for certain fields in messages `QueryAssetsResponse` and `ResourceSearchResult` ([commit dabdcad](https://github.com/googleapis/google-cloud-dotnet/commit/dabdcadfd6dd65693b9059d775d5919951109556))
