### PR TITLE
Release Google.Cloud.DocumentAI.V1Beta3 version 2.0.0-beta25

### DIFF
--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta24</Version>
+    <Version>2.0.0-beta25</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Document AI API (v1beta3), which is a service to parse structured information from unstructured or semi-structured documents using state-of-the-art Google AI such as natural language, computer vision, translation, and AutoML.</Description>

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/docs/history.md
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 2.0.0-beta25, released 2025-04-28
+
+### New features
+
+- Added config options to enable image annotation ([commit 7e02ca8](https://github.com/googleapis/google-cloud-dotnet/commit/7e02ca8c5f7fe43124026f9550cc00e002e9409c))
+- Add image block and blob asset in Document proto ([commit 2d344c0](https://github.com/googleapis/google-cloud-dotnet/commit/2d344c0f62d7a544101870aba929cea850e23b43))
+
 ## Version 2.0.0-beta24, released 2025-03-24
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -2354,7 +2354,7 @@
     },
     {
       "id": "Google.Cloud.DocumentAI.V1Beta3",
-      "version": "2.0.0-beta24",
+      "version": "2.0.0-beta25",
       "type": "grpc",
       "productName": "Cloud Document AI",
       "productUrl": "https://cloud.google.com/solutions/document-ai",


### PR DESCRIPTION

Changes in this release:

### New features

- Added config options to enable image annotation ([commit 7e02ca8](https://github.com/googleapis/google-cloud-dotnet/commit/7e02ca8c5f7fe43124026f9550cc00e002e9409c))
- Add image block and blob asset in Document proto ([commit 2d344c0](https://github.com/googleapis/google-cloud-dotnet/commit/2d344c0f62d7a544101870aba929cea850e23b43))
