### PR TITLE
tools: Allow an explicit value of "adc" for the credentials path

### DIFF
--- a/docs/generate-devsite-help.sh
+++ b/docs/generate-devsite-help.sh
@@ -15,7 +15,7 @@ if [[ "$2" != "" ]]
 then
   declare -r SERVICE_ACCOUNT_JSON=$2
 else
-  declare -r SERVICE_ACCOUNT_JSON=""
+  declare -r SERVICE_ACCOUNT_JSON=adc
 fi
 
 declare -r DEVSITE_STAGING_BUCKET=docs-staging-v2

--- a/docs/generate-devsite-utilities.sh
+++ b/docs/generate-devsite-utilities.sh
@@ -28,7 +28,7 @@ if [[ "$3" != "" ]]
 then
   declare -r SERVICE_ACCOUNT_JSON=$3
 else
-  declare -r SERVICE_ACCOUNT_JSON=""
+  declare -r SERVICE_ACCOUNT_JSON=adc
 fi
 
 set -eu -o pipefail

--- a/tools/Google.Cloud.Tools.DocUploader/Program.cs
+++ b/tools/Google.Cloud.Tools.DocUploader/Program.cs
@@ -87,7 +87,7 @@ Metadata GetMetadataFromJsonFile(string metadataFilePath)
 void UploadFile(MemoryStream memoryStream, string destination, string bucketName, string credentialsPath)
 {
     // Create a new Storage client.
-    StorageClient client = string.IsNullOrWhiteSpace(credentialsPath)
+    StorageClient client = string.IsNullOrWhiteSpace(credentialsPath) || credentialsPath == "adc"
         ? StorageClient.Create()
         : StorageClient.Create(GoogleCredential.FromFile(credentialsPath));
     client.UploadObject(bucketName, destination, null, memoryStream);

--- a/tools/Google.Cloud.Tools.DocUploader/UploadFileOptions.cs
+++ b/tools/Google.Cloud.Tools.DocUploader/UploadFileOptions.cs
@@ -29,7 +29,7 @@ public class UploadFileOptions
     [Option("staging-bucket", Default = "docs-resources", HelpText = "The bucket to upload the staged documentation to.")]
     public string StagingBucket { get; set; }
 
-    [Option("credentials", Required = false, HelpText = "Path to the credentials file to use for Google Cloud Storage.")]
+    [Option("credentials", Required = false, HelpText = "Path to the credentials file to use for Google Cloud Storage. When not specified, or explicitly specified as 'adc', application default credentials are used.")]
     public string Credentials { get; set; }
 
     [Option("metadata-file", Required = false, HelpText = "Path to the docs.metadata file. The path must be relative to the CWD.")]

--- a/uploaddocs.sh
+++ b/uploaddocs.sh
@@ -14,7 +14,7 @@ declare -r DOCS_OUTPUT_DIR=$2
 
 if [[ -z "$5" ]]
 then
-  declare -r SERVICE_ACCOUNT_JSON=""
+  declare -r SERVICE_ACCOUNT_JSON=adc
   declare -r GOOGLEAPIS_DEV_STAGING_BUCKET=$3
   declare -r DEVSITE_STAGING_BUCKET=$4
 else


### PR DESCRIPTION
It's easier to specify a non-empty value than an empty one on the command line.