### PR TITLE
Release Google.Cloud.AIPlatform.V1 version 3.26.0

### DIFF
--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.25.0</Version>
+    <Version>3.26.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Vertex AI API (v1), which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1/docs/history.md
@@ -1,5 +1,12 @@
 # Version history
 
+## Version 3.26.0, released 2025-04-29
+
+### New features
+
+- Adding ThinkingConfig to v1 client library ([commit cb44e6e](https://github.com/googleapis/google-cloud-dotnet/commit/cb44e6e4235d928bdddf3a46172367ccc726da5b))
+- Model Registry Model Checkpoint API ([commit b698c85](https://github.com/googleapis/google-cloud-dotnet/commit/b698c85f1cc0379dd5703887cfaa52fcee11139a))
+
 ## Version 3.25.0, released 2025-03-31
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -397,7 +397,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1",
-      "version": "3.25.0",
+      "version": "3.26.0",
       "type": "grpc",
       "productName": "Vertex AI",
       "productUrl": "https://cloud.google.com/vertex-ai/docs",


### PR DESCRIPTION

Changes in this release:

### New features

- Adding ThinkingConfig to v1 client library ([commit cb44e6e](https://github.com/googleapis/google-cloud-dotnet/commit/cb44e6e4235d928bdddf3a46172367ccc726da5b))
- Model Registry Model Checkpoint API ([commit b698c85](https://github.com/googleapis/google-cloud-dotnet/commit/b698c85f1cc0379dd5703887cfaa52fcee11139a))
