### PR TITLE
feat: Make SourceLink work when building in containers

### DIFF
--- a/generator-input/pipeline-config.json
+++ b/generator-input/pipeline-config.json
@@ -1,5 +1,13 @@
 {
   "commands": {
+    "build-library": {
+      "environmentVariables": [
+        {
+          "name": "SOURCELINK_REPO",
+          "defaultValue": "https://github.com/googleapis/google-cloud-dotnet"
+        }
+      ]
+    },
     "integration-test-library": {
       "environmentVariables": [
         {
@@ -8,6 +16,10 @@
         },
         {
           "name": "INTEGRATION_TEST_SERVICE_ACCOUNT_JSON"
+        },
+        {
+          "name": "SOURCELINK_REPO",
+          "defaultValue": "https://github.com/googleapis/google-cloud-dotnet"
         }
       ]
     },
@@ -16,6 +28,10 @@
         {
           "name": "DOCS_METADATA_REPO",
           "defaultValue": "googleapis/google-cloud-dotnet"
+        },
+        {
+          "name": "SOURCELINK_REPO",
+          "defaultValue": "https://github.com/googleapis/google-cloud-dotnet"
         }
       ]
     }

--- a/tools/Google.Cloud.Tools.ReleaseManager/ContainerCommands/BuildLibraryCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/ContainerCommands/BuildLibraryCommand.cs
@@ -32,6 +32,9 @@ public class BuildLibraryCommand : IContainerCommand
     public int Execute(ContainerOptions options)
     {
         var repoRoot = options.RequireOption(options.RepoRoot);
+
+        using var _ = SourceLinkFixer.Create(repoRoot);
+
         var rootLayout = RootLayout.ForRepositoryRoot(repoRoot);
         var catalog = ApiCatalog.Load(rootLayout);
         var apis = options.GetApisFromLibraryId(catalog);

--- a/tools/Google.Cloud.Tools.ReleaseManager/ContainerCommands/IntegrationTestLibraryCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/ContainerCommands/IntegrationTestLibraryCommand.cs
@@ -28,6 +28,8 @@ internal class IntegrationTestLibraryCommand : IContainerCommand
     {
         MaybeSaveServiceAccount();
         var repoRoot = options.RequireOption(options.RepoRoot);
+        using var _ = SourceLinkFixer.Create(repoRoot);
+
         var rootLayout = RootLayout.ForRepositoryRoot(repoRoot);
         var catalog = ApiCatalog.Load(rootLayout);
         var apis = options.GetApisFromLibraryId(catalog);

--- a/tools/Google.Cloud.Tools.ReleaseManager/ContainerCommands/SourceLinkFixer.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/ContainerCommands/SourceLinkFixer.cs
@@ -1,0 +1,68 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License"):
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using LibGit2Sharp;
+using System;
+
+namespace Google.Cloud.Tools.ReleaseManager.ContainerCommands;
+
+/// <summary>
+/// Helper to add a remote to the local repo and tell SourceLink to use that remote
+/// when building, to avoid problems when we're building from a private repo. This implements
+/// IDisposable so that the remote can be removed automatically. If the SOURCELINK_REPO environment
+/// variable hasn't been set, or the GitRepositoryRemoteName environment variable *has* already been
+/// set, this is a no-op.
+/// </summary>
+internal sealed class SourceLinkFixer : IDisposable
+{
+    private readonly Repository _repository;
+
+    // The environment variable populated by Librarian to tell us where SourceLink should point.
+    private const string SourceLinkRepoEnvironmentVariable = "SOURCELINK_REPO";
+
+    // The MS Build property we need to set to the remote name.
+    private const string MsBuildProperty = "GitRepositoryRemoteName";
+
+    private const string RemoteName = "sourcelink";
+
+    private SourceLinkFixer(Repository repository)
+    {
+        this._repository = repository;
+    }
+
+    internal static SourceLinkFixer Create(string repoRoot)
+    {
+        string url = Environment.GetEnvironmentVariable(SourceLinkRepoEnvironmentVariable);
+        string existingProperty = Environment.GetEnvironmentVariable(MsBuildProperty);
+        if (string.IsNullOrEmpty(url) || !string.IsNullOrEmpty(existingProperty))
+        {
+            return new SourceLinkFixer(null);
+        }
+        var repository = new Repository(repoRoot);
+        repository.Network.Remotes.Add(RemoteName, url);
+        Environment.SetEnvironmentVariable(MsBuildProperty, RemoteName);
+        return new SourceLinkFixer(repository);
+    }
+
+    public void Dispose()
+    {
+        if (_repository is null)
+        {
+            return;
+        }
+        _repository.Network.Remotes.Remove(RemoteName);
+        _repository.Dispose();
+        Environment.SetEnvironmentVariable(MsBuildProperty, null);
+    }
+}


### PR DESCRIPTION
The duplication of the environment variable within pipeline-config.json is unfortunate, and we might be able to revisit that later, but this should fix things to start with.