### PR TITLE
tests: Skip smoke tests which require additional set-up in CI

### DIFF
--- a/apis/Google.Cloud.ApiKeys.V2/smoketests.json
+++ b/apis/Google.Cloud.ApiKeys.V2/smoketests.json
@@ -2,6 +2,7 @@
   {
     "method": "ListKeys",
     "client": "ApiKeysClient",
+    "skip": "Requires apikeys.keys.list permission",
     "arguments": {
       "parent": "projects/${PROJECT_ID}/locations/global"
     }

--- a/apis/Google.Cloud.AppEngine.V1/smoketests.json
+++ b/apis/Google.Cloud.AppEngine.V1/smoketests.json
@@ -2,6 +2,7 @@
   {
     "method": "ListServices",
     "client": "ServicesClient",
+    "skip": "Requires AppEngine app",
     "arguments": {
       "request": {
         "parent": "apps/${PROJECT_ID}"

--- a/apis/Google.Cloud.DeviceStreaming.V1/smoketests.json
+++ b/apis/Google.Cloud.DeviceStreaming.V1/smoketests.json
@@ -2,6 +2,7 @@
   {
     "method": "ListDeviceSessions",
     "client": "DirectAccessServiceClient",
+    "skip": "Requires permission devicestreaming.deviceSessions.list",
     "arguments": {
       "parent": "projects/${PROJECT_ID}"
     }

--- a/apis/Google.Cloud.DiscoveryEngine.V1/smoketests.json
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/smoketests.json
@@ -2,6 +2,7 @@
   {
     "method": "ListDocuments",
     "client": "DocumentServiceClient",
+    "skip": "Requires additional resources to be set up",
     "arguments": {
       "parent": "projects/${PROJECT_ID}/locations/global/collections/default_collection/dataStores/default_data_store/branches/default_branch"
     }
@@ -9,6 +10,7 @@
   {
     "method": "ListSchemas",
     "client": "SchemaServiceClient",
+    "skip": "Requires additional resources to be set up",
     "arguments": {
       "parent": "projects/${PROJECT_ID}/locations/global/collections/default_collection/dataStores/default_data_store"
     }
@@ -16,6 +18,7 @@
   {
     "method": "CompleteQuery",
     "client": "CompletionServiceClient",
+    "skip": "Requires additional resources to be set up",
     "arguments": {
       "request": {
         "dataStore": "projects/${PROJECT_ID}/locations/global/collections/default_collection/dataStores/default_data_store",

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/smoketests.json
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/smoketests.json
@@ -2,6 +2,7 @@
   {
     "method": "ListDocuments",
     "client": "DocumentServiceClient",
+    "skip": "Requires additional resources to be set up",
     "arguments": {
       "parent": "projects/${PROJECT_ID}/locations/global/dataStores/default_data_store/branches/default_branch"
     }

--- a/apis/Google.Cloud.Domains.V1/smoketests.json
+++ b/apis/Google.Cloud.Domains.V1/smoketests.json
@@ -2,6 +2,7 @@
   {
     "method": "ListRegistrations",
     "client": "DomainsClient",
+    "skip": "Requires permission domains.registrations.list",
     "arguments": {
       "parent": "projects/${PROJECT_ID}/locations/global"
     }

--- a/apis/Google.Cloud.Domains.V1Beta1/smoketests.json
+++ b/apis/Google.Cloud.Domains.V1Beta1/smoketests.json
@@ -2,6 +2,7 @@
   {
     "method": "ListRegistrations",
     "client": "DomainsClient",
+    "skip": "Requires permission domains.registrations.list",
     "arguments": {
       "parent": "projects/${PROJECT_ID}/locations/global"
     }

--- a/apis/Google.Cloud.Iam.V2/smoketests.json
+++ b/apis/Google.Cloud.Iam.V2/smoketests.json
@@ -2,6 +2,7 @@
   {
     "method": "ListPolicies",
     "client": "PoliciesClient",
+    "skip": "Requires permission iam.googleapis.com/denypolicies.list",
     "arguments": {
       "parent": "policies/cloudresourcemanager.googleapis.com%2Fprojects%2F${PROJECT_ID}/denypolicies"
     }

--- a/apis/Google.Cloud.OsLogin.V1/smoketests.json
+++ b/apis/Google.Cloud.OsLogin.V1/smoketests.json
@@ -2,6 +2,7 @@
   {
     "client": "OsLoginServiceClient",
     "method": "GetLoginProfile",
+    "skip": "Requires service account",
     "arguments": {
       "name": "users/${SERVICE_ACCOUNT_ID}"
     }

--- a/apis/Google.Cloud.OsLogin.V1Beta/smoketests.json
+++ b/apis/Google.Cloud.OsLogin.V1Beta/smoketests.json
@@ -2,6 +2,7 @@
   {
     "client": "OsLoginServiceClient",
     "method": "GetLoginProfile",
+    "skip": "Requires service account",
     "arguments": {
       "name": "users/${SERVICE_ACCOUNT_ID}"
     }

--- a/apis/Google.Cloud.Retail.V2/smoketests.json
+++ b/apis/Google.Cloud.Retail.V2/smoketests.json
@@ -2,6 +2,7 @@
   {
     "method": "ListCatalogs",
     "client": "CatalogServiceClient",
+    "skip": "Requires additional set-up",
     "arguments": {
       "parent": "projects/${PROJECT_ID}/locations/global"
     }

--- a/apis/Google.Cloud.SecureSourceManager.V1/smoketests.json
+++ b/apis/Google.Cloud.SecureSourceManager.V1/smoketests.json
@@ -2,6 +2,7 @@
   {
     "method": "ListLocations",
     "client": "SecureSourceManagerClient",
+    "skip": "Requires API enablement",
     "clientNavigationProperty": "LocationsClient",
     "arguments": {
       "request": {
@@ -12,6 +13,7 @@
   {
     "method": "ListInstances",
     "client": "SecureSourceManagerClient",
+    "skip": "Requires API enablement",
     "arguments": {
       "parent": "projects/${PROJECT_ID}/locations/us-central1"
     }

--- a/apis/Google.Cloud.Talent.V4/smoketests.json
+++ b/apis/Google.Cloud.Talent.V4/smoketests.json
@@ -2,6 +2,7 @@
   {
     "method": "ListTenants",
     "client": "TenantServiceClient",
+    "skip": "Requires additional set-up",
     "arguments": {
       "parent": "projects/${PROJECT_ID}"
     }

--- a/apis/Google.Cloud.Talent.V4Beta1/smoketests.json
+++ b/apis/Google.Cloud.Talent.V4Beta1/smoketests.json
@@ -2,6 +2,7 @@
   {
     "client": "CompanyServiceClient",
     "method": "ListCompanies",
+    "skip": "Requires additional set-up",
     "arguments": {
       "parent": "projects/${PROJECT_ID}"
     }

--- a/apis/Google.Cloud.Tasks.V2/smoketests.json
+++ b/apis/Google.Cloud.Tasks.V2/smoketests.json
@@ -2,6 +2,7 @@
   {
     "client": "CloudTasksClient",
     "method": "ListQueues",
+    "skip": "Requires AppEngine application",
     "arguments": {
       "parent": "projects/${PROJECT_ID}/locations/${PROJECT_APPENGINE_LOCATION}"
     }

--- a/apis/Google.Cloud.Video.Stitcher.V1/smoketests.json
+++ b/apis/Google.Cloud.Video.Stitcher.V1/smoketests.json
@@ -2,6 +2,7 @@
   {
     "method": "ListSlates",
     "client": "VideoStitcherServiceClient",
+    "skip": "Requires API enablement",
     "arguments": {
       "parent": "projects/${PROJECT_ID}/locations/us-east1"
     }
@@ -9,6 +10,7 @@
   {
     "method": "ListCdnKeys",
     "client": "VideoStitcherServiceClient",
+    "skip": "Requires API enablement",
     "arguments": {
       "parent": "projects/${PROJECT_ID}/locations/us-east1"
     }


### PR DESCRIPTION
It may be feasible to do the set-up and unskip these in the future, but we want to get to a passing CI run first.