### PR TITLE
tests: Skip snippet tests that require additional set-up

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -183,10 +183,11 @@ resource names):
 Google.Cloud.Vision.V1
 ----------------------
 
-The test project must have a populated product set, and have AutoML
-configured appropriately. To create the product set expected by the
-snippets, change to the `apis/Google.Cloud.Vision.V1` directory and
-run:
+There are two snippets which require a populated product set, and to
+have AutoML configured appropriately. These tests are currently
+skipped, but are preserved so it's easy to test manually when
+required. To create the product set expected by the snippets, change
+to the `apis/Google.Cloud.Vision.V1` directory and run:
 
 ```text
 dotnet run -p Google.Cloud.Vision.V1.PopulateProductSearchTestSet -- Google.Cloud.Vision.V1.Snippets {YOUR_PROJECT_ID}

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.Snippets/SampleSnippets.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.Snippets/SampleSnippets.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Google LLC
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ namespace Google.Cloud.Talent.V4Beta1.Snippets
 
         public SampleSnippets(TalentFixture fixture) => _fixture = fixture;
 
-        [Fact]
+        [Fact(Skip = "Requires additional set-up")]
         public void CreateCompany()
         {
             string projectId = _fixture.ProjectId;
@@ -48,7 +48,7 @@ namespace Google.Cloud.Talent.V4Beta1.Snippets
             // End sample
         }
 
-        [Fact]
+        [Fact(Skip = "Requires additional set-up")]
         public void CreateJob()
         {
             string projectId = _fixture.ProjectId;

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/ImageAnnotatorClientSnippets.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/ImageAnnotatorClientSnippets.cs
@@ -418,7 +418,7 @@ namespace Google.Cloud.Vision.V1.Snippets
             // End sample
         }
 
-        [Fact]
+        [Fact(Skip = "Requires test product set; skipped for now")]
         public void DetectSimilarProducts()
         {
             Image image = LoadResourceImage("shoes_1.jpg");
@@ -448,7 +448,7 @@ namespace Google.Cloud.Vision.V1.Snippets
         // See [DetectSimilarProducts](ref) for a synchronous example.
         // End see-also
 
-        [Fact]
+        [Fact(Skip = "Requires test product set; skipped for now")]
         public void DetectSimilarProducts_WithFilter()
         {
             Image image = LoadResourceImage("shoes_1.jpg");


### PR DESCRIPTION
(We could come back to this if the set-up can be automated easily.)