### PR TITLE
tests: Add more environment variables for 1PP

### DIFF
--- a/generator-input/pipeline-config.json
+++ b/generator-input/pipeline-config.json
@@ -11,8 +11,22 @@
     "integration-test-library": {
       "environmentVariables": [
         {
-          "name": "TEST_PROJECT",
-          "secretName": "integration-test-project"
+          "name": "TEST_PROJECT"
+        },
+        {
+          "name": "TEST_PROJECT_LOCATION"
+        },
+        {
+          "name": "BIGTABLE_TEST_INSTANCE"
+        },
+        {
+          "name": "US_KMS_TEST_KEYRING"
+        },
+        {
+          "name": "US_KMS_TEST_KEY1"
+        },
+        {
+          "name": "US_KMS_TEST_KEY2"
         },
         {
           "name": "INTEGRATION_TEST_SERVICE_ACCOUNT_JSON"


### PR DESCRIPTION
We also don't need to get the integration test project from Secret Manager - it's fine to have as internal config.