### PR TITLE
tools: Fix README generation for first releases of libraries

### DIFF
--- a/tools/Google.Cloud.Tools.ReleaseManager/ContainerCommands/PrepareLibraryReleaseCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/ContainerCommands/PrepareLibraryReleaseCommand.cs
@@ -54,11 +54,13 @@ public sealed class PrepareLibraryReleaseCommand : IContainerCommand
         var releaseDate = DateTime.UtcNow.Date;
 
         var rootLayout = RootLayout.ForRepositoryRoot(repoRoot);
-        var apiCatalog = ApiCatalog.Load(rootLayout);
+        var nonSourceGenerator = new NonSourceGenerator(rootLayout);
+        // Use the same API catalog object as the non-source generator, so
+        // that version changes we make here are reflected consistently.
+        var apiCatalog = nonSourceGenerator.ApiCatalog;
 
         var packageGroup = apiCatalog.PackageGroups.FirstOrDefault(pg => pg.Id == libraryId);
         var packageIds = packageGroup?.PackageIds ?? new() { libraryId };
-        var nonSourceGenerator = new NonSourceGenerator(rootLayout);
         var structuredVersion = StructuredVersion.FromString(version);
 
         foreach (var packageId in packageIds)


### PR DESCRIPTION
We only generate a README entry for libraries which have been released (i.e. the version doesn't end with alpha00 or beta00). When preparing for the first library release, we're setting the version - but if NonSourceGenerator already has a reference to an ApiCatalog with the original version number, it can't spot that.

Fixes b/416456892