### PR TITLE
docs(Google.Cloud.BigQuery.V2): document WRITE_TRUNCATE_DATA

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/WriteDisposition.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/WriteDisposition.cs
@@ -35,6 +35,12 @@ namespace Google.Cloud.BigQuery.V2
         /// Attempting to write data to a non-empty table fails with an error.
         /// </summary>
         [ApiValue("WRITE_EMPTY")]
-        WriteIfEmpty
+        WriteIfEmpty,
+	/// <summary>
+	/// If the table already exists, BigQuery overwrites the
+	/// data, but keeps the constraints and schema of the existing table.
+	/// </summary>
+	[ApiValue("WRITE_TRUNCATE_DATA")]
+	WriteTruncateData
     }
 }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/WriteDisposition.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/WriteDisposition.cs
@@ -36,11 +36,11 @@ namespace Google.Cloud.BigQuery.V2
         /// </summary>
         [ApiValue("WRITE_EMPTY")]
         WriteIfEmpty,
-	/// <summary>
-	/// If the table already exists, BigQuery overwrites the
-	/// data, but keeps the constraints and schema of the existing table.
-	/// </summary>
-	[ApiValue("WRITE_TRUNCATE_DATA")]
-	WriteTruncateData
+        /// <summary>
+        /// If the table already exists, BigQuery overwrites the
+        /// data, but keeps the constraints and schema of the existing table.
+        /// </summary>
+        [ApiValue("WRITE_TRUNCATE_DATA")]
+        WriteTruncateData
     }
 }


### PR DESCRIPTION
This PR adds a reference to the WRITE_TRUNCATE_DATA value and associated description to the WriteDisposition enum declared within the library.

internal issue: b/406848221