### PR TITLE
tests: Skip Google.Maps.Places.V1 smoke test in CI for now

### DIFF
--- a/apis/Google.Maps.Places.V1/smoketests.json
+++ b/apis/Google.Maps.Places.V1/smoketests.json
@@ -3,6 +3,7 @@
     "method": "SearchText",
     "client": "PlacesClient",
     "fieldMask": "places.formattedAddress",
+    "restrictedSkip": "b/414750416",
     "transports": [ "Grpc" ],
     "arguments": {
       "request": {


### PR DESCRIPTION
(We can re-enable it when the tasks are running as the right project.)