### PR TITLE
tests: Fix tests for restricted environment

### DIFF
--- a/tools/Google.Cloud.ClientTesting/TestEnvironment.cs
+++ b/tools/Google.Cloud.ClientTesting/TestEnvironment.cs
@@ -86,7 +86,7 @@ namespace Google.Cloud.ClientTesting
         /// </summary>
         public static void SkipOnRestrictedEnvironment()
         {
-            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(GoogleApplicationCredentialsEnvironmentVariable)))
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(GoogleApplicationCredentialsEnvironmentVariable)))
             {
                 throw new SkipException("Test skipped in VPCSC environment");
             }


### PR DESCRIPTION
We need to detect the absence, not the presence, of GOOGLE_APPLICATION_CREDENTIALS.