### PR TITLE
fix(BigTable): ReadRow/s respects rowsLimit and retries on Aborted exception

### DIFF
--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.ConformanceTests/bigtable-conformance.sh
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.ConformanceTests/bigtable-conformance.sh
@@ -34,7 +34,7 @@ cd cloud-bigtable-clients-test/tests
 # Cookie, RetryInfo, ExecuteQuery, ReverseScans and FeatureGap are known failures of new features that we don't yet support.
 # CloseClient we don't support as expected, but we support it in a valid manner.
 # For the others we have issues to investigate, see comments in b/372509076 .
-eval "go test -v -proxy_addr=:7238 -skip _Retry_WithRoutingCookie\|_Retry_WithRetryInfo\|_CloseClient\|_ReverseScans\|TestFeatureGap\|TestExecuteQuery\|TestReadRows_NoRetry_ErrorAfterLastRow\|TestReadRows_Retry_PausedScan\|TestReadRows_Retry_LastScannedRow_Reverse\|TestReadRow_Generic_DeadlineExceeded"
+eval "go test -v -proxy_addr=:7238 -skip _Retry_WithRoutingCookie\|_Retry_WithRetryInfo\|_CloseClient\|_ReverseScans\|TestFeatureGap\|TestExecuteQuery\|TestReadRows_Retry_LastScannedRow_Reverse\|TestReadRow_Generic_DeadlineExceeded"
 returnCode=$?
 popd
 

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClientPartial.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClientPartial.cs
@@ -18,12 +18,8 @@ using Google.Cloud.Bigtable.Common.V2;
 using Grpc.Core;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Threading;
 using System.Threading.Tasks;
-using Google.Apis.Auth.OAuth2;
-using Grpc.Auth;
 using static Google.Cloud.Bigtable.V2.BigtableMutateRowsRequestManager;
 
 namespace Google.Cloud.Bigtable.V2
@@ -876,6 +872,7 @@ namespace Google.Cloud.Bigtable.V2
                 tableName,
                 new RowSet { RowKeys = { rowKey.Value } },
                 filter,
+                rowsLimit: 1,
                 callSettings: callSettings);
 
             // Equivalent to using SingleOrDefaultAsync, but avoids a System.Linq.Async dependency.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableReadRowsRequestManager.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableReadRowsRequestManager.cs
@@ -43,6 +43,8 @@ namespace Google.Cloud.Bigtable.V2
 
         internal void IncrementRowsReadSoFar(int count = 1) => _rowsReadSoFar += count;
 
+        internal long RowsReadSoFar() => _rowsReadSoFar;
+
         /// <summary>
         /// Builds and returns updated subrequest that excludes all rowKeys that have already been found,
         /// or null if all rows have already been found.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableServiceApiClientPartial.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableServiceApiClientPartial.cs
@@ -69,6 +69,7 @@ namespace Google.Cloud.Bigtable.V2
         /// <list type="bullet">
         /// <item><description><see cref="StatusCode.DeadlineExceeded"/></description></item>
         /// <item><description><see cref="StatusCode.Unavailable"/></description></item>
+        /// <item><description><see cref="StatusCode.Aborted"/></description></item>
         /// </list>
         /// </remarks>
         /// <seealso cref="ReadRowsSettings"/>
@@ -78,7 +79,7 @@ namespace Google.Cloud.Bigtable.V2
                 initialBackoff: TimeSpan.FromMilliseconds(10),
                 maxBackoff: TimeSpan.FromMinutes(1),
                 backoffMultiplier: 2,
-                retryFilter: RetrySettings.FilterForStatusCodes(StatusCode.DeadlineExceeded, StatusCode.Unavailable));
+                retryFilter: RetrySettings.FilterForStatusCodes(StatusCode.DeadlineExceeded, StatusCode.Unavailable, StatusCode.Aborted));
 
         /// <summary>
         /// This value specifies routing for replication. If not specified, the


### PR DESCRIPTION
Fixes TestReadRows_Retry_PausedScan, TestReadRows_NoRetry_ErrorAfterLastRow, and (partially) TestReadRow_Generic_DeadlineExceeded.

As of 5/23/2025, TestReadRow_Generic_DeadlineExceeded still fails not because DotNet BT library is behaving incorrectly, but the response status that the DotNet test proxy reports (OK) differs from Go client's expectations (DeadlineExceeded). This is because the Dotnet BT library swallows and retries DeadlineExceeded RPC exception and does not bubble the exception up to the Proxy. To make the it bubble up, we will need to make structural changes to the response model for ReadRow/s operations. However, I don't think this is worth it because such change will be irrelevant to our customers and we'd only be doing it to get 1 assert statement in the Go test to pass; other more important assert statements pass. I think the correct thing to do is to remove [this line](https://github.com/googleapis/cloud-bigtable-clients-test/blob/main/tests/readrow_test.go#L121) from the Go client test.