### PR TITLE
chore: Fix the service config file used by Spanner Admin Instance

### DIFF
--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -5161,7 +5161,7 @@
       },
       "noVersionHistory": true,
       "shortName": "spanner",
-      "serviceConfigFile": "spanner_admin_instance.yaml",
+      "serviceConfigFile": "spanner.yaml",
       "restNumericEnums": true,
       "transport": "grpc+rest",
       "includeCommonResourcesProto": true,


### PR DESCRIPTION
Following up on https://github.com/googleapis/googleapis/commit/0a4ce50a6664cce6eaae3dfb4deb0135155027ec