### PR TITLE
chore: Unblock Google.Cloud.ModelArmor.V1Beta for release

### DIFF
--- a/apis/Google.Cloud.ModelArmor.V1Beta/smoketests.json
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/smoketests.json
@@ -1,0 +1,9 @@
+[
+  {
+    "method": "ListTemplates",
+    "client": "ModelArmorClient",
+    "arguments": {
+      "parent": "projects/${PROJECT_ID}/locations/global"
+    }
+  }
+]

--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -4120,7 +4120,7 @@
             "id": "Google.Cloud.ModelArmor.V1Beta",
             "nextVersion": "1.0.0-beta01",
             "generationAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
-            "releaseAutomationLevel": "AUTOMATION_LEVEL_BLOCKED",
+            "releaseAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "lastGeneratedCommit": "17b10a69d4a5d79e5196feed3742e00378ade9b0",
             "apiPaths": [
                 "google/cloud/modelarmor/v1beta"


### PR DESCRIPTION
The smoke tests are copied over from V1, and work without change.