### PR TITLE
tools: Update the Bigtable client generator to .NET 8

### DIFF
--- a/generator-input/tweaks/Directory.Packages.props
+++ b/generator-input/tweaks/Directory.Packages.props
@@ -3,27 +3,13 @@
     <PackageVersion Include="Grpc.Core" Version="[2.46.6, 3.0.0)" />
     <PackageVersion Include="Grpc.Core.Testing" Version="[2.46.6, 3.0.0)" />
     
-    <PackageVersion Include="Google.Api.Gax.Grpc" Version="[4.9.0, 5.0.0)" />    
-    <PackageVersion Include="Google.Api.CommonProtos" Version="[2.16.0, 3.0.0)" />
+    <PackageVersion Include="Google.Api.Gax.Grpc" Version="[4.11.0, 5.0.0)" />
+    <PackageVersion Include="Google.Api.CommonProtos" Version="[2.17.0, 3.0.0)" />
     <PackageVersion Include="Google.LongRunning" Version="[3.3.0, 4.0.0)" />
     <PackageVersion Include="Google.Protobuf" Version="3.31.1"/>
-    <PackageVersion Include="Microsoft.Build.Locator" Version="1.7.8" />
     
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
-    
-    <!-- 
-      - Note: do not upgrade 4.8.0 until we're using .NET SDK v8
-      - or https://github.com/dotnet/roslyn/issues/71784 is fixed.
-      - See b/328172159 as an example of the failure.
-      -->
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.8.0" />
-
-    <!--
-      - For some reason, the above packages introduce a dependency somewhere on version 3.0.3
-      - of Microsoft.Extensions.Logging.Abstractions, so MSBuild gets confused. It's simplest
-      - to just specify v6 ourselves.
-      -->
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.14.0" />
   </ItemGroup>
 </Project>

--- a/generator-input/tweaks/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/Google.Cloud.Bigtable.V2.GenerateClient.csproj
+++ b/generator-input/tweaks/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/Google.Cloud.Bigtable.V2.GenerateClient.csproj
@@ -2,28 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Google.Api.Gax.Grpc" />
-    <PackageReference Include="Microsoft.Build.Locator" />
-    
-    <!-- 
-      - Note: do not upgrade 4.8.0 until we're using .NET SDK v8
-      - or https://github.com/dotnet/roslyn/issues/71784 is fixed.
-      - See b/328172159 as an example of the failure.
-      -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />
-
-    <!--
-      - For some reason, the above packages introduce a dependency somewhere on version 3.0.3
-      - of Microsoft.Extensions.Logging.Abstractions, so MSBuild gets confused. It's simplest
-      - to just specify v6 ourselves.
-      -->
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/generator-input/tweaks/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/Program.cs
+++ b/generator-input/tweaks/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GenerateClient/Program.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using Google.Api.Gax.Grpc;
-using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -29,7 +28,7 @@ using System.Threading.Tasks;
 
 using static Google.Cloud.Bigtable.V2.GenerateClient.RoslynHelpers;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
-using gax = Google.Api.Gax;
+using GAX = Google.Api.Gax;
 
 namespace Google.Cloud.Bigtable.V2.GenerateClient
 {
@@ -109,7 +108,6 @@ namespace Google.Cloud.Bigtable.V2.GenerateClient
             var apiClientName = args[1];
             var userClientName = args[2];
 
-            MSBuildLocator.RegisterDefaults();
             var workspace = MSBuildWorkspace.Create(new Dictionary<string, string> { ["TargetFramework"] = "net45" });
 
             Project project;
@@ -207,7 +205,7 @@ namespace Google.Cloud.Bigtable.V2.GenerateClient
                             var clientImplSyncMethod = clientImplMethod.WithBodySafe(
                                 Task().Member(nameof(System.Threading.Tasks.Task.Run))
                                     .Invoke(Lambda(asyncMethod.Invoke(clientImplMethod.ParameterList.AsArguments())))
-                                    .Member(nameof(gax::TaskExtensions.ResultWithUnwrappedExceptions)).Invoke());
+                                    .Member(nameof(GAX::TaskExtensions.ResultWithUnwrappedExceptions)).Invoke());
                             userClientImplSyntax = userClientImplSyntax.AddMembers(clientImplSyncMethod);
 
                             var clientImplAsyncMethod = clientImplMethod.ToAsync();
@@ -240,7 +238,7 @@ namespace Google.Cloud.Bigtable.V2.GenerateClient
             // copyright notice and generated code warnings in its leading trivia.
             // We also need a using directive for GAX, so that we can use ResultWithUnwrappedExceptions.
             var usings = syntaxTree.GetCompilationUnitRoot().Usings
-                .Add(UsingDirective(ParseName(typeof(gax::TaskExtensions).Namespace)));
+                .Add(UsingDirective(ParseName(typeof(GAX::TaskExtensions).Namespace)));
             var compilationUnit = CompilationUnit().WithUsings(usings);
 
             // Add in the namespace with the ...Client and ...ClientImpl classes.

--- a/generator-input/tweaks/global.json
+++ b/generator-input/tweaks/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.414",
+    "version": "8.0.410",
     "allowPrerelease": false,
     "rollForward": "latestMinor"
   }


### PR DESCRIPTION
This allows us to remove the MSBuildLocator entirely, and update our Roslyn dependencies (which had issues with .NET 6).