### PR TITLE
feat: Spanner universe domain implementation

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerClientCreationOptionsTest.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerClientCreationOptionsTest.cs
@@ -114,14 +114,6 @@ namespace Google.Cloud.Spanner.Data.Tests
         }
 
         [Fact]
-        public async Task CredentialFileP12Error()
-        {
-            var builder = new SpannerConnectionStringBuilder("CredentialFile=SpannerEF-8dfc036f6000.p12");
-            var options = new SpannerClientCreationOptions(builder);
-            await Assert.ThrowsAsync<InvalidOperationException>(() => options.GetCredentialsAsync());
-        }
-
-        [Fact]
         public async Task CredentialFileNotFound()
         {
             var builder = new SpannerConnectionStringBuilder("CredentialFile=..\\BadFilePath.json");
@@ -136,6 +128,22 @@ namespace Google.Cloud.Spanner.Data.Tests
             var builder = new SpannerConnectionStringBuilder("", credential);
             var options = new SpannerClientCreationOptions(builder);
             Assert.NotNull(await options.GetCredentialsAsync());
+        }
+
+        [Theory]
+        // InlineData format: ConnectionString, ExpectedUniverseDomain, ExpectedEndpoint 
+        [InlineData("UniverseDomain=test-domain.test.goog", "test-domain.test.goog", "spanner.test-domain.test.goog:443")]
+        [InlineData("Host=test-host;Port=567", "googleapis.com", "test-host:567")]
+        [InlineData("Host=test-host;Port=567;UniverseDomain=test-domain.test.goog", "test-domain.test.goog", "test-host:567")]
+        [InlineData("Data Spurce=projects/p1/instances/i1/databases/d1", "googleapis.com", "spanner.googleapis.com:443")]
+        public void Equality_UniverseDomainAndEndpoint(string connectionString, string expectedUniverseDomain, string expectedEndpoint)
+        {
+            //string universeDomain = "test-domain.test.goog";
+            var builder = new SpannerConnectionStringBuilder(connectionString);
+            var options = new SpannerClientCreationOptions(builder);
+
+            Assert.Equal(expectedUniverseDomain, options.UniverseDomain);
+            Assert.Equal(expectedEndpoint, options.Endpoint);
         }
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerConnectionStringBuilderTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerConnectionStringBuilderTests.cs
@@ -336,5 +336,23 @@ namespace Google.Cloud.Spanner.Data.Tests
             var clone = builder.Clone();
             Assert.Same(credential, clone.GoogleCredential);
         }
+
+        [Fact]
+        public void UniverseDomainTest()
+        {
+            string universeDomain = "test-domain.test.goog";
+            var builder = new SpannerConnectionStringBuilder($"UniverseDomain={universeDomain}");
+
+            Assert.Equal(universeDomain, builder.UniverseDomain);
+            Assert.Equal(SpannerConnectionStringBuilder.DefaultHost, builder.Host);
+            Assert.Equal($"{SpannerConnectionStringBuilder.DefaultHost}:{SpannerConnectionStringBuilder.DefaultPort}", builder.EndPoint);
+
+            string host = "h1";
+            string port = "567";
+            builder = new SpannerConnectionStringBuilder($"Host={host};Port={port};UniverseDomain={universeDomain}");
+
+            Assert.Equal(host, builder.Host);
+            Assert.Equal($"{host}:{port}", builder.EndPoint);
+        }
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SessionPoolManager.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SessionPoolManager.cs
@@ -309,19 +309,7 @@ namespace Google.Cloud.Spanner.Data
         // Internal for testing.
         internal static async Task<SpannerClient> CreateClientAsync(SpannerClientCreationOptions clientCreationOptions, SpannerSettings spannerSettings, Logger logger)
         {
-            var credentials = await clientCreationOptions.GetCredentialsAsync().ConfigureAwait(false);
-
-            var apiConfig = new ApiConfig
-            {
-                ChannelPool = new ChannelPoolConfig
-                {
-                    MaxSize = (uint)clientCreationOptions.MaximumGrpcChannels,
-                    MaxConcurrentStreamsLowWatermark = clientCreationOptions.MaximumConcurrentStreamsLowWatermark
-                },
-                Method = { s_methodConfigs }
-            };
-
-            var callInvoker = new GcpCallInvoker(SpannerClient.ServiceMetadata, clientCreationOptions.Endpoint, credentials, s_grpcChannelOptions, apiConfig, clientCreationOptions.GrpcAdapter);
+            var callInvoker = await clientCreationOptions.GetGcpCallInvoker(s_methodConfigs, s_grpcChannelOptions).ConfigureAwait(false);
             return new SpannerClientBuilder
             {
                 CallInvoker = callInvoker,

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnectionStringBuilder.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerConnectionStringBuilder.cs
@@ -60,6 +60,10 @@ namespace Google.Cloud.Spanner.Data
         private InstanceName _instanceName;
         private DatabaseName _databaseName;
 
+        internal const string DefaultDomain = "googleapis.com";
+        internal const string DefaultHost = $"spanner.{DefaultDomain}";
+        internal const int DefaultPort = 443;
+
         /// <summary>
         /// The database role for the sessions created by this connection.
         /// </summary>
@@ -112,6 +116,28 @@ namespace Google.Cloud.Spanner.Data
                 ConversionOptions = ConversionOptions.WithClrDefaultForNullSetting(value);
                 this[UseClrDefaultForNullKeyword] = value.ToString(); // Always "True" or "False", regardless of culture.
             }
+        }
+
+        /// <summary>
+        /// The universe domain to connect to, or null to use the default universe domain <see cref="DefaultDomain"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <see cref="UniverseDomain"/> is used to build the endpoint to connect to, unless <see cref="EndPoint"/>
+        /// is set, in which case <see cref="EndPoint"/> will be used without further modification.
+        /// </para>
+        /// <para>
+        /// If default credentials or one of <see cref="GoogleCredential"/> or <see cref="CredentialFile"/>
+        /// is used, <see cref="GoogleCredential.GetUniverseDomain"/> should be:
+        /// <list type="bullet">
+        /// <item>The same as <see cref="UniverseDomain"/> if <see cref="UniverseDomain"/> has been set.</item>
+        /// </list>
+        /// </para>
+        /// </remarks>
+        public string UniverseDomain
+        {
+            get => GetValueOrDefault(nameof(UniverseDomain), DefaultDomain);
+            set => this[nameof(UniverseDomain)] = value;
         }
 
         // Note: GetSchemaTable can't be a link as it wouldn't build on netstandard1.0.
@@ -261,7 +287,7 @@ namespace Google.Cloud.Spanner.Data
             // TODO: Now that ServiceEndpoint has been removed, we don't have separate host/port for the default endpoint.
             // This is currently hardcoded for convenience; it's unlikely to ever change, but ideally we'd parse it from the
             // SpannerClient.DefaultEndpoint;
-            get => GetValueOrDefault(nameof(Host), "spanner.googleapis.com");
+            get => GetValueOrDefault(nameof(Host), DefaultHost);
             set => this[nameof(Host)] = value;
         }
 
@@ -274,7 +300,7 @@ namespace Google.Cloud.Spanner.Data
             // TODO: Now that ServiceEndpoint has been removed, we don't have separate host/port for the default endpoint.
             // This is currently hardcoded for convenience; it's unlikely to ever change, but ideally we'd parse it from the
             // SpannerClient.DefaultEndpoint;
-            get => GetInt32OrDefault(nameof(Port), 1, 65535, 443);
+            get => GetInt32OrDefault(nameof(Port), 1, 65535, DefaultPort);
             set => SetInt32WithValidation(nameof(Port), 1, 65535, value);
         }
 


### PR DESCRIPTION
Leveraging changes for UniverseDomain in the ClientBuilderBase in GAX to 1) Do the right creds domain check with the set universe domain, and 2) Create the right effective endpoint based on whether the universe domain is set.

Added tests to check correct UniverseDomain setting in the [SpannerConnectionStringBuilderTests.cs](https://github.com/googleapis/google-cloud-dotnet/compare/main...purva9413:spanner-universe-domain-split?expand=1#diff-6e0afd8892eb42d2aa405b2c3dbf57a101b4eb6ece98a095b6ce28deeb5e4644) and correct Endpoint resolution in [SpannerClientCreationOptionsTest.cs](https://github.com/googleapis/google-cloud-dotnet/compare/main...purva9413:spanner-universe-domain-split?expand=1#diff-8385b6edd45fe0d301efd185211a0ce83155e2c749c4556dc7667ab60489fbf6)

Removed `CredentialFileP12Error` since invalid creds check will now be done via Auth library since we create the builder from ClientBuilderBase. No extra creds checking code needed in these files now.

Tested:
1. Created a simple app which uses a test universe domain and creates a Spanner table + inserts some rows into it
2. Running Google.Cloud.Spanner.Data.Tests --> Passed