### PR TITLE
chore: create cloudbuild file to publish to AR exit gate

### DIFF
--- a/cloudbuild-generator-exitgate.yaml
+++ b/cloudbuild-generator-exitgate.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-timeout: 21600s  # 6 hours
-options:
-  logging: CLOUD_LOGGING_ONLY
 steps:
 - id: 'build'
   name: gcr.io/cloud-builders/docker
@@ -22,11 +19,11 @@ steps:
   args: [
     'build',
     '-t',
-    'us-central1-docker.pkg.dev/$PROJECT_ID/images-dev/google-cloud-dotnet-generator:$SHORT_SHA',
+    'us-central1-docker.pkg.dev/$PROJECT_ID/images-dev/google-cloud-dotnet-generator',
     '-f',
     'Dockerfile.generator',
     '.'
   ]
 
 images:
-  - us-central1-docker.pkg.dev/$PROJECT_ID/images-dev/google-cloud-dotnet-generator:$SHORT_SHA
+  - us-central1-docker.pkg.dev/$PROJECT_ID/images-dev/google-cloud-dotnet-generator

--- a/cloudbuild-generator-exitgate.yaml
+++ b/cloudbuild-generator-exitgate.yaml
@@ -1,0 +1,32 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+timeout: 21600s  # 6 hours
+options:
+  logging: CLOUD_LOGGING_ONLY
+steps:
+- id: 'build'
+  name: gcr.io/cloud-builders/docker
+  waitFor: ['-']
+  args: [
+    'build',
+    '-t',
+    'us-central1-docker.pkg.dev/$PROJECT_ID/images-dev/google-cloud-dotnet-generator:$SHORT_SHA',
+    '-f',
+    'Dockerfile.generator',
+    '.'
+  ]
+
+images:
+  - us-central1-docker.pkg.dev/$PROJECT_ID/images-dev/google-cloud-dotnet-generator:$SHORT_SHA


### PR DESCRIPTION
We will use this to migrate generator image to exit gate flow.  After migration is complete we will remove existing cloudbuild-generator.yaml