### PR TITLE
tools: First pass at tests for CleanCommand

### DIFF
--- a/tools/Google.Cloud.Tools.Common/ApiCatalog.cs
+++ b/tools/Google.Cloud.Tools.Common/ApiCatalog.cs
@@ -38,16 +38,19 @@ namespace Google.Cloud.Tools.Common
         /// <summary>
         /// Groups of related packages which need to be released together.
         /// </summary>
+        [JsonProperty("packageGroups")]
         public List<PackageGroup> PackageGroups { get; set; }
 
         /// <summary>
         /// The APIs within the catalog.
         /// </summary>
+        [JsonProperty("apis")]
         public List<ApiMetadata> Apis { get; set; }
 
         /// <summary>
         /// Proto paths for APIs we knowingly don't generate. The values are the reasons for not generating.
         /// </summary>
+        [JsonProperty("ignoredPaths")]
         public Dictionary<string, string> IgnoredPaths { get; set; }
 
         /// <summary>
@@ -61,6 +64,12 @@ namespace Google.Cloud.Tools.Common
         /// Formats <see cref="Json"/>.
         /// </summary>
         public string FormatJson() => Json.ToString(Formatting.Indented);
+
+        /// <summary>
+        /// Recreates <see cref="Json"/> from the in-memory representation of this object, ignoring
+        /// any previous JSON.
+        /// </summary>
+        public void RecreateJson() => Json = JObject.FromObject(this);
 
         /// <summary>
         /// Retrieves an API by ID.
@@ -160,10 +169,14 @@ namespace Google.Cloud.Tools.Common
             {
                 followingApi.Json.AddBeforeSelf(api.Json);
             }
-            else
+            else if (Apis.Count > 0)
             {
                 // Looks like this API will be last in the list.
                 Apis.Last().Json.AddAfterSelf(api.Json);
+            }
+            else
+            {
+                Json["apis"] = new JArray(api.Json);
             }
         }
     }

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/CleanCommandTest.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/CleanCommandTest.cs
@@ -1,0 +1,119 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License"):
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using Google.Cloud.Tools.ReleaseManager.ContainerCommands;
+using Xunit;
+
+namespace Google.Cloud.Tools.ReleaseManager.IntegrationTests.ContainerCommands;
+
+[Collection(nameof(ContainerCommandFixture))]
+public class CleanCommandTest
+{
+    private readonly ContainerCommandFixture _fixture;
+
+    public CleanCommandTest(ContainerCommandFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public void SinglePackage()
+    {
+        var context = _fixture.CreateContext();
+        var catalog = context.CreateApiCatalog("Test.Other", "Test.CleanMe");
+        var codeRepo = context.CreateCodeRepo(catalog);
+        codeRepo.AddGeneratedFiles(catalog.Apis)
+            .AddFile("apis/Test.CleanMe/Test.CleanMe/Handwritten.cs")
+            .AddFile("apis/Test.CleanMe/Test.CleanMe.Snippets/Handwritten.cs");
+        var command = new CleanCommand();
+        var options = ContainerOptions.FromArgs(
+            $"--repo-root={codeRepo.Directory}",
+            "--library-id=Test.CleanMe");
+        Assert.Equal(0, command.Execute(options));
+
+        // We've deleted what we should...
+        context.CodeRepo.AssertDoNotExist(
+            "apis/Test.CleanMe/Test.CleanMe.sln",
+            "apis/Test.CleanMe/Test.CleanMe/Test.CleanMe.csproj",
+            "apis/Test.CleanMe/Test.CleanMe/SourceCode.g.cs",
+            "apis/Test.CleanMe/Test.CleanMe.Snippets/Test.CleanMe.Snippets.csproj",
+            "apis/Test.CleanMe/Test.CleanMe.Snippets/SourceCode.g.cs",
+            "apis/Test.CleanMe/Test.CleanMe.GeneratedSnippets/Test.CleanMe.GeneratedSnippets.csproj",
+            "apis/Test.CleanMe/Test.CleanMe.GeneratedSnippets/SourceCode.g.cs",
+            // The directory itself should have been deleted.
+            "apis/Test.CleanMe/Test.CleanMe.GeneratedSnippets",
+            "apis/Test.CleanMe/gapic_metadata.json",
+            "apis/Test.CleanMe/.repo-metadata.json"
+            );
+
+        // We haven't touched the other project...
+        context.CodeRepo.AssertExist(
+            "apis/Test.Other/Test.Other.sln",
+            "apis/Test.Other/Test.Other/Test.Other.csproj",
+            "apis/Test.Other/Test.Other/SourceCode.g.cs",
+            "apis/Test.Other/Test.Other.Snippets/Test.Other.Snippets.csproj",
+            "apis/Test.Other/Test.Other.Snippets/SourceCode.g.cs",
+            "apis/Test.Other/Test.Other.GeneratedSnippets/Test.Other.GeneratedSnippets.csproj",
+            "apis/Test.Other/Test.Other.GeneratedSnippets/SourceCode.g.cs",
+            "apis/Test.Other/gapic_metadata.json",
+            "apis/Test.Other/.repo-metadata.json"
+            );
+
+        // The handwritten files are still there
+        context.CodeRepo.AssertExist(
+            "apis/Test.CleanMe/Test.CleanMe/Handwritten.cs",
+            "apis/Test.CleanMe/Test.CleanMe.Snippets/Handwritten.cs");
+    }
+
+    [Fact]
+    public void PackageGroup()
+    {
+        var context = _fixture.CreateContext();
+        var catalog = context.CreateApiCatalog("Test.Other", "Test.Clean1", "Test.Clean2");
+        var group = new PackageGroup
+        {
+            DisplayName = "Test clean",
+            Id = "Test.Clean",
+            PackageIds = { "Test.Clean1", "Test.Clean2" }
+        };
+        catalog.PackageGroups.Add(group);
+        catalog["Test.Clean1"].PackageGroup = group;
+        catalog["Test.Clean2"].PackageGroup = group;
+        var codeRepo = context.CreateCodeRepo(catalog);
+        codeRepo.AddGeneratedFiles(catalog.Apis);
+        var command = new CleanCommand();
+        var options = ContainerOptions.FromArgs(
+            $"--repo-root={codeRepo.Directory}",
+            "--library-id=Test.Clean");
+        Assert.Equal(0, command.Execute(options));
+
+        // Only checking the solution files as a simple way of checking that we've cleaned the right projects.
+        context.CodeRepo.AssertDoNotExist(
+            "apis/Test.Clean1/Test.Clean1.sln",
+            "apis/Test.Clean2/Test.Clean2.sln");
+        context.CodeRepo.AssertExist("apis/Test.Other/Test.Other.sln");
+    }
+
+    [Fact]
+    public void MissingLibrary()
+    {
+        var context = _fixture.CreateContext();
+        var catalog = context.CreateApiCatalog("Test.Other", "Test.CleanMe");
+        var codeRepo = context.CreateCodeRepo(catalog);
+        codeRepo.AddGeneratedFiles(catalog.Apis);
+        var command = new CleanCommand();
+        var options = ContainerOptions.FromArgs(
+            $"--repo-root={codeRepo.Directory}",
+            $"--library-id=no-such-library");
+        Assert.Throws<UserErrorException>(() => command.Execute(options));
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/ContainerCommandFixture.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/ContainerCommandFixture.cs
@@ -1,0 +1,53 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License"):
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.ClientTesting;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Google.Cloud.Tools.ReleaseManager.IntegrationTests.ContainerCommands;
+
+[CollectionDefinition(nameof(ContainerCommandFixture))]
+public sealed class ContainerCommandFixture : ICollectionFixture<ContainerCommandFixture>
+{
+    private static readonly bool DeleteContextDirectoriesOnExit = false;
+
+    private readonly List<ContainerCommandTestContext> _contexts;
+    private readonly string _contextRoot;
+
+    public ContainerCommandFixture()
+    {
+        _contexts = [];
+        _contextRoot = Path.Combine(Path.GetTempPath(), IdGenerator.FromDateTime("ContainerCommandFixture"));
+    }
+
+    public ContainerCommandTestContext CreateContext([CallerFilePath] string callerFile = null, [CallerMemberName] string callerMember = null)
+    {
+        var file = Path.GetFileNameWithoutExtension(callerFile);
+        var context = new ContainerCommandTestContext(Path.Combine(_contextRoot, $"{file}-{callerMember}"));
+        _contexts.Add(context);
+        return context;
+    }
+
+    public void Dispose()
+    {
+        _contexts.ForEach(c => c.Dispose());
+        if (DeleteContextDirectoriesOnExit)
+        {
+            Directory.Delete(_contextRoot, true);
+        }
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/ContainerCommandTestContext.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/ContainerCommandTestContext.cs
@@ -1,0 +1,109 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License"):
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Google.Cloud.Tools.ReleaseManager.IntegrationTests.ContainerCommands;
+
+/// <summary>
+/// The context in which a container command test is run. This may include multiple
+/// git repositories and other directories.
+/// </summary>
+public class ContainerCommandTestContext : IDisposable
+{
+    /// <summary>
+    /// The root directory for the context.
+    /// </summary>
+    public string RootDirectory { get; }
+
+    public TestRepo CodeRepo { get; private set; }
+    public TestRepo ApiRepo { get; private set; }
+
+    public ContainerCommandTestContext(string rootDirectory)
+    {
+        RootDirectory = rootDirectory;
+        Directory.CreateDirectory(rootDirectory);
+    }
+
+    /// <summary>
+    /// Creates a git repo with metadata in generator-input to match <paramref name="apiCatalog"/>.
+    /// (No directories are created under apis, however.)
+    /// The repo is clean (committed) after this returns.
+    /// The same repo returned by this method is also available as <see cref="CodeRepo"/>.
+    /// </summary>
+    public TestRepo CreateCodeRepo(ApiCatalog apiCatalog)
+    {
+        if (CodeRepo is not null)
+        {
+            throw new InvalidOperationException("Already got a code repo");
+        }
+        CodeRepo = new TestRepo(Path.Combine(RootDirectory, "code-repo"));        
+        var rootLayout = RootLayout.ForRepositoryRoot(CodeRepo.Directory);
+        Directory.CreateDirectory(rootLayout.GeneratorInput);
+        Directory.CreateDirectory(Path.Combine(CodeRepo.Directory, ".github"));
+        apiCatalog.RecreateJson();
+        apiCatalog.Save(rootLayout);
+        var pipelineState = new PipelineState();
+        pipelineState.Libraries.AddRange(apiCatalog.Apis.Where(api => api.PackageGroup is null).Select(CreateLibraryState));
+        pipelineState.Libraries.AddRange(apiCatalog.PackageGroups.Select(CreatePackageGroupLibraryState));
+        pipelineState.Save(rootLayout);
+        CodeRepo.CommitAll();
+        return CodeRepo;
+
+        LibraryState CreateLibraryState(ApiMetadata api) => new LibraryState
+        {
+            Id = api.Id,
+            ApiPaths = api.ProtoPath is null ? [] : [api.ProtoPath],
+            CurrentVersion = api.Version
+        };
+
+        LibraryState CreatePackageGroupLibraryState(PackageGroup group) => new LibraryState
+        {
+            Id = group.Id,
+            ApiPaths = [.. group.PackageIds.Select(p => apiCatalog[p].ProtoPath).Where(p => p is not null)],
+            CurrentVersion = apiCatalog[group.PackageIds[0]].Version
+        };
+    }
+
+    /// <summary>
+    /// Creates an in-memory API catalog with the given API IDs, each of which is assumed to be a GAPIC
+    /// API.
+    /// </summary>
+    public ApiCatalog CreateApiCatalog(params string[] ids)
+    {
+        var apis = ids.Select(id => new ApiMetadata
+        {
+            Id = id,
+            Generator = GeneratorType.Micro,
+            Type = ApiType.Grpc,
+            ProtoPath = id.Replace(".", "/").ToLowerInvariant()
+        });
+        var catalog = new ApiCatalog
+        {
+            Apis = [.. apis],
+            PackageGroups = []
+        };
+        catalog.RecreateJson();
+        return catalog;
+    }
+
+    public void Dispose()
+    {
+        CodeRepo?.Dispose();
+        ApiRepo?.Dispose();
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/TestRepo.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/TestRepo.cs
@@ -1,0 +1,111 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License"):
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using LibGit2Sharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+using IO = System.IO;
+
+namespace Google.Cloud.Tools.ReleaseManager.IntegrationTests.ContainerCommands;
+
+/// <summary>
+/// A git repository used for testing. This is mostly a wrapper around libgit2sharp
+/// with convenience methods.
+/// </summary>
+public class TestRepo : IDisposable
+{
+    private readonly Repository _repo;
+    public string Directory { get; }
+
+    public TestRepo(string directory)
+    {
+        Repository.Init(directory);
+        _repo = new Repository(directory);
+        Directory = directory;
+    }
+
+    public TestRepo AddFile(string relativePath, string text = "test")
+    {
+        var path = Path.Combine(Directory, relativePath);
+        IO::Directory.CreateDirectory(Path.GetDirectoryName(path));
+        File.WriteAllText(path, text);
+        return this;
+    }
+
+    public TestRepo AddProjectAndSource(ApiMetadata api, string suffix) =>
+        AddFile($"apis/{api.Id}/{api.Id}{suffix}/{api.Id}{suffix}.csproj")
+        .AddFile($"apis/{api.Id}/{api.Id}{suffix}/SourceCode.g.cs");
+
+    public TestRepo AddGeneratedFiles(IEnumerable<ApiMetadata> apis)
+    {
+        foreach (var api in apis)
+        {
+            AddGeneratedFiles(api);
+        }
+        return this;
+    }
+
+    public TestRepo AddGeneratedFiles(ApiMetadata api) =>
+        AddProjectAndSource(api, "")
+        .AddProjectAndSource(api, ".GeneratedSnippets")
+        .AddProjectAndSource(api, ".Snippets")
+        .AddFile($"apis/{api.Id}/{api.Id}.sln")
+        .AddFile($"apis/{api.Id}/gapic_metadata.json")
+        .AddFile($"apis/{api.Id}/.repo-metadata.json");
+
+    public Commit CommitAll(string message = "commit")
+    {
+        RepositoryStatus status = _repo.RetrieveStatus();
+        AddAll(status.Modified);
+        AddAll(status.Missing);
+        AddAll(status.Untracked);
+        _repo.Index.Write();
+        var signature = _repo.Config.BuildSignature(DateTimeOffset.UtcNow);
+        return _repo.Commit(message, signature, signature);
+
+        void AddAll(IEnumerable<StatusEntry> entries)
+        {
+            foreach (var entry in entries)
+            {
+                _repo.Index.Add(entry.FilePath);
+            }
+        }
+    }
+
+    public void AssertDoNotExist(params string[] relativePaths)
+    {
+        foreach (var relativePath in relativePaths)
+        {
+            Assert.False(Exists(Path.Combine(Directory, relativePath)), $"Expected {relativePath} not to exist");
+        }
+    }
+
+    public void AssertExist(params string[] relativePaths)
+    {
+        foreach (var relativePath in relativePaths)
+        {
+            Assert.True(Exists(Path.Combine(Directory, relativePath)), $"Expected {relativePath} to exist");
+        }
+    }
+
+    private static bool Exists(string path) => File.Exists(path) || IO::Directory.Exists(path);
+
+    public void Dispose()
+    {
+        _repo.Dispose();
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/Google.Cloud.Tools.ReleaseManager.IntegrationTests.csproj
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/Google.Cloud.Tools.ReleaseManager.IntegrationTests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <ProjectReference Include="..\Google.Cloud.Tools.ReleaseManager\Google.Cloud.Tools.ReleaseManager.csproj" />
+    <ProjectReference Include="..\Google.Cloud.ClientTesting\Google.Cloud.ClientTesting.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/Google.Cloud.Tools.ReleaseManager/AssemblyInfo.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,10 +15,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Google.Cloud.Tools.ReleaseManager.Tests")]
-/*, PublicKey="
-                              + "0024000004800000940000000602000000240000525341310004000001000100afab79952ee222"
-                              + "15f12b4e09337e65509c943fbc22d7006bc371d581d0f0ebf0da5d8039aab2607fb68a138a5d80"
-                              + "a71bc02b7ebf586dbe1f2493c0ab20423ababfd15ce74d2264a6b37745f3658f016abaad662182"
-                              + "aaef634a60f1346fcc45343acab5b6781535a3134818e13fac895a6c106c0480e34bbb06cb123e"
-                              + "5583d8d2"
-)]*/
+[assembly: InternalsVisibleTo("Google.Cloud.Tools.ReleaseManager.IntegrationTests")]

--- a/tools/Google.Cloud.Tools.ReleaseManager/ContainerCommands/ContainerOptions.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/ContainerCommands/ContainerOptions.cs
@@ -62,6 +62,8 @@ public class ContainerOptions
         ReleaseNotes = options.GetValueOrDefault(ReleaseNotesOption);
     }
 
+    internal static ContainerOptions FromArgs(params string[] args) => FromArgs((IEnumerable<string>) args);
+
     internal static ContainerOptions FromArgs(IEnumerable<string> args)
     {
         return new(args.Select(SplitNameAndValue).ToDictionary(pair => pair.name, pair => pair.value));

--- a/tools/Google.Cloud.Tools.sln
+++ b/tools/Google.Cloud.Tools.sln
@@ -27,6 +27,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.SbomGene
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.SbomGenerator.Tests", "Google.Cloud.Tools.SbomGenerator.Tests\Google.Cloud.Tools.SbomGenerator.Tests.csproj", "{AFAB7D20-EDBD-460B-A209-BB5C797AD8E1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Tools.ReleaseManager.IntegrationTests", "Google.Cloud.Tools.ReleaseManager.IntegrationTests\Google.Cloud.Tools.ReleaseManager.IntegrationTests.csproj", "{FAD58071-C5F0-4F35-B3E6-FF5059E7713F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -181,6 +183,18 @@ Global
 		{AFAB7D20-EDBD-460B-A209-BB5C797AD8E1}.Release|x64.Build.0 = Release|Any CPU
 		{AFAB7D20-EDBD-460B-A209-BB5C797AD8E1}.Release|x86.ActiveCfg = Release|Any CPU
 		{AFAB7D20-EDBD-460B-A209-BB5C797AD8E1}.Release|x86.Build.0 = Release|Any CPU
+		{FAD58071-C5F0-4F35-B3E6-FF5059E7713F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FAD58071-C5F0-4F35-B3E6-FF5059E7713F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FAD58071-C5F0-4F35-B3E6-FF5059E7713F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FAD58071-C5F0-4F35-B3E6-FF5059E7713F}.Debug|x64.Build.0 = Debug|Any CPU
+		{FAD58071-C5F0-4F35-B3E6-FF5059E7713F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FAD58071-C5F0-4F35-B3E6-FF5059E7713F}.Debug|x86.Build.0 = Debug|Any CPU
+		{FAD58071-C5F0-4F35-B3E6-FF5059E7713F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FAD58071-C5F0-4F35-B3E6-FF5059E7713F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FAD58071-C5F0-4F35-B3E6-FF5059E7713F}.Release|x64.ActiveCfg = Release|Any CPU
+		{FAD58071-C5F0-4F35-B3E6-FF5059E7713F}.Release|x64.Build.0 = Release|Any CPU
+		{FAD58071-C5F0-4F35-B3E6-FF5059E7713F}.Release|x86.ActiveCfg = Release|Any CPU
+		{FAD58071-C5F0-4F35-B3E6-FF5059E7713F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
We'll need to expand the framework over time, for sure, but this was the easiest command to start with.

Towards https://github.com/googleapis/librarian/issues/304

We also need to run this regularly, of course. Thoughts on that welcome - just make runintegrationtests.sh do it?