### PR TITLE
tests: Add Docker-based tests for integration-test-library

### DIFF
--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/CommonFiles/Google.Test.V2/Google.Test.V2.IntegrationTests/Google.Test.V2.IntegrationTests.csproj
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/CommonFiles/Google.Test.V2/Google.Test.V2.IntegrationTests/Google.Test.V2.IntegrationTests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <ProjectReference Include="..\Google.Test.V2\Google.Test.V2.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/CommonFiles/Google.Test.V2/Google.Test.V2.IntegrationTests/PassingTest.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/CommonFiles/Google.Test.V2/Google.Test.V2.IntegrationTests/PassingTest.cs
@@ -1,0 +1,27 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License"):
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+namespace Google.Test.V2.IntegrationTests;
+
+public class PassingTest
+{
+    [Fact]
+    public void ConstructorDoesNotThrowException()
+    {
+        var handwritten = new Handwritten();
+        Assert.NotNull(handwritten);
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/BuildLibrary-Simple/metadata.yaml
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/BuildLibrary-Simple/metadata.yaml
@@ -18,6 +18,14 @@ repoFiles:
     target: repo/build.sh
   - source: toolversions.sh
     target: repo/toolversions.sh
+  - source: Directory.Packages.props
+    target: repo/Directory.Packages.props
+  - source: apis/Directory.Build.props
+    target: repo/apis/Directory.Build.props
+  - source: apis/Directory.Build.targets
+    target: repo/apis/Directory.Build.targets
+  - source: apis/GoogleApis.snk
+    target: repo/apis/GoogleApis.snk
 fileExpectations:
   present:
   - repo/apis/Google.Test.V1/Google.Test.V1/bin

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/IntegrationTestLibrary-FailingTest/metadata.yaml
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/IntegrationTestLibrary-FailingTest/metadata.yaml
@@ -1,7 +1,7 @@
-command: build-library
+command: integration-test-library
 args:
 - '--repo-root=/test/repo'
-- '--library-id=Google.Test.V1'
+- '--library-id=Google.Test.V2'
 commonFiles:
   - source: test-apis.json
     target: repo/generator-input/apis.json
@@ -11,13 +11,11 @@ commonFiles:
     target: repo/apis/Google.Test.V1
   - source: Google.Test.V2
     target: repo/apis/Google.Test.V2
-  - source: Broken.cs
-    target: repo/apis/Google.Test.V1/Google.Test.V1/Broken.cs
 repoFiles:
   - source: global.json
     target: repo/global.json
-  - source: build.sh
-    target: repo/build.sh
+  - source: runintegrationtests.sh
+    target: repo/runintegrationtests.sh
   - source: toolversions.sh
     target: repo/toolversions.sh
   - source: Directory.Packages.props
@@ -29,3 +27,9 @@ repoFiles:
   - source: apis/GoogleApis.snk
     target: repo/apis/GoogleApis.snk
 expectedExitCode: 1
+fileExpectations:
+  present:
+  - repo/apis/Google.Test.V2/Google.Test.V2/bin
+  - repo/apis/Google.Test.V2/Google.Test.V2.IntegrationTests/bin
+  absent:
+  - repo/apis/Google.Test.V1/Google.Test.V1/bin

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/IntegrationTestLibrary-FailingTest/repo/apis/Google.Test.V2/Google.Test.V2.IntegrationTests/FailingTest.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/IntegrationTestLibrary-FailingTest/repo/apis/Google.Test.V2/Google.Test.V2.IntegrationTests/FailingTest.cs
@@ -1,0 +1,27 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License"):
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.IO;
+using Xunit;
+
+namespace Google.Test.V2.IntegrationTests;
+
+public class FailingTest
+{
+    [Fact]
+    public void FailAlways()
+    {
+        Assert.Fail("This test always fails.");
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/IntegrationTestLibrary-FlakyTest/metadata.yaml
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/IntegrationTestLibrary-FlakyTest/metadata.yaml
@@ -1,7 +1,7 @@
-command: build-library
+command: integration-test-library
 args:
 - '--repo-root=/test/repo'
-- '--library-id=Google.Test.V1'
+- '--library-id=Google.Test.V2'
 commonFiles:
   - source: test-apis.json
     target: repo/generator-input/apis.json
@@ -11,13 +11,11 @@ commonFiles:
     target: repo/apis/Google.Test.V1
   - source: Google.Test.V2
     target: repo/apis/Google.Test.V2
-  - source: Broken.cs
-    target: repo/apis/Google.Test.V1/Google.Test.V1/Broken.cs
 repoFiles:
   - source: global.json
     target: repo/global.json
-  - source: build.sh
-    target: repo/build.sh
+  - source: runintegrationtests.sh
+    target: repo/runintegrationtests.sh
   - source: toolversions.sh
     target: repo/toolversions.sh
   - source: Directory.Packages.props
@@ -27,5 +25,11 @@ repoFiles:
   - source: apis/Directory.Build.targets
     target: repo/apis/Directory.Build.targets
   - source: apis/GoogleApis.snk
-    target: repo/apis/GoogleApis.snk
-expectedExitCode: 1
+    target: repo/apis/GoogleApis.snk    
+fileExpectations:
+  present:
+  - repo/failure-indicator.txt
+  - repo/apis/Google.Test.V2/Google.Test.V2/bin
+  - repo/apis/Google.Test.V2/Google.Test.V2.IntegrationTests/bin
+  absent:
+  - repo/apis/Google.Test.V1/Google.Test.V1/bin

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/IntegrationTestLibrary-FlakyTest/repo/apis/Google.Test.V2/Google.Test.V2.IntegrationTests/FlakyTest.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/IntegrationTestLibrary-FlakyTest/repo/apis/Google.Test.V2/Google.Test.V2.IntegrationTests/FlakyTest.cs
@@ -1,0 +1,32 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License"):
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.IO;
+using Xunit;
+
+namespace Google.Test.V2.IntegrationTests;
+
+public class FlakyTest
+{
+    [Fact]
+    public void FailOnce()
+    {
+        if (File.Exists("/test/repo/failure-indicator.txt"))
+        {
+            return;
+        }
+        File.WriteAllText("/test/repo/failure-indicator.txt", "This test has failed once");
+        Assert.Fail("Failure that will pass on retry");
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/IntegrationTestLibrary-NoTests/metadata.yaml
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/IntegrationTestLibrary-NoTests/metadata.yaml
@@ -1,4 +1,4 @@
-command: build-library
+command: integration-test-library
 args:
 - '--repo-root=/test/repo'
 - '--library-id=Google.Test.V1'
@@ -11,13 +11,11 @@ commonFiles:
     target: repo/apis/Google.Test.V1
   - source: Google.Test.V2
     target: repo/apis/Google.Test.V2
-  - source: Broken.cs
-    target: repo/apis/Google.Test.V1/Google.Test.V1/Broken.cs
 repoFiles:
   - source: global.json
     target: repo/global.json
-  - source: build.sh
-    target: repo/build.sh
+  - source: runintegrationtests.sh
+    target: repo/runintegrationtests.sh
   - source: toolversions.sh
     target: repo/toolversions.sh
   - source: Directory.Packages.props
@@ -27,5 +25,9 @@ repoFiles:
   - source: apis/Directory.Build.targets
     target: repo/apis/Directory.Build.targets
   - source: apis/GoogleApis.snk
-    target: repo/apis/GoogleApis.snk
-expectedExitCode: 1
+    target: repo/apis/GoogleApis.snk    
+fileExpectations:
+  absent:
+  - repo/apis/Google.Test.V1/Google.Test.V1/bin
+  - repo/apis/Google.Test.V2/Google.Test.V2/bin
+  - repo/apis/Google.Test.V2/Google.Test.V2.IntegrationTests/bin

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/IntegrationTestLibrary-PassingTest/metadata.yaml
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/IntegrationTestLibrary-PassingTest/metadata.yaml
@@ -1,7 +1,7 @@
-command: build-library
+command: integration-test-library
 args:
 - '--repo-root=/test/repo'
-- '--library-id=Google.Test.V1'
+- '--library-id=Google.Test.V2'
 commonFiles:
   - source: test-apis.json
     target: repo/generator-input/apis.json
@@ -11,13 +11,11 @@ commonFiles:
     target: repo/apis/Google.Test.V1
   - source: Google.Test.V2
     target: repo/apis/Google.Test.V2
-  - source: Broken.cs
-    target: repo/apis/Google.Test.V1/Google.Test.V1/Broken.cs
 repoFiles:
   - source: global.json
     target: repo/global.json
-  - source: build.sh
-    target: repo/build.sh
+  - source: runintegrationtests.sh
+    target: repo/runintegrationtests.sh
   - source: toolversions.sh
     target: repo/toolversions.sh
   - source: Directory.Packages.props
@@ -27,5 +25,8 @@ repoFiles:
   - source: apis/Directory.Build.targets
     target: repo/apis/Directory.Build.targets
   - source: apis/GoogleApis.snk
-    target: repo/apis/GoogleApis.snk
-expectedExitCode: 1
+    target: repo/apis/GoogleApis.snk    
+fileExpectations:
+  present:
+  - repo/apis/Google.Test.V2/Google.Test.V2/bin
+  - repo/apis/Google.Test.V2/Google.Test.V2.IntegrationTests/bin


### PR DESCRIPTION
It's unfortunate that we need quite a lot of real-repo files, and currently we have to specify those everywhere. We could potentially have some "named file collections" or similar, so you could just specify "copy this set to /repo" but that can come later.