### PR TITLE
feat: Support for Spanner ReadLockMode options

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerTransactionCreationOptionsTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerTransactionCreationOptionsTests.cs
@@ -19,6 +19,8 @@ using static Google.Cloud.Spanner.V1.TransactionOptions.Types;
 using IsolationLevel = System.Data.IsolationLevel;
 using SpannerIsolationLevel = Google.Cloud.Spanner.V1.TransactionOptions.Types.IsolationLevel;
 
+using TransactionReadLockMode = Google.Cloud.Spanner.V1.TransactionOptions.Types.ReadWrite.Types.ReadLockMode;
+
 namespace Google.Cloud.Spanner.Data.Tests;
 public class SpannerTransactionCreationOptionsTests
 {
@@ -63,6 +65,7 @@ public class SpannerTransactionCreationOptionsTests
         Assert.False(readWrite.ExcludeFromChangeStreams);
         Assert.Equal(IsolationLevel.Unspecified, readWrite.IsolationLevel);
         Assert.Equal(new TransactionOptions { ReadWrite = new ReadWrite() }, readWrite.GetTransactionOptions());
+        Assert.Equal(TransactionReadLockMode.Unspecified, readWrite.ReadLockMode);
     }
 
     [Fact]
@@ -79,6 +82,7 @@ public class SpannerTransactionCreationOptionsTests
         Assert.False(partitionedDml.ExcludeFromChangeStreams);
         Assert.Equal(IsolationLevel.Unspecified, partitionedDml.IsolationLevel);
         Assert.Equal(new TransactionOptions { PartitionedDml = new PartitionedDml() }, partitionedDml.GetTransactionOptions());
+        Assert.Equal(TransactionReadLockMode.Unspecified, partitionedDml.ReadLockMode);
     }
 
     [Fact]
@@ -95,6 +99,7 @@ public class SpannerTransactionCreationOptionsTests
         Assert.False(readOnly.ExcludeFromChangeStreams);
         Assert.Equal(IsolationLevel.Unspecified, readOnly.IsolationLevel);
         Assert.Equal(TimestampBound.Strong.ToTransactionOptions(), readOnly.GetTransactionOptions());
+        Assert.Equal(TransactionReadLockMode.Unspecified, readOnly.ReadLockMode);
     }
 
     [Fact]
@@ -110,6 +115,7 @@ public class SpannerTransactionCreationOptionsTests
         Assert.False(options.ExcludeFromChangeStreams);
         Assert.Equal(IsolationLevel.Unspecified, options.IsolationLevel);
         Assert.Equal(TimestampBound.Strong.ToTransactionOptions(), options.GetTransactionOptions());
+        Assert.Equal(TransactionReadLockMode.Unspecified, options.ReadLockMode);
     }
 
     [Fact]
@@ -126,6 +132,7 @@ public class SpannerTransactionCreationOptionsTests
         Assert.False(options.ExcludeFromChangeStreams);
         Assert.Equal(IsolationLevel.Unspecified, options.IsolationLevel);
         Assert.Equal(timestampBound.ToTransactionOptions(), options.GetTransactionOptions());
+        Assert.Equal(TransactionReadLockMode.Unspecified, options.ReadLockMode);
     }
 
     [Fact]
@@ -147,6 +154,7 @@ public class SpannerTransactionCreationOptionsTests
         Assert.False(options.ExcludeFromChangeStreams);
         Assert.Equal(IsolationLevel.Unspecified, options.IsolationLevel);
         Assert.Null(options.GetTransactionOptions());
+        Assert.Equal(TransactionReadLockMode.Unspecified, options.ReadLockMode);
     }
 
     [Fact]
@@ -156,6 +164,38 @@ public class SpannerTransactionCreationOptionsTests
         Assert.True(options.IsDetached);
         options = options.WithIsDetached(false);
         Assert.False(options.IsDetached);
+    }
+
+    [Theory]
+    [InlineData(TransactionReadLockMode.Unspecified)]
+    [InlineData(TransactionReadLockMode.Pessimistic)]
+    [InlineData(TransactionReadLockMode.Optimistic)]
+    public void WithReadLockMode(TransactionReadLockMode readLockMode)
+    {
+        var options = SpannerTransactionCreationOptions.ReadWrite.WithReadLockMode(readLockMode);
+        Assert.Equal(readLockMode, options.ReadLockMode);
+    }
+
+    [Fact]
+    public void WithReadLockMode_ReadOnly()
+    {
+        var oldOptions = SpannerTransactionCreationOptions.ReadOnly;
+        var newOptions = oldOptions.WithReadLockMode(TransactionReadLockMode.Unspecified);
+
+        Assert.Same(oldOptions, newOptions);
+
+        Assert.Throws<ArgumentException>(() => newOptions.WithReadLockMode(TransactionReadLockMode.Optimistic));
+    }
+
+    [Fact]
+    public void WithReadLockMode_PartitionedDml()
+    {
+        var oldOptions = SpannerTransactionCreationOptions.PartitionedDml;
+        var newOptions = oldOptions.WithReadLockMode(TransactionReadLockMode.Unspecified);
+
+        Assert.Same(oldOptions, newOptions);
+
+        Assert.Throws<ArgumentException>(() => newOptions.WithReadLockMode(TransactionReadLockMode.Optimistic));
     }
 
     [Fact]

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerTransactionCreationOptionsTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerTransactionCreationOptionsTests.cs
@@ -19,8 +19,6 @@ using static Google.Cloud.Spanner.V1.TransactionOptions.Types;
 using IsolationLevel = System.Data.IsolationLevel;
 using SpannerIsolationLevel = Google.Cloud.Spanner.V1.TransactionOptions.Types.IsolationLevel;
 
-using TransactionReadLockMode = Google.Cloud.Spanner.V1.TransactionOptions.Types.ReadWrite.Types.ReadLockMode;
-
 namespace Google.Cloud.Spanner.Data.Tests;
 public class SpannerTransactionCreationOptionsTests
 {
@@ -65,7 +63,7 @@ public class SpannerTransactionCreationOptionsTests
         Assert.False(readWrite.ExcludeFromChangeStreams);
         Assert.Equal(IsolationLevel.Unspecified, readWrite.IsolationLevel);
         Assert.Equal(new TransactionOptions { ReadWrite = new ReadWrite() }, readWrite.GetTransactionOptions());
-        Assert.Equal(TransactionReadLockMode.Unspecified, readWrite.ReadLockMode);
+        Assert.Equal(ReadLockMode.Unspecified, readWrite.ReadLockMode);
     }
 
     [Fact]
@@ -82,7 +80,7 @@ public class SpannerTransactionCreationOptionsTests
         Assert.False(partitionedDml.ExcludeFromChangeStreams);
         Assert.Equal(IsolationLevel.Unspecified, partitionedDml.IsolationLevel);
         Assert.Equal(new TransactionOptions { PartitionedDml = new PartitionedDml() }, partitionedDml.GetTransactionOptions());
-        Assert.Equal(TransactionReadLockMode.Unspecified, partitionedDml.ReadLockMode);
+        Assert.Equal(ReadLockMode.Unspecified, partitionedDml.ReadLockMode);
     }
 
     [Fact]
@@ -99,7 +97,7 @@ public class SpannerTransactionCreationOptionsTests
         Assert.False(readOnly.ExcludeFromChangeStreams);
         Assert.Equal(IsolationLevel.Unspecified, readOnly.IsolationLevel);
         Assert.Equal(TimestampBound.Strong.ToTransactionOptions(), readOnly.GetTransactionOptions());
-        Assert.Equal(TransactionReadLockMode.Unspecified, readOnly.ReadLockMode);
+        Assert.Equal(ReadLockMode.Unspecified, readOnly.ReadLockMode);
     }
 
     [Fact]
@@ -115,7 +113,7 @@ public class SpannerTransactionCreationOptionsTests
         Assert.False(options.ExcludeFromChangeStreams);
         Assert.Equal(IsolationLevel.Unspecified, options.IsolationLevel);
         Assert.Equal(TimestampBound.Strong.ToTransactionOptions(), options.GetTransactionOptions());
-        Assert.Equal(TransactionReadLockMode.Unspecified, options.ReadLockMode);
+        Assert.Equal(ReadLockMode.Unspecified, options.ReadLockMode);
     }
 
     [Fact]
@@ -132,7 +130,7 @@ public class SpannerTransactionCreationOptionsTests
         Assert.False(options.ExcludeFromChangeStreams);
         Assert.Equal(IsolationLevel.Unspecified, options.IsolationLevel);
         Assert.Equal(timestampBound.ToTransactionOptions(), options.GetTransactionOptions());
-        Assert.Equal(TransactionReadLockMode.Unspecified, options.ReadLockMode);
+        Assert.Equal(ReadLockMode.Unspecified, options.ReadLockMode);
     }
 
     [Fact]
@@ -154,7 +152,7 @@ public class SpannerTransactionCreationOptionsTests
         Assert.False(options.ExcludeFromChangeStreams);
         Assert.Equal(IsolationLevel.Unspecified, options.IsolationLevel);
         Assert.Null(options.GetTransactionOptions());
-        Assert.Equal(TransactionReadLockMode.Unspecified, options.ReadLockMode);
+        Assert.Equal(ReadLockMode.Unspecified, options.ReadLockMode);
     }
 
     [Fact]
@@ -167,10 +165,10 @@ public class SpannerTransactionCreationOptionsTests
     }
 
     [Theory]
-    [InlineData(TransactionReadLockMode.Unspecified)]
-    [InlineData(TransactionReadLockMode.Pessimistic)]
-    [InlineData(TransactionReadLockMode.Optimistic)]
-    public void WithReadLockMode(TransactionReadLockMode readLockMode)
+    [InlineData(ReadLockMode.Unspecified)]
+    [InlineData(ReadLockMode.Pessimistic)]
+    [InlineData(ReadLockMode.Optimistic)]
+    public void WithReadLockMode(ReadLockMode readLockMode)
     {
         var options = SpannerTransactionCreationOptions.ReadWrite.WithReadLockMode(readLockMode);
         Assert.Equal(readLockMode, options.ReadLockMode);
@@ -180,22 +178,33 @@ public class SpannerTransactionCreationOptionsTests
     public void WithReadLockMode_ReadOnly()
     {
         var oldOptions = SpannerTransactionCreationOptions.ReadOnly;
-        var newOptions = oldOptions.WithReadLockMode(TransactionReadLockMode.Unspecified);
+        var newOptions = oldOptions.WithReadLockMode(ReadLockMode.Unspecified);
 
         Assert.Same(oldOptions, newOptions);
 
-        Assert.Throws<ArgumentException>(() => newOptions.WithReadLockMode(TransactionReadLockMode.Optimistic));
+        Assert.Throws<ArgumentException>(() => newOptions.WithReadLockMode(ReadLockMode.Optimistic));
     }
 
     [Fact]
     public void WithReadLockMode_PartitionedDml()
     {
         var oldOptions = SpannerTransactionCreationOptions.PartitionedDml;
-        var newOptions = oldOptions.WithReadLockMode(TransactionReadLockMode.Unspecified);
+        var newOptions = oldOptions.WithReadLockMode(ReadLockMode.Unspecified);
 
         Assert.Same(oldOptions, newOptions);
 
-        Assert.Throws<ArgumentException>(() => newOptions.WithReadLockMode(TransactionReadLockMode.Optimistic));
+        Assert.Throws<ArgumentException>(() => newOptions.WithReadLockMode(ReadLockMode.Optimistic));
+    }
+
+    [Theory]
+    [InlineData(ReadLockMode.Unspecified, ReadWrite.Types.ReadLockMode.Unspecified)]
+    [InlineData(ReadLockMode.Pessimistic, ReadWrite.Types.ReadLockMode.Pessimistic)]
+    [InlineData(ReadLockMode.Optimistic, ReadWrite.Types.ReadLockMode.Optimistic)]
+    public void ReadLockModeEnumConversion(ReadLockMode readLockMode, ReadWrite.Types.ReadLockMode expectedReadLockMode)
+    {
+        var options = SpannerTransactionCreationOptions.ReadWrite.WithReadLockMode(readLockMode);
+        TransactionOptions spannerBackendOptions = options.GetTransactionOptions();
+        Assert.Equal(expectedReadLockMode, spannerBackendOptions.ReadWrite.ReadLockMode);
     }
 
     [Fact]

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerTransactionCreationOptions.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerTransactionCreationOptions.cs
@@ -18,6 +18,7 @@ using System;
 using static Google.Cloud.Spanner.V1.TransactionOptions.Types;
 using IsolationLevel = System.Data.IsolationLevel;
 using SpannerIsolationLevel = Google.Cloud.Spanner.V1.TransactionOptions.Types.IsolationLevel;
+using TransactionReadLockMode = Google.Cloud.Spanner.V1.TransactionOptions.Types.ReadWrite.Types.ReadLockMode;
 
 namespace Google.Cloud.Spanner.Data;
 
@@ -31,19 +32,19 @@ public sealed class SpannerTransactionCreationOptions
     /// Options that will result in a read-write transaction.
     /// </summary>
     public static SpannerTransactionCreationOptions ReadWrite { get; } = new SpannerTransactionCreationOptions(
-        timestampBound: null, transactionId: null, isDetached: false, isSingleUse: false, isPartitionedDml: false, excludeFromChangeStreams: false, isolationLevel: IsolationLevel.Unspecified);
+        timestampBound: null, transactionId: null, isDetached: false, isSingleUse: false, isPartitionedDml: false, excludeFromChangeStreams: false, isolationLevel: IsolationLevel.Unspecified, readLockMode: TransactionReadLockMode.Unspecified);
 
     /// <summary>
     /// Options that will result in a read-write transaction suitable for executing partioned DML.
     /// </summary>
     public static SpannerTransactionCreationOptions PartitionedDml { get; } = new SpannerTransactionCreationOptions(
-        timestampBound: null, transactionId: null, isDetached: false, isSingleUse: false, isPartitionedDml: true, excludeFromChangeStreams: false, isolationLevel: IsolationLevel.Unspecified);
+        timestampBound: null, transactionId: null, isDetached: false, isSingleUse: false, isPartitionedDml: true, excludeFromChangeStreams: false, isolationLevel: IsolationLevel.Unspecified, readLockMode: TransactionReadLockMode.Unspecified);
 
     /// <summary>
     /// Options that will result in a read-only transaction bound by <see cref="TimestampBound.Strong"/>.
     /// </summary>
     public static SpannerTransactionCreationOptions ReadOnly { get; } = new SpannerTransactionCreationOptions(
-        TimestampBound.Strong, transactionId: null, isDetached: false, isSingleUse: false, isPartitionedDml: false, excludeFromChangeStreams: false, isolationLevel: IsolationLevel.Unspecified);
+        TimestampBound.Strong, transactionId: null, isDetached: false, isSingleUse: false, isPartitionedDml: false, excludeFromChangeStreams: false, isolationLevel: IsolationLevel.Unspecified, readLockMode: TransactionReadLockMode.Unspecified);
 
     /// <summary>
     /// Timestamp bound settings for the transaction. May be null.
@@ -114,7 +115,13 @@ public sealed class SpannerTransactionCreationOptions
     /// </remarks>
     public bool ExcludeFromChangeStreams { get; }
 
-    private SpannerTransactionCreationOptions(TimestampBound timestampBound, TransactionId transactionId, bool isDetached, bool isSingleUse, bool isPartitionedDml, bool excludeFromChangeStreams, IsolationLevel isolationLevel)
+    /// <summary>
+    /// Read lock modes for the transaction.
+    /// Check <see cref="TransactionOptions.Types.ReadWrite.ReadLockMode"/> for enum values and their intended behaviours.
+    /// </summary>
+    public TransactionReadLockMode ReadLockMode { get; }
+
+    private SpannerTransactionCreationOptions(TimestampBound timestampBound, TransactionId transactionId, bool isDetached, bool isSingleUse, bool isPartitionedDml, bool excludeFromChangeStreams, IsolationLevel isolationLevel, TransactionReadLockMode readLockMode)
     {
         GaxPreconditions.CheckArgument(
             timestampBound is null || transactionId is null,
@@ -151,6 +158,11 @@ public sealed class SpannerTransactionCreationOptions
             nameof(isolationLevel),
             $"Isolation Level can only be specified for read-write transactions. This transaction would be {TransactionMode} and the specified level is {isolationLevel}");
         IsolationLevel = isolationLevel;
+        GaxPreconditions.CheckArgument(
+            (TransactionMode == TransactionMode.ReadWrite && !isPartitionedDml) || readLockMode == TransactionReadLockMode.Unspecified,
+            nameof(readLockMode),
+            $"Read lock mode can only be specified for read-write and non partitioned DML transactions. {TransactionMode}, {readLockMode}");
+        ReadLockMode = readLockMode;
     }
 
     /// <summary>
@@ -170,7 +182,8 @@ public sealed class SpannerTransactionCreationOptions
             isSingleUse: timestampBound?.Mode == TimestampBoundMode.MinReadTimestamp || timestampBound?.Mode == TimestampBoundMode.MaxStaleness,
             isPartitionedDml: false,
             excludeFromChangeStreams: false,
-            isolationLevel: IsolationLevel.Unspecified);
+            isolationLevel: IsolationLevel.Unspecified,
+            readLockMode: TransactionReadLockMode.Unspecified);
 
     /// <summary>
     /// Creates transaction options with the given <paramref name="transactionId"/>.
@@ -186,7 +199,8 @@ public sealed class SpannerTransactionCreationOptions
             isSingleUse: false,
             isPartitionedDml: false,
             excludeFromChangeStreams: false,
-            isolationLevel: IsolationLevel.Unspecified);
+            isolationLevel: IsolationLevel.Unspecified,
+             readLockMode: TransactionReadLockMode.Unspecified);
 
     /// <summary>
     /// Options used to acquire the transaction's underlying session.
@@ -200,6 +214,11 @@ public sealed class SpannerTransactionCreationOptions
         {
             options.ExcludeTxnFromChangeStreams = ExcludeFromChangeStreams;
             options.IsolationLevel = ConvertToSpannerIsolatonLevel(IsolationLevel);
+
+            if(options.ReadWrite is not null)
+            {
+                options.ReadWrite.ReadLockMode = ReadLockMode;
+            }
         }
 
         SpannerIsolationLevel ConvertToSpannerIsolatonLevel(IsolationLevel isolationLevel) => isolationLevel switch
@@ -220,7 +239,7 @@ public sealed class SpannerTransactionCreationOptions
     /// If <see cref="TransactionId"/> is set, <see cref="IsDetached"/> cannot be false.
     /// </summary>
     public SpannerTransactionCreationOptions WithIsDetached(bool isDetached) =>
-        isDetached == IsDetached ? this : new SpannerTransactionCreationOptions(TimestampBound, TransactionId, isDetached, IsSingleUse, IsPartitionedDml, ExcludeFromChangeStreams, IsolationLevel);
+        isDetached == IsDetached ? this : new SpannerTransactionCreationOptions(TimestampBound, TransactionId, isDetached, IsSingleUse, IsPartitionedDml, ExcludeFromChangeStreams, IsolationLevel, ReadLockMode);
 
     /// <summary>
     /// Returns a new instance identical to this one except for the value of <see cref="IsSingleUse"/>.
@@ -229,19 +248,26 @@ public sealed class SpannerTransactionCreationOptions
     /// <see cref="IsSingleUse"/> cannot be false.
     /// </summary>
     public SpannerTransactionCreationOptions WithIsSingleUse(bool isSingleUse) =>
-        isSingleUse == IsSingleUse ? this : new SpannerTransactionCreationOptions(TimestampBound, TransactionId, IsDetached, isSingleUse, IsPartitionedDml, ExcludeFromChangeStreams, IsolationLevel);
+        isSingleUse == IsSingleUse ? this : new SpannerTransactionCreationOptions(TimestampBound, TransactionId, IsDetached, isSingleUse, IsPartitionedDml, ExcludeFromChangeStreams, IsolationLevel, ReadLockMode);
 
     /// <summary>
     /// Returns a new instance identical to this one except for the value of <see cref="ExcludeFromChangeStreams"/>.
     /// <see cref="ExcludeFromChangeStreams"/> can only be true for read-write transactions.
     /// </summary>
     public SpannerTransactionCreationOptions WithExcludeFromChangeStreams(bool excludeFromChangeStreams) =>
-        excludeFromChangeStreams == ExcludeFromChangeStreams ? this : new SpannerTransactionCreationOptions(TimestampBound, TransactionId, IsDetached, IsSingleUse, IsPartitionedDml, excludeFromChangeStreams, IsolationLevel);
+        excludeFromChangeStreams == ExcludeFromChangeStreams ? this : new SpannerTransactionCreationOptions(TimestampBound, TransactionId, IsDetached, IsSingleUse, IsPartitionedDml, excludeFromChangeStreams, IsolationLevel, ReadLockMode);
 
     /// <summary>
     /// Returns a new instance identical to this one except for the value of <see cref="IsolationLevel"/>.
     /// <see cref="IsolationLevel"/> can only be set for read-write transactions.
     /// </summary>
     public SpannerTransactionCreationOptions WithIsolationLevel(IsolationLevel isolationLevel) =>
-        isolationLevel == IsolationLevel ? this : new SpannerTransactionCreationOptions(TimestampBound, TransactionId, IsDetached, IsSingleUse, IsPartitionedDml, ExcludeFromChangeStreams, isolationLevel);
+        isolationLevel == IsolationLevel ? this : new SpannerTransactionCreationOptions(TimestampBound, TransactionId, IsDetached, IsSingleUse, IsPartitionedDml, ExcludeFromChangeStreams, isolationLevel, ReadLockMode);
+
+    /// <summary>
+    /// Returns a new instance identical to this one except for the value of <see cref="ReadLockMode"/>.
+    /// <see cref="ReadLockMode"/> can only be set for read-write transactions.
+    /// </summary>
+    public SpannerTransactionCreationOptions WithReadLockMode(TransactionReadLockMode readLockMode) =>
+        readLockMode == ReadLockMode ? this : new SpannerTransactionCreationOptions(TimestampBound, TransactionId, IsDetached, IsSingleUse, IsPartitionedDml, ExcludeFromChangeStreams, IsolationLevel, readLockMode);
 }


### PR DESCRIPTION
Keeping the ReadLockMode getter `public`. Clients should be able to set the property via chaining through the `WithReadLockMode` method giving us better control over validation of the property.