### PR TITLE
chore: ignore google/cloud/maintenance/api/v1beta for now

### DIFF
--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -4218,6 +4218,7 @@
         "google/cloud/licensemanager/v1",
         "google/cloud/redis/cluster/v1beta1",
         "google/cloud/configdelivery/v1alpha",
-        "google/cloud/geminidataanalytics/v1alpha"
+        "google/cloud/geminidataanalytics/v1alpha",
+        "google/cloud/maintenance/api/v1beta"
     ]
 }


### PR DESCRIPTION
Some proto messages are missing doc comments.
See b/425568875