### PR TITLE
fix: when library-id is empty, build all libraries

### DIFF
--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/BuildLibrary-All/metadata.yaml
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/BuildLibrary-All/metadata.yaml
@@ -1,0 +1,32 @@
+command: build-library
+args:
+- '--repo-root=/test/repo'
+- '--library-id='
+commonFiles:
+  - source: test-apis.json
+    target: repo/generator-input/apis.json
+  - source: test-state.json
+    target: repo/generator-input/pipeline-state.json
+  - source: Google.Test.V1
+    target: repo/apis/Google.Test.V1
+  - source: Google.Test.V2
+    target: repo/apis/Google.Test.V2
+repoFiles:
+  - source: global.json
+    target: repo/global.json
+  - source: build.sh
+    target: repo/build.sh
+  - source: toolversions.sh
+    target: repo/toolversions.sh
+  - source: Directory.Packages.props
+    target: repo/Directory.Packages.props
+  - source: apis/Directory.Build.props
+    target: repo/apis/Directory.Build.props
+  - source: apis/Directory.Build.targets
+    target: repo/apis/Directory.Build.targets
+  - source: apis/GoogleApis.snk
+    target: repo/apis/GoogleApis.snk
+fileExpectations:
+  present:
+  - repo/apis/Google.Test.V1/Google.Test.V1/bin
+  - repo/apis/Google.Test.V2/Google.Test.V2/bin

--- a/tools/Google.Cloud.Tools.ReleaseManager/ContainerCommands/ContainerOptions.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/ContainerCommands/ContainerOptions.cs
@@ -93,7 +93,7 @@ public class ContainerOptions
     internal string RequireOption(string option, [CallerArgumentExpression("option")] string expression = null) =>
         option ?? throw new UserErrorException($"Option for {expression} is required");
 
-    internal List<ApiMetadata> GetApisFromLibraryId(ApiCatalog catalog) => LibraryId is null ? catalog.Apis
+    internal List<ApiMetadata> GetApisFromLibraryId(ApiCatalog catalog) => string.IsNullOrEmpty(LibraryId) ? catalog.Apis
         : catalog.PackageGroups.FirstOrDefault(pg => pg.Id == LibraryId) is PackageGroup group ? group.PackageIds.Select(id => catalog[id]).ToList()
         : new() { catalog[LibraryId] };
 }


### PR DESCRIPTION
(This is only used in the update-image-tag CLI command.)