### PR TITLE
chore: update to .NET 8.0.411 and GAPIC generator 1.4.34

### DIFF
--- a/Dockerfile.generator
+++ b/Dockerfile.generator
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0.410-jammy AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0.411-jammy AS build
 COPY --from=mcr.microsoft.com/dotnet/sdk:6.0.414-jammy /usr/share/dotnet/sdk /usr/share/dotnet/sdk
 COPY --from=mcr.microsoft.com/dotnet/sdk:6.0.414-jammy /usr/share/dotnet/shared /usr/share/dotnet/shared
 
@@ -40,7 +40,7 @@ RUN dotnet build tweaks/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Genera
 # Install protobuf, the gRPC plugin and GAPIC generator, ready to run
 RUN bash -c 'source toolversions.sh && install_protoc && install_microgenerator && install_grpc'
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0.410-jammy
+FROM mcr.microsoft.com/dotnet/sdk:8.0.411-jammy
 # Whatever SDKs and runtimes we picked up earlier, copy them over.
 COPY --from=build /usr/share/dotnet/sdk /usr/share/dotnet/sdk
 COPY --from=build /usr/share/dotnet/shared /usr/share/dotnet/shared

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.410",
+    "version": "8.0.411",
     "allowPrerelease": false,
     "rollForward": "latestMinor"
   }

--- a/toolversions.sh
+++ b/toolversions.sh
@@ -13,7 +13,7 @@ declare -r PROTOC_VERSION=3.25.2
 declare -r GRPC_VERSION=2.60.0
 if [[ $GAPIC_GENERATOR_VERSION == "" ]]
 then
-  declare -r GAPIC_GENERATOR_VERSION=v1.4.33
+  declare -r GAPIC_GENERATOR_VERSION=v1.4.34
 else
   echo "Using GAPIC generator override: ${GAPIC_GENERATOR_VERSION}"
 fi


### PR DESCRIPTION
When this is merged, we should create and push a new Librarian container image.