### PR TITLE
chore: re-enable Google.Cloud.Compute.V1 generation

### DIFF
--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -1020,7 +1020,7 @@
         {
             "id": "Google.Cloud.Compute.V1",
             "currentVersion": "3.9.0",
-            "generationAutomationLevel": "AUTOMATION_LEVEL_BLOCKED",
+            "generationAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseTimestamp": "2025-04-23T17:04:24Z",
             "lastGeneratedCommit": "a5443137a48ea08092643716dc251c13087e438f",


### PR DESCRIPTION
This now works as we've updated the GAPIC generator.

(We should only merge this after updating to the new container image, obviously - hence the do-not-merge label.)