### PR TITLE
tests: Add smoke tests for Gemini Data Analytics.

### DIFF
--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/smoketests.json
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/smoketests.json
@@ -1,0 +1,34 @@
+[
+  {
+    "method": "ListLocations",
+    "client": "DataAgentServiceClient",
+    "clientNavigationProperty": "LocationsClient",
+    "skip": "b/428834051",
+    "arguments": {
+      "request": {
+        "name": "projects/${PROJECT_ID}"
+      }
+    }
+  },
+  {
+    "method": "ListDataAgents",
+    "client": "DataAgentServiceClient",
+    "arguments": {
+      "parent": "projects/${PROJECT_ID}/locations/global"
+    }
+  },
+  {
+    "method": "ListAccessibleDataAgents",
+    "client": "DataAgentServiceClient",
+    "arguments": {
+      "parent": "projects/${PROJECT_ID}/locations/global"
+    }
+  },
+  {
+    "method": "ListConversations",
+    "client": "DataChatServiceClient",
+    "arguments": {
+      "parent": "projects/${PROJECT_ID}/locations/global"
+    }
+  }
+]


### PR DESCRIPTION
See cl/780098686 for corresponding internal permissions.