### PR TITLE
chore: Prep Google.Cloud.Maintenance.Api.V1Beta for release

### DIFF
--- a/apis/Google.Cloud.Maintenance.Api.V1Beta/smoketests.json
+++ b/apis/Google.Cloud.Maintenance.Api.V1Beta/smoketests.json
@@ -1,0 +1,16 @@
+[
+  {
+    "method": "SummarizeMaintenances",
+    "client": "MaintenanceClient",
+    "arguments": {
+      "parent": "projects/${PROJECT_ID}/locations/us-east1"
+    }
+  },
+  {
+    "method": "ListResourceMaintenances",
+    "client": "MaintenanceClient",
+    "arguments": {
+      "parent": "projects/${PROJECT_ID}/locations/us-east1"
+    }
+  }
+]

--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -4244,7 +4244,7 @@
             "id": "Google.Cloud.Maintenance.Api.V1Beta",
             "nextVersion": "1.0.0-beta01",
             "generationAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
-            "releaseAutomationLevel": "AUTOMATION_LEVEL_BLOCKED",
+            "releaseAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "lastGeneratedCommit": "9510a3a5c2932c84616d4f03856bc0aa4826cc31",
             "apiPaths": [
                 "google/cloud/maintenance/api/v1beta"


### PR DESCRIPTION
- Adds smoke tests
- Signals that Librarian can release 1.0.0-beta01

Internal CI permissions in cl/781434695