### PR TITLE
chore: do not configure google/shopping/merchant/reports/v1alpha

### DIFF
--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -4264,6 +4264,7 @@
         "google/cloud/licensemanager/v1",
         "google/cloud/redis/cluster/v1beta1",
         "google/cloud/configdelivery/v1alpha",
-        "google/cloud/geminidataanalytics/v1alpha"
+        "google/cloud/geminidataanalytics/v1alpha",
+        "google/shopping/merchant/reports/v1alpha"
     ]
 }


### PR DESCRIPTION
(It looks like this isn't actually required. We can unignore it if necessary.)