### PR TITLE
chore: use an approved base image for Librarian container

### DIFF
--- a/Dockerfile.generator
+++ b/Dockerfile.generator
@@ -12,9 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0.411-jammy AS build
-COPY --from=mcr.microsoft.com/dotnet/sdk:6.0.414-jammy /usr/share/dotnet/sdk /usr/share/dotnet/sdk
-COPY --from=mcr.microsoft.com/dotnet/sdk:6.0.414-jammy /usr/share/dotnet/shared /usr/share/dotnet/shared
+FROM marketplace.gcr.io/google/debian12:latest AS dotnet-base
+
+RUN apt-get update
+RUN apt-get install -y curl git
+
+RUN curl https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -o packages-microsoft-prod.deb
+RUN dpkg -i packages-microsoft-prod.deb
+RUN rm packages-microsoft-prod.deb
+# TODO(https://github.com/googleapis/google-cloud-dotnet/issues/14957): Remove dotnet-sdk-6.0
+RUN apt-get update && apt-get install -y dotnet-sdk-8.0 dotnet-sdk-6.0
+
+FROM dotnet-base AS build
 
 WORKDIR /src
 
@@ -40,10 +49,7 @@ RUN dotnet build tweaks/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Genera
 # Install protobuf, the gRPC plugin and GAPIC generator, ready to run
 RUN bash -c 'source toolversions.sh && install_protoc && install_microgenerator && install_grpc'
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0.411-jammy
-# Whatever SDKs and runtimes we picked up earlier, copy them over.
-COPY --from=build /usr/share/dotnet/sdk /usr/share/dotnet/sdk
-COPY --from=build /usr/share/dotnet/shared /usr/share/dotnet/shared
+FROM dotnet-base
 
 WORKDIR /app
 COPY --from=build /src/packages/Google.Protobuf.Tools.* protobuf


### PR DESCRIPTION
Installing the .NET SDK from a separate feed isn't ideal; need to investigate this further. (An alternative is to use Ubuntu as a base image, as Ubuntu provides .NET directly.)