### PR TITLE
tools: enable Librarian to publish Google.Cloud.Tools packages

### DIFF
--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/CommonFiles/Google.Cloud.Tools.TestTool.IntegrationTests/Google.Cloud.Tools.TestTool.IntegrationTests.csproj
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/CommonFiles/Google.Cloud.Tools.TestTool.IntegrationTests/Google.Cloud.Tools.TestTool.IntegrationTests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <ProjectReference Include="..\Google.Cloud.Tools.TestTool\Google.Cloud.Tools.TestTool.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/CommonFiles/Google.Cloud.Tools.TestTool.IntegrationTests/PassingTest.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/CommonFiles/Google.Cloud.Tools.TestTool.IntegrationTests/PassingTest.cs
@@ -1,0 +1,27 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License"):
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+namespace Google.Cloud.Tools.TestTool.IntegrationTests;
+
+public class PassingTest
+{
+    [Fact]
+    public void ConstructorDoesNotThrowException()
+    {
+        var tool = new Tool();
+        Assert.NotNull(tool);
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/CommonFiles/Google.Cloud.Tools.TestTool.Tests/Google.Cloud.Tools.TestTool.Tests.csproj
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/CommonFiles/Google.Cloud.Tools.TestTool.Tests/Google.Cloud.Tools.TestTool.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <ProjectReference Include="..\Google.Cloud.Tools.TestTool\Google.Cloud.Tools.TestTool.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/CommonFiles/Google.Cloud.Tools.TestTool.Tests/PassingTest.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/CommonFiles/Google.Cloud.Tools.TestTool.Tests/PassingTest.cs
@@ -1,0 +1,27 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License"):
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+namespace Google.Cloud.Tools.TestTool.Tests;
+
+public class PassingTest
+{
+    [Fact]
+    public void ConstructorDoesNotThrowException()
+    {
+        var tool = new Tool();
+        Assert.NotNull(tool);
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/CommonFiles/Google.Cloud.Tools.TestTool/Google.Cloud.Tools.TestTool.csproj
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/CommonFiles/Google.Cloud.Tools.TestTool/Google.Cloud.Tools.TestTool.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../DotnetToolProperties.xml" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Version>1.2.0</Version>
+    <Description>Not a real tool.</Description>
+    <ToolCommandName>test-tool</ToolCommandName>
+  </PropertyGroup>
+</Project>

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/CommonFiles/Google.Cloud.Tools.TestTool/Tool.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/CommonFiles/Google.Cloud.Tools.TestTool/Tool.cs
@@ -1,0 +1,26 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License"):
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Google.Cloud.Tools.TestTool;
+
+/// <summary>
+/// This is a tool.
+/// </summary>
+public class Tool
+{
+    private static void Main()
+    {
+        System.Console.WriteLine("This is a tool");
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/BuildLibrary-Tools-Broken/metadata.yaml
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/BuildLibrary-Tools-Broken/metadata.yaml
@@ -1,0 +1,22 @@
+command: build-library
+args:
+- '--repo-root=/test/repo'
+- '--library-id=Google.Cloud.Tools.TestTool'
+- '--test=true'
+commonFiles:
+  - source: test-apis.json
+    target: repo/generator-input/apis.json
+  - source: test-state.json
+    target: repo/generator-input/pipeline-state.json
+  - source: Google.Cloud.Tools.TestTool
+    target: repo/tools/Google.Cloud.Tools.TestTool
+  - source: Broken.cs
+    target: repo/tools/Google.Cloud.Tools.TestTool/Broken.cs
+repoFiles:
+  - source: global.json
+    target: repo/global.json
+  - source: Directory.Packages.props
+    target: repo/Directory.Packages.props
+  - source: tools
+    target: repo/tools
+expectedExitCode: 1

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/BuildLibrary-Tools-FailingTest/metadata.yaml
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/BuildLibrary-Tools-FailingTest/metadata.yaml
@@ -1,0 +1,22 @@
+command: build-library
+args:
+- '--repo-root=/test/repo'
+- '--library-id=Google.Cloud.Tools.TestTool'
+- '--test=true'
+commonFiles:
+  - source: test-apis.json
+    target: repo/generator-input/apis.json
+  - source: test-state.json
+    target: repo/generator-input/pipeline-state.json
+  - source: Google.Cloud.Tools.TestTool
+    target: repo/tools/Google.Cloud.Tools.TestTool
+  - source: Google.Cloud.Tools.TestTool.Tests
+    target: repo/tools/Google.Cloud.Tools.TestTool.Tests
+repoFiles:
+  - source: global.json
+    target: repo/global.json
+  - source: Directory.Packages.props
+    target: repo/Directory.Packages.props
+  - source: tools
+    target: repo/tools
+expectedExitCode: 1

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/BuildLibrary-Tools-FailingTest/repo/tools/Google.Cloud.Tools.TestTool.Tests/FailingTest.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/BuildLibrary-Tools-FailingTest/repo/tools/Google.Cloud.Tools.TestTool.Tests/FailingTest.cs
@@ -1,0 +1,26 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License"):
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+namespace Google.Cloud.Tools.TestTool.Tests;
+
+public class FailingTest
+{
+    [Fact]
+    public void FailAlways()
+    {
+        Assert.Fail("This test always fails.");
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/BuildLibrary-Tools-Working-NoTests/metadata.yaml
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/BuildLibrary-Tools-Working-NoTests/metadata.yaml
@@ -1,0 +1,22 @@
+command: build-library
+args:
+- '--repo-root=/test/repo'
+- '--library-id=Google.Cloud.Tools.TestTool'
+- '--test=true'
+commonFiles:
+  - source: test-apis.json
+    target: repo/generator-input/apis.json
+  - source: test-state.json
+    target: repo/generator-input/pipeline-state.json
+  - source: Google.Cloud.Tools.TestTool
+    target: repo/tools/Google.Cloud.Tools.TestTool
+repoFiles:
+  - source: global.json
+    target: repo/global.json
+  - source: Directory.Packages.props
+    target: repo/Directory.Packages.props
+  - source: tools
+    target: repo/tools
+fileExpectations:
+  present:
+  - repo/tools/Google.Cloud.Tools.TestTool/bin

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/BuildLibrary-Tools-Working/metadata.yaml
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/BuildLibrary-Tools-Working/metadata.yaml
@@ -1,0 +1,25 @@
+command: build-library
+args:
+- '--repo-root=/test/repo'
+- '--library-id=Google.Cloud.Tools.TestTool'
+- '--test=true'
+commonFiles:
+  - source: test-apis.json
+    target: repo/generator-input/apis.json
+  - source: test-state.json
+    target: repo/generator-input/pipeline-state.json
+  - source: Google.Cloud.Tools.TestTool
+    target: repo/tools/Google.Cloud.Tools.TestTool
+  - source: Google.Cloud.Tools.TestTool.Tests
+    target: repo/tools/Google.Cloud.Tools.TestTool.Tests
+repoFiles:
+  - source: global.json
+    target: repo/global.json
+  - source: Directory.Packages.props
+    target: repo/Directory.Packages.props
+  - source: tools
+    target: repo/tools
+fileExpectations:
+  present:
+  - repo/tools/Google.Cloud.Tools.TestTool/bin
+  - repo/tools/Google.Cloud.Tools.TestTool.Tests/bin

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/IntegrationTestLibrary-Tools-FailingTest/metadata.yaml
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/IntegrationTestLibrary-Tools-FailingTest/metadata.yaml
@@ -1,0 +1,23 @@
+command: integration-test-library
+args:
+- '--repo-root=/test/repo'
+- '--library-id=Google.Cloud.Tools.TestTool'
+commonFiles:
+  - source: test-apis.json
+    target: repo/generator-input/apis.json
+  - source: test-state.json
+    target: repo/generator-input/pipeline-state.json
+  - source: Google.Cloud.Tools.TestTool
+    target: repo/tools/Google.Cloud.Tools.TestTool
+  - source: Google.Cloud.Tools.TestTool.Tests
+    target: repo/tools/Google.Cloud.Tools.TestTool.Tests
+  - source: Google.Cloud.Tools.TestTool.Tests
+    target: repo/tools/Google.Cloud.Tools.TestTool.IntegrationTests
+repoFiles:
+  - source: global.json
+    target: repo/global.json
+  - source: Directory.Packages.props
+    target: repo/Directory.Packages.props
+  - source: tools
+    target: repo/tools
+expectedExitCode: 1

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/IntegrationTestLibrary-Tools-FailingTest/repo/tools/Google.Cloud.Tools.TestTool.IntegrationTests/FailingTest.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/IntegrationTestLibrary-Tools-FailingTest/repo/tools/Google.Cloud.Tools.TestTool.IntegrationTests/FailingTest.cs
@@ -1,0 +1,27 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License"):
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.IO;
+using Xunit;
+
+namespace Google.Cloud.Tools.TestTool.IntegrationTests;
+
+public class FailingTest
+{
+    [Fact]
+    public void FailAlways()
+    {
+        Assert.Fail("This test always fails.");
+    }
+}

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/IntegrationTestLibrary-Tools-NoTests/metadata.yaml
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/IntegrationTestLibrary-Tools-NoTests/metadata.yaml
@@ -1,0 +1,20 @@
+command: integration-test-library
+args:
+- '--repo-root=/test/repo'
+- '--library-id=Google.Cloud.Tools.TestTool'
+commonFiles:
+  - source: test-apis.json
+    target: repo/generator-input/apis.json
+  - source: test-state.json
+    target: repo/generator-input/pipeline-state.json
+  - source: Google.Cloud.Tools.TestTool
+    target: repo/tools/Google.Cloud.Tools.TestTool
+  - source: Google.Cloud.Tools.TestTool.Tests
+    target: repo/tools/Google.Cloud.Tools.TestTool.Tests
+repoFiles:
+  - source: global.json
+    target: repo/global.json
+  - source: Directory.Packages.props
+    target: repo/Directory.Packages.props
+  - source: tools
+    target: repo/tools

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/IntegrationTestLibrary-Tools-PassingTest/metadata.yaml
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/IntegrationTestLibrary-Tools-PassingTest/metadata.yaml
@@ -1,0 +1,25 @@
+command: integration-test-library
+args:
+- '--repo-root=/test/repo'
+- '--library-id=Google.Cloud.Tools.TestTool'
+commonFiles:
+  - source: test-apis.json
+    target: repo/generator-input/apis.json
+  - source: test-state.json
+    target: repo/generator-input/pipeline-state.json
+  - source: Google.Cloud.Tools.TestTool
+    target: repo/tools/Google.Cloud.Tools.TestTool
+  - source: Google.Cloud.Tools.TestTool.Tests
+    target: repo/tools/Google.Cloud.Tools.TestTool.Tests
+  - source: Google.Cloud.Tools.TestTool.IntegrationTests
+    target: repo/tools/Google.Cloud.Tools.TestTool.IntegrationTests
+repoFiles:
+  - source: global.json
+    target: repo/global.json
+  - source: Directory.Packages.props
+    target: repo/Directory.Packages.props
+  - source: tools
+    target: repo/tools
+fileExpectations:
+  present:
+  - repo/tools/Google.Cloud.Tools.TestTool.IntegrationTests/bin

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/PackageLibrary-Tools/metadata.yaml
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/PackageLibrary-Tools/metadata.yaml
@@ -1,0 +1,40 @@
+command: package-library
+args:
+- '--repo-root=/test/repo'
+- '--library-id=Google.Cloud.Tools.TestTool'
+- '--output=/test/output'
+commonFiles:
+  # This is the simplest way of creating an empty directory
+  - source: irrelevant-content
+    target: output/.ignored
+  - source: test-apis.json
+    target: repo/generator-input/apis.json
+  - source: test-state.json
+    target: repo/generator-input/pipeline-state.json
+  - source: Google.Cloud.Tools.TestTool
+    target: repo/tools/Google.Cloud.Tools.TestTool
+  - source: Google.Cloud.Tools.TestTool.Tests
+    target: repo/tools/Google.Cloud.Tools.TestTool.Tests
+repoFiles:
+  - source: global.json
+    target: repo/global.json
+  - source: runintegrationtests.sh
+    target: repo/runintegrationtests.sh
+  - source: toolversions.sh
+    target: repo/toolversions.sh
+  - source: Directory.Packages.props
+    target: repo/Directory.Packages.props
+  - source: LICENSE
+    target: repo/LICENSE
+  - source: NuGetIcon.png
+    target: repo/NuGetIcon.png
+  - source: tools
+    target: repo/tools
+fileExpectations:
+  present:
+  - output/Google.Cloud.Tools.TestTool.1.2.0.nupkg
+  - output/Google.Cloud.Tools.TestTool.1.2.0.nupkg-sbom.spdx.json
+  - output/package-owner.txt
+  containsText:
+  - file: output/package-owner.txt
+    text: google-cloud

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/PrepareLibraryRelease-Tools/metadata.yaml
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerTests/PrepareLibraryRelease-Tools/metadata.yaml
@@ -1,0 +1,25 @@
+command: prepare-library-release
+args:
+- '--repo-root=/test/repo'
+- '--library-id=Google.Cloud.Tools.TestTool'
+- '--version=1.3.0'
+- '--release-notes=/test/inputs/release-notes.txt'
+commonFiles:
+  - source: test-apis.json
+    target: repo/generator-input/apis.json
+  - source: test-state.json
+    target: repo/generator-input/pipeline-state.json
+  - source: Google.Cloud.Tools.TestTool
+    target: repo/tools/Google.Cloud.Tools.TestTool
+repoFiles:
+  - source: global.json
+    target: repo/global.json
+  - source: Directory.Packages.props
+    target: repo/Directory.Packages.props
+  - source: tools
+    target: repo/tools
+fileExpectations:
+  containsText:
+  # The project file contains the new version number
+  - file: repo/tools/Google.Cloud.Tools.TestTool/Google.Cloud.Tools.TestTool.csproj
+    text: 1.3.0

--- a/tools/Google.Cloud.Tools.ReleaseManager/ContainerCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/ContainerCommand.cs
@@ -75,6 +75,10 @@ public sealed class ContainerCommand : ICommand
             {
                 return UtilityDocCommands.Execute(args[0], options);
             }
+            if (options.LibraryId?.StartsWith("Google.Cloud.Tools.", StringComparison.Ordinal) == true)
+            {
+                return ToolCommands.Execute(args[0], options);
+            }
 
             return subcommand.Execute(options);
         }

--- a/tools/Google.Cloud.Tools.ReleaseManager/ContainerCommands/ToolCommands.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/ContainerCommands/ToolCommands.cs
@@ -1,0 +1,105 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License"):
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Tools.Common;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Google.Cloud.Tools.ReleaseManager.ContainerCommands;
+
+/// <summary>
+/// Everything that needs to run for dotnet tools under the tools/ directory.
+/// This is invoked for any library starting "Google.Cloud.Tools"
+/// </summary>
+internal static class ToolCommands
+{
+    internal static int Execute(string subcommand, ContainerOptions options)
+    {
+        return subcommand switch
+        {
+            // Package publication is exactly the same as for a library.
+            // (We've already built the package at that point.)
+            ContainerCommand.PublishLibrary => new PublishLibraryCommand().Execute(options),
+            ContainerCommand.IntegrationTestLibrary => IntegrationTest(options),
+            ContainerCommand.PackageLibrary => Package(options),
+            ContainerCommand.BuildLibrary => Build(options),
+            ContainerCommand.PrepareLibraryRelease => AdjustVersion(options),
+            _ => LogSkip(subcommand, options.LibraryId),
+        };
+
+        static int LogSkip(string subcommand, string libraryId)
+        {
+            Console.WriteLine($"Skipping {subcommand} for tool {libraryId}");
+            return 0;
+        }
+    }
+
+    private static int Build(ContainerOptions options)
+    {
+        var repoRoot = options.RequireOption(options.RepoRoot);
+        Processes.RunDotnet(repoRoot, "build",
+            "-c", "Release",
+            $"tools/{options.LibraryId}");
+
+        MaybeTest(options, "Tests");
+        return 0;
+    }
+
+    private static int Package(ContainerOptions options)
+    {
+        var repoRoot = options.RequireOption(options.RepoRoot);
+        var outputDirectory = options.RequireOption(options.Output);
+        // All tools are owned by "google-cloud"
+        File.WriteAllText(Path.Combine(outputDirectory, PackageLibraryCommand.PackageOwnerFile), "google-cloud");
+        Processes.RunDotnet(repoRoot, "pack",
+            "-c", "Release",
+            "-o", outputDirectory,
+            $"tools/{options.LibraryId}");
+        var packages = Directory.GetFiles(outputDirectory, "*.nupkg");
+        foreach (var package in packages)
+        {
+            // Run from the container directory to use the tool configuration from there.
+            Processes.RunDotnet("/app", "generate-sbom", package);
+        }
+        return 0;
+    }
+
+    private static int IntegrationTest(ContainerOptions options)
+    {
+        MaybeTest(options, "IntegrationTests");
+        return 0;
+    }
+
+    private static void MaybeTest(ContainerOptions options, string suffix)
+    {
+        var repoRoot = options.RequireOption(options.RepoRoot);
+        var testDirectory = Path.Combine(repoRoot, "tools", $"{options.LibraryId}.{suffix}");
+        if (Directory.Exists(testDirectory))
+        {
+            Processes.RunDotnet(repoRoot, "test", "-c", "Release", testDirectory);
+        }
+    }
+
+    private static int AdjustVersion(ContainerOptions options)
+    {
+        var repoRoot = options.RequireOption(options.RepoRoot);
+        var projectFile = Path.Combine(repoRoot, $"tools/{options.LibraryId}/{options.LibraryId}.csproj");
+        var text = File.ReadAllText(projectFile);
+        var modified = Regex.Replace(text, "<Version>[^<]+</Version>", options.Version);
+        File.WriteAllText(projectFile, modified);
+        return 0;
+    }
+}


### PR DESCRIPTION
This will allow us to easily release new versions of docuploader and generate-sbom to use .NET 8.