### PR TITLE
tools: allow 0 as a structured version major component

### DIFF
--- a/tools/Google.Cloud.Tools.Common.Tests/Google.Cloud.Tools.Common.Tests.csproj
+++ b/tools/Google.Cloud.Tools.Common.Tests/Google.Cloud.Tools.Common.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+    <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <ProjectReference Include="..\Google.Cloud.Tools.Common\Google.Cloud.Tools.Common.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/Google.Cloud.Tools.Common.Tests/StructuredVersionTest.cs
+++ b/tools/Google.Cloud.Tools.Common.Tests/StructuredVersionTest.cs
@@ -1,0 +1,50 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License"):
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Xunit;
+
+namespace Google.Cloud.Tools.Common.Tests;
+
+public class StructuredVersionTest
+{
+    [Theory]
+    [InlineData("0.1.0", 0, 1, 0, null, null, false)]
+    [InlineData("1.2.3-beta01", 1, 2, 3, null, "beta01", false)]
+    [InlineData("1.2.3", 1, 2, 3, null, null, true)]
+    [InlineData("1.2.3.4", 1, 2, 3, 4, null, true)]
+    public void FromString_Valid(string text, int major, int minor, int patch, int? build, string prerelease, bool stable)
+    {
+        var parsed = StructuredVersion.FromString(text);
+        Assert.Equal(major, parsed.Major);
+        Assert.Equal(minor, parsed.Minor);
+        Assert.Equal(patch, parsed.Patch);
+        Assert.Equal(build, parsed.Build);
+        Assert.Equal(prerelease, parsed.Prerelease);
+        Assert.Equal(stable, parsed.IsStable);
+        Assert.Equal(text, parsed.ToString());
+    }
+
+    [Theory]
+    [InlineData("1")]
+    [InlineData("1.2")]
+    [InlineData("1.2.3.4.5")]
+    [InlineData("bad")]
+    [InlineData("bad-1.0.0")]
+    [InlineData("1.bad.0.1")]
+    public void FromString_Invalid(string text)
+    {
+        Assert.Throws<ArgumentException>(() => StructuredVersion.FromString(text));
+    }
+}

--- a/tools/Google.Cloud.Tools.Common/StructuredVersion.cs
+++ b/tools/Google.Cloud.Tools.Common/StructuredVersion.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Google LLC.
+// Copyright 2019 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,14 +24,14 @@ namespace Google.Cloud.Tools.Common
     /// </summary>
     public class StructuredVersion : IEquatable<StructuredVersion>, IComparable<StructuredVersion>
     {
-        private static readonly Regex s_pattern = new Regex(@"^(?<major>[1-9]\d*)\.(?<minor>\d+)\.(?<patch>\d+)(\.(?<build>\d+))?(-(?<prerelease>.*))?$");
+        private static readonly Regex s_pattern = new Regex(@"^(?<major>[0-9]\d*)\.(?<minor>\d+)\.(?<patch>\d+)(\.(?<build>\d+))?(-(?<prerelease>.*))?$");
 
         public int Major { get; }
         public int Minor { get; }
         public int Patch { get; }
         public int? Build { get; }
         public string Prerelease { get; }
-        public bool IsStable => Prerelease is null;
+        public bool IsStable => Major > 0 && Prerelease is null;
 
         /// <summary>
         /// A non-release version (in google-cloud-dotnet) is something like 1.0.0-beta00 or 2.0.0-beta00.

--- a/tools/Google.Cloud.Tools.sln
+++ b/tools/Google.Cloud.Tools.sln
@@ -29,6 +29,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Cloud.Tools.SbomGene
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Tools.ReleaseManager.IntegrationTests", "Google.Cloud.Tools.ReleaseManager.IntegrationTests\Google.Cloud.Tools.ReleaseManager.IntegrationTests.csproj", "{FAD58071-C5F0-4F35-B3E6-FF5059E7713F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Cloud.Tools.Common.Tests", "Google.Cloud.Tools.Common.Tests\Google.Cloud.Tools.Common.Tests.csproj", "{86BE3961-BAC2-49F8-B662-2D2EF90A0007}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -195,6 +197,18 @@ Global
 		{FAD58071-C5F0-4F35-B3E6-FF5059E7713F}.Release|x64.Build.0 = Release|Any CPU
 		{FAD58071-C5F0-4F35-B3E6-FF5059E7713F}.Release|x86.ActiveCfg = Release|Any CPU
 		{FAD58071-C5F0-4F35-B3E6-FF5059E7713F}.Release|x86.Build.0 = Release|Any CPU
+		{86BE3961-BAC2-49F8-B662-2D2EF90A0007}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86BE3961-BAC2-49F8-B662-2D2EF90A0007}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86BE3961-BAC2-49F8-B662-2D2EF90A0007}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{86BE3961-BAC2-49F8-B662-2D2EF90A0007}.Debug|x64.Build.0 = Debug|Any CPU
+		{86BE3961-BAC2-49F8-B662-2D2EF90A0007}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{86BE3961-BAC2-49F8-B662-2D2EF90A0007}.Debug|x86.Build.0 = Debug|Any CPU
+		{86BE3961-BAC2-49F8-B662-2D2EF90A0007}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{86BE3961-BAC2-49F8-B662-2D2EF90A0007}.Release|Any CPU.Build.0 = Release|Any CPU
+		{86BE3961-BAC2-49F8-B662-2D2EF90A0007}.Release|x64.ActiveCfg = Release|Any CPU
+		{86BE3961-BAC2-49F8-B662-2D2EF90A0007}.Release|x64.Build.0 = Release|Any CPU
+		{86BE3961-BAC2-49F8-B662-2D2EF90A0007}.Release|x86.ActiveCfg = Release|Any CPU
+		{86BE3961-BAC2-49F8-B662-2D2EF90A0007}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
(This will unblock releasing SbomGenerator and DocUploader, which have 0.x versions.)