### PR TITLE
tools: Skip extra integration tests for tools packages

### DIFF
--- a/tools/Google.Cloud.Tools.ReleaseManager/ContainerCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/ContainerCommand.cs
@@ -22,6 +22,8 @@ namespace Google.Cloud.Tools.ReleaseManager;
 
 public sealed class ContainerCommand : ICommand
 {
+    internal const string ToolsLibraryPrefix = "Google.Cloud.Tools.";
+
     internal const string GenerateRaw = "generate-raw";
     internal const string GenerateLibrary = "generate-library";
     internal const string Clean = "clean";
@@ -75,7 +77,7 @@ public sealed class ContainerCommand : ICommand
             {
                 return UtilityDocCommands.Execute(args[0], options);
             }
-            if (options.LibraryId?.StartsWith("Google.Cloud.Tools.", StringComparison.Ordinal) == true)
+            if (options.LibraryId?.StartsWith(ToolsLibraryPrefix, StringComparison.Ordinal) == true)
             {
                 return ToolCommands.Execute(args[0], options);
             }

--- a/tools/Google.Cloud.Tools.ReleaseManager/RunReleaseTestsCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/RunReleaseTestsCommand.cs
@@ -63,6 +63,11 @@ public sealed class RunReleaseTestsCommand : CommandBase
                 Console.WriteLine($"Skipping integration tests for {libraryId}; it's a docs package.");
                 continue;
             }
+            if (libraryId.StartsWith(ContainerCommand.ToolsLibraryPrefix, StringComparison.Ordinal))
+            {
+                Console.WriteLine($"Skipping additional integration tests for {libraryId}; it's a tools package.");
+                continue;
+            }
             Console.WriteLine($"Testing {libraryId} at {commit.Sha}");
 
             Commands.Checkout(repo, commit.Sha);


### PR DESCRIPTION
(This is run as the "Windows-only" part of the release, for .NET Framework. We'll still have run any normal integration tests as part of the release.)