### PR TITLE
chore: update dependencies of Google.Cloud.PolicySimulator.V1

### DIFF
--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.csproj
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Grpc" />
     <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.2.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.OrgPolicy.V2" VersionOverride="[2.8.0, 3.0.0)" />
     <PackageReference Include="Google.LongRunning" VersionOverride="[3.2.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -4394,6 +4394,7 @@
       ],
       "dependencies": {
         "Google.Cloud.Iam.V1": "3.2.0",
+        "Google.Cloud.OrgPolicy.V2": "2.8.0",
         "Google.LongRunning": "3.2.0"
       },
       "generator": "micro",


### PR DESCRIPTION
(Tested locally that this will fix the build failure during regeneration.)