### PR TITLE
chore: temporarily block Spanner and BigQuery releases

### DIFF
--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -731,7 +731,7 @@
             "id": "Google.Cloud.BigQuery.V2",
             "currentVersion": "3.11.0",
             "generationAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
-            "releaseAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseAutomationLevel": "AUTOMATION_LEVEL_BLOCKED",
             "releaseTimestamp": "2025-02-03T17:58:23Z",
             "sourcePaths": [
                 "apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2"
@@ -3887,7 +3887,7 @@
             "id": "Google.Cloud.Spanner",
             "currentVersion": "5.1.0",
             "generationAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
-            "releaseAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseAutomationLevel": "AUTOMATION_LEVEL_BLOCKED",
             "releaseTimestamp": "2025-06-17T21:25:21.762422506Z",
             "lastGeneratedCommit": "2a2ea87fcad7327e0afcfeaa84ec4d4b014f11a3",
             "lastReleasedCommit": "62babf26d128656ac94fcc73c415b5f9f85cfc45",


### PR DESCRIPTION
We can unblock when the integration tests are passing again. But until then, let's avoid messing up the state file each time we do a release.