### PR TITLE
tests: Fix diagnostics integration test

### DIFF
--- a/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.IntegrationTests/Logging/LoggingTest.cs
+++ b/apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3.IntegrationTests/Logging/LoggingTest.cs
@@ -897,7 +897,7 @@ namespace Google.Cloud.Diagnostics.AspNetCore3.IntegrationTests
             : base()
         { }
 
-        public NoBufferWarningLoggerTestApplication(double traceQps)
+        protected NoBufferWarningLoggerTestApplication(double traceQps)
             : base(traceQps)
         { }
 


### PR DESCRIPTION
Currently this is failing with:

> System.InvalidOperationException : Multiple constructors accepting
> all given argument types have been found in type
> 'Google.Cloud.Diagnostics.AspNetCore3.IntegrationTests.NoBufferWarningLoggerTestApplication'.
> There should only be one applicable constructor.

Making the constructor protected allows it to still be called from derived classes, but without confusing DI.