### PR TITLE
tools: Allow breaking changes for release PRs

### DIFF
--- a/.github/workflows/diff-pr.yml
+++ b/.github/workflows/diff-pr.yml
@@ -37,8 +37,9 @@ jobs:
     - name: Detect PR changes
       env:
         ALLOW_BREAKING_CHANGES: ${{contains(github.event.pull_request.labels.*.name, 'allow breaking changes')}}
+        IS_RELEASE_PR: "${{contains(github.event.pull_request.title, 'chore: Library release')}}"
       run: |
-        if [[ $ALLOW_BREAKING_CHANGES == "true" ]]
+        if [[ $ALLOW_BREAKING_CHANGES == "true" || $IS_RELEASE_PR == "true" ]]
         then
           SCRIPT_OPTION=--allow-breaking-changes
         fi


### PR DESCRIPTION
This works around a limitation in Librarian v0.1.0 (b/434870204). We'll probably rethink how/when breaking changes are reported when we move to a later version of Librarian.

We could make this change more selective, using the email address of the user inconjunction with the title - but it's very unlikely that we'll actually see any other PRs with a title containing "chore: Library relase".

Note that the new variable needs double quotes around the condition to avoid YAML parsing issues on the colon.