### PR TITLE
chore: unblock releasing for Google.Cloud.LocationFinder.V1

### DIFF
--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -4545,7 +4545,7 @@
             "id": "Google.Cloud.LocationFinder.V1",
             "nextVersion": "1.0.0-beta01",
             "generationAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
-            "releaseAutomationLevel": "AUTOMATION_LEVEL_BLOCKED",
+            "releaseAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "lastGeneratedCommit": "60e1300d4a0b60b85b3df167ddc4062ac7cc4f44",
             "apiPaths": [
                 "google/cloud/locationfinder/v1"


### PR DESCRIPTION
(Local smoke tests are now passing.)