### PR TITLE
Multiplex sessions v1

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/CloudSpannerFixtureBase.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.CommonTesting/CloudSpannerFixtureBase.cs
@@ -14,8 +14,10 @@
 
 using Google.Cloud.ClientTesting;
 using Google.Cloud.Spanner.Common.V1;
+using Google.Cloud.Spanner.V1;
 using Google.Cloud.Spanner.V1.Internal.Logging;
 using System;
+using System.Threading.Tasks;
 
 namespace Google.Cloud.Spanner.Data.CommonTesting;
 
@@ -39,4 +41,6 @@ public abstract class CloudSpannerFixtureBase<TDatabase> : CloudProjectFixtureBa
     protected CloudSpannerFixtureBase(Func<string, TDatabase> databaseFactory) => Database = databaseFactory(ProjectId);
 
     public SpannerConnection GetConnection(Logger logger = null, bool logCommitStats = false) => Database.GetConnection(logger, logCommitStats);
+
+    public async Task<MultiplexSession> GetMultiplexSession() => await Database.GetMultiplexSession().ConfigureAwait(false);
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/V1/MultiplexSessionTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/V1/MultiplexSessionTests.cs
@@ -1,0 +1,248 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License"):
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax.Grpc;
+using Google.Cloud.ClientTesting;
+using Google.Cloud.Spanner.Data.CommonTesting;
+using Google.Cloud.Spanner.V1;
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Cloud.Spanner.Data.IntegrationTests;
+[Collection(nameof(AllTypesTableFixture))]
+[CommonTestDiagnostics]
+public class MultiplexSessionTests
+{
+    private readonly AllTypesTableFixture _fixture;
+
+    public MultiplexSessionTests(AllTypesTableFixture fixture) =>
+        _fixture = fixture;
+
+    [Fact]
+    [Trait(Constants.SupportedOnEmulator, Constants.No)]
+    public async Task SessionCreationSucceeds()
+    {
+        MultiplexSession muxSession = await _fixture.GetMultiplexSession();
+
+        Assert.NotNull(muxSession.Session);
+        Assert.NotNull(muxSession.SessionName);
+
+        // Use the underlying client to get the mux session from the server.
+        SpannerClient client = muxSession.Client;
+        var getSessionRequest = new GetSessionRequest
+        {
+            SessionName = muxSession.SessionName,
+        };
+        var matchingSession = client.GetSession(getSessionRequest);
+
+        Assert.Equal(muxSession.SessionName, matchingSession.SessionName);
+        Assert.True(matchingSession.Multiplexed);
+    }
+
+    [Fact]
+    [Trait(Constants.SupportedOnEmulator, Constants.No)]
+    public async Task RunReadWriteTransactionWithMultipleQueries()
+    {
+        MultiplexSession multiplexSession = await _fixture.GetMultiplexSession();
+        Transaction transaction = new Transaction(multiplexSession, null, new TransactionOptions { ReadWrite = new TransactionOptions.Types.ReadWrite() }, false, null);
+        String uniqueRowId = IdGenerator.FromGuid();
+        // Query 1: Read some data before modification.
+        var result = await ExecuteSelectQuery(transaction, uniqueRowId);
+        Assert.NotNull(result);
+        Assert.NotNull(transaction.PrecommitToken);
+        Assert.NotNull(transaction.TransactionId);
+
+        int preCommitTokenSeqNumber = transaction.PrecommitToken.SeqNum;
+
+        // Query 2: Insert a new record.
+        result = await ExecuteInsertInt64Value(transaction, uniqueRowId, 10);
+        Assert.NotNull(result);
+        Assert.NotNull(transaction.PrecommitToken);
+        Assert.NotNull(transaction.Id);
+        Assert.True(transaction.PrecommitToken.SeqNum >= preCommitTokenSeqNumber);
+
+        preCommitTokenSeqNumber = transaction.PrecommitToken.SeqNum;
+
+        // Commit the transaction
+        var commitResponse = await transaction.CommitAsync(new CommitRequest(), null);
+        Assert.NotNull(commitResponse);
+        Assert.NotNull(transaction.Id);
+    }
+
+    [Fact]
+    [Trait(Constants.SupportedOnEmulator, Constants.No)]
+    public async Task TestMultipleTransactionWritesOnSameSession()
+    {
+        MultiplexSession multiplexSession = await _fixture.GetMultiplexSession();
+        const int concurrentThreads = 5;
+        String uniqueRowId = IdGenerator.FromGuid();
+
+        try
+        {
+            var transactions = new Transaction[concurrentThreads];
+            for (var i = 0; i < concurrentThreads; i++)
+            {
+                transactions[i] = new Transaction(multiplexSession, null, new TransactionOptions { ReadWrite = new TransactionOptions.Types.ReadWrite() }, false, null);
+            }
+
+            for (var i = 0; i < concurrentThreads; i++)
+            {
+                await IncrementByOneAsync(transactions[i], uniqueRowId);
+            }
+
+            Transaction fetchResultsTransaction = new Transaction(multiplexSession, null, new TransactionOptions { ReadWrite = new TransactionOptions.Types.ReadWrite() }, false, null);
+            var fetched = await ExecuteSelectQuery(fetchResultsTransaction, uniqueRowId);
+
+            var row = fetched.Rows.First();
+            var actual = long.Parse(row.Values[1].StringValue);
+            Assert.Equal(5, actual);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex.ToString());
+            Console.WriteLine(ex.InnerException?.ToString());
+            throw;
+        }
+    }
+
+    private async Task IncrementByOneAsync(Transaction transaction, string uniqueRowId, bool orphanTransaction = false)
+    {
+        var retrySettings = RetrySettings.FromExponentialBackoff(
+            maxAttempts: int.MaxValue,
+            initialBackoff: TimeSpan.FromMilliseconds(250),
+            maxBackoff: TimeSpan.FromSeconds(5),
+            backoffMultiplier: 1.5,
+            retryFilter: ignored => false,
+            RetrySettings.RandomJitter);
+        TimeSpan nextDelay = TimeSpan.Zero;
+        SpannerException spannerException;
+        DateTime deadline = DateTime.UtcNow.AddSeconds(30);
+
+        while (true)
+        {
+            spannerException = null;
+            try
+            {
+                // We use manually created transactions here so the tests run on .NET Core.
+                long current;
+
+                var fetched = await ExecuteSelectQuery(transaction, uniqueRowId);
+                if (fetched?.Rows.Any() == true)
+                {
+                    var row = fetched.Rows.First();
+                    current = long.Parse(row.Values[1].StringValue);
+                }
+                else
+                {
+                    current = 0L;
+                }
+
+
+                ResultSet result;
+                if (current == 0)
+                {
+                    result = await ExecuteInsertInt64Value(transaction, uniqueRowId, current + 1);
+                }
+                else
+                {
+                    result = await ExecuteUpdateInt64Value(transaction, uniqueRowId, current + 1);
+                }
+
+                await transaction.CommitAsync(new CommitRequest(), null);
+                return;
+            }
+            // Keep trying for up to 30 seconds
+            catch (SpannerException ex) when (ex.IsRetryable && DateTime.UtcNow < deadline)
+            {
+                nextDelay = retrySettings.NextBackoff(nextDelay);
+                await Task.Delay(retrySettings.BackoffJitter.GetDelay(nextDelay));
+                spannerException = ex;
+            }
+        }
+    }
+
+    private async Task<ResultSet> ExecuteSelectQuery(Transaction transaction, String uniqueRowId)
+    {
+        var selectParams = new Dictionary<string, SpannerParameter>
+        {
+            { "id", new SpannerParameter { Value = Value.ForString(uniqueRowId) } }
+        };
+        var selectSql = $"SELECT K, Int64Value FROM {_fixture.TableName} WHERE K = @id";
+        var request = new ExecuteSqlRequest
+        {
+            Sql = selectSql,
+            Params = CreateStructFromParameters(selectParams),
+        };
+
+        return await transaction.ExecuteSqlAsync(request, null);
+    }
+
+    private async Task<ResultSet> ExecuteInsertInt64Value(Transaction transaction, String uniqueRowId, long insertValue)
+    {
+        var insertSql = $"INSERT {_fixture.TableName} (K, Int64Value) VALUES (@k, @int64Value)";
+        var insertParams = new Dictionary<string, SpannerParameter>
+        {
+            { "k", new SpannerParameter { Value = Value.ForString(uniqueRowId) } },
+            { "int64Value", new SpannerParameter("int64Value", SpannerDbType.Int64, insertValue) }
+        };
+
+        var request = new ExecuteSqlRequest
+        {
+            Sql = insertSql,
+            Params = CreateStructFromParameters(insertParams),
+        };
+        return await transaction.ExecuteSqlAsync(request, null);
+    }
+
+    private async Task<ResultSet> ExecuteUpdateInt64Value(Transaction transaction, String uniqueRowId, long updateValue)
+    {
+        var updateSql = $"UPDATE {_fixture.TableName} SET Int64Value = @newIntValue WHERE K = @id";
+        var updateParams = new Dictionary<string, SpannerParameter>
+        {
+            { "newIntValue", new SpannerParameter("newIntValue", SpannerDbType.Int64, updateValue) },
+            { "id", new SpannerParameter { Value = Value.ForString(uniqueRowId) } }
+         };
+
+        var request = new ExecuteSqlRequest
+        {
+            Sql = updateSql,
+            Params = CreateStructFromParameters(updateParams),
+        };
+        return await transaction.ExecuteSqlAsync(request, null);
+    }
+
+    /// <summary>
+    /// Converts a dictionary of Spanner parameters to a Google.Protobuf.WellKnownTypes.Struct.
+    /// </summary>
+    private Struct CreateStructFromParameters(Dictionary<string, SpannerParameter> parameters)
+    {
+        var pbStruct = new Struct();
+        var options = SpannerConversionOptions.Default;
+        if (parameters != null)
+        {
+            foreach (var param in parameters)
+            {
+                var parameter = param.Value;
+                var protobufValue = parameter.GetConfiguredSpannerDbType(options).ToProtobufValue(parameter.GetValidatedValue());
+                pbStruct.Fields.Add(param.Key, protobufValue);
+            }
+        }
+        return pbStruct;
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/MultiplexSessionTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/MultiplexSessionTests.cs
@@ -1,0 +1,85 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License"):
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax.Testing;
+using Google.Cloud.Spanner.Common.V1;
+using Google.Cloud.Spanner.V1.Internal.Logging;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using static Google.Cloud.Spanner.V1.MultiplexSession;
+
+namespace Google.Cloud.Spanner.V1.Tests;
+public class MultiplexSessionTests
+{
+    private const string testDatabase = "projects/testproject/instances/testinstance/databases/testdb";
+
+    [Fact]
+    public async Task TestBuilderCreation()
+    {
+        MultiplexSession multiplexSession = await FetchTestMultiplexSession();
+
+        Assert.NotNull(multiplexSession);
+        Assert.NotNull(multiplexSession.Session);
+        Assert.NotNull(multiplexSession.Client);
+        Assert.NotNull(multiplexSession.DatabaseName);
+        Assert.NotNull(multiplexSession.DatabaseRole);
+    }
+
+    [Fact]
+    public async Task TestSessionHasExpired()
+    {
+        SpannerClient fakeClient = CreateFakeClient();
+        MultiplexSession multiplexSession = await FetchTestMultiplexSession(fakeClient);
+
+        DateTime sessionCreateTime = multiplexSession.Session.CreateTime.ToDateTime();
+        FakeClock clock = (FakeClock) fakeClient.Settings.Clock;
+
+        clock.AdvanceTo(sessionCreateTime + TimeSpan.FromDays(3));
+        Assert.True(multiplexSession.SessionHasExpired(2.0));
+
+        clock.AdvanceTo(sessionCreateTime + TimeSpan.FromDays(7));
+        Assert.True(multiplexSession.SessionHasExpired());
+    }
+
+    private SpannerClient CreateFakeClient()
+    {
+        SpannerClient fakeClient = SpannerClientHelpers.CreateMockClient(Logger.DefaultLogger);
+        fakeClient.SetupMultiplexSessionCreationAsync();
+
+        return fakeClient;
+    }
+
+    private async Task<MultiplexSession> FetchTestMultiplexSession(SpannerClient client = null)
+    {
+        if (!DatabaseName.TryParse(testDatabase, out var databaseName))
+        {
+            throw new Exception($"Unable to parse string to DatabaseName {testDatabase}");
+        }
+
+        if (client == null)
+        {
+            client = CreateFakeClient();
+        }
+
+        MultiplexSessionBuilder builder = new MultiplexSessionBuilder(databaseName, client)
+        {
+            DatabaseRole = "testRole",
+        };
+
+        MultiplexSession multiplexSession = await builder.BuildAsync();
+
+        return multiplexSession;
+    }
+}

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SpannerClientHelpers.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/V1/SpannerClientHelpers.cs
@@ -65,6 +65,24 @@ namespace Google.Cloud.Spanner.V1.Tests
             return mock;
         }
 
+        internal static SpannerClient SetupMultiplexSessionCreationAsync(this SpannerClient spannerClientMock)
+        {
+            spannerClientMock.Configure().CreateSessionAsync(Arg.Is<CreateSessionRequest>(x => x != null), Arg.Any<CallSettings>())
+                .Returns(args =>
+                {
+                    var request = (CreateSessionRequest) args[0];
+                    Session response = new Session();
+                    response.CreateTime = spannerClientMock.GetNowTimestamp();
+                    response.CreatorRole = request.Session.CreatorRole;
+                    response.Multiplexed = request.Session.Multiplexed;
+                    response.Name = Guid.NewGuid().ToString();
+                    response.SessionName = new SessionName(ProjectId, Instance, Database, response.Name);
+
+                    return Task.FromResult(response);
+                });
+            return spannerClientMock;
+        }
+
         internal static SpannerClient SetupBatchCreateSessionsAsync(this SpannerClient spannerClientMock)
         {
             spannerClientMock.Configure()

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/MultiplexSession.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/MultiplexSession.cs
@@ -1,0 +1,272 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License"):
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Api.Gax.Grpc;
+using Google.Cloud.Spanner.Common.V1;
+using Google.Cloud.Spanner.V1.Internal;
+using Google.Cloud.Spanner.V1.Internal.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Cloud.Spanner.V1;
+
+/// <summary>
+/// TODO: Add summary for mux sessions
+/// </summary>
+public class MultiplexSession
+{
+    private readonly SemaphoreSlim _sessionCreateSemaphore;
+    private readonly Logger _logger;
+    private readonly CreateSessionRequest _createSessionRequestTemplate;
+
+    internal Session _session;
+    internal int _markedForRefresh;
+
+    private const double ForceRefreshIntervalInDays = 28.0;
+    private const double SoftRefreshIntervalInDays = 7.0;
+
+    private readonly IClock _clock;
+
+    /// <summary>
+    /// The client used for all operations in this multiplex session.
+    /// </summary>
+    internal SpannerClient Client { get; }
+
+    internal Task<Session> CreateSessionTask { get; }
+
+    /// <summary>
+    /// The name of the session. This is never null.
+    /// </summary>
+    public SessionName SessionName => Session.SessionName;
+
+    /// <summary>
+    /// The Spanner session resource associated to this pooled session.
+    /// Won't be null.
+    /// </summary>
+    internal Session Session
+    {
+        get { return _session; }
+        private set { _session = value; }
+    }
+
+    private bool MarkedForRefresh => Interlocked.CompareExchange(ref _markedForRefresh, 0, 0) == 1;
+
+    /// <summary>
+    /// The options governing this multiplex session.
+    /// </summary>
+    public MultiplexSessionOptions Options { get; }
+
+    /// <summary>
+    /// The database for this multiplex session
+    /// </summary>
+    public DatabaseName DatabaseName { get; }
+
+    /// <summary>
+    /// The database role of the multiplex session
+    /// </summary>
+    public string DatabaseRole { get; }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="client"></param>
+    /// <param name="dbName"></param>
+    /// <param name="dbRole"></param>
+    /// <param name="options"></param>
+    public MultiplexSession(SpannerClient client, DatabaseName dbName, string dbRole, MultiplexSessionOptions options)
+    {
+        Client = GaxPreconditions.CheckNotNull(client, nameof(client));
+        Options = options ?? new MultiplexSessionOptions();
+        _logger = client.Settings.Logger; // Just to avoid fetching it all the time
+        _sessionCreateSemaphore = new SemaphoreSlim(1);
+
+        DatabaseName = dbName;
+        DatabaseRole = dbRole;
+
+        _clock = client.Settings.Clock ?? SystemClock.Instance;
+
+        _createSessionRequestTemplate = new CreateSessionRequest
+        {
+            DatabaseAsDatabaseName = DatabaseName,
+            Session = new Session
+            {
+                CreatorRole = DatabaseRole ?? "",
+                Multiplexed = true
+            }
+        };
+    }
+
+    private async Task<Boolean> UpdateMuxSession(bool needsRefresh, double intervalInDays)
+    {
+        Session oldSession = _session;
+        await CreateOrRefreshSessionsAsync(default).ConfigureAwait(false);
+
+        return _session != oldSession;
+    }
+
+    internal void MaybeRefreshWithTimePeriodCheck()
+    {
+        if (SessionHasExpired(ForceRefreshIntervalInDays))
+        {
+            // If the session has expired on a client RPC request call, or has exceeded the 28 day Mux session refresh guidance
+            // No request can proceed without us having a new Session to work with
+            // Block on refreshing and getting a new session
+            bool sessionIsRefreshed = UpdateMuxSession(true, ForceRefreshIntervalInDays).Result;
+
+            if (!sessionIsRefreshed)
+            {
+                throw new Exception("Unable to refresh multiplex session, and the old session has expired or is 28 days past refresh");
+            }
+
+            _logger.Info($"Refreshed session since it was expired or past 28 days refresh period. New session {SessionName}");
+        }
+
+        if (SessionHasExpired(SoftRefreshIntervalInDays))
+        {
+            // The Mux sessions have a lifespan of 28 days. We check if we need a session refresh in every request needing the session
+            // If the timespan of a request needing a session and the session creation time is greater than 7 days, we proactively refresh the mux session
+            // The request can safely use the older session since it is still valid while we do this refresh to fetch the new session.
+            // Hence fire and forget the session refresh.
+            _ = Task.Run(() => UpdateMuxSession(true, SoftRefreshIntervalInDays));
+        }
+    }
+
+    // internal for testing
+    internal bool SessionHasExpired(double intervalInDays = SoftRefreshIntervalInDays)
+    {
+        DateTime currentTime = _clock.GetCurrentDateTimeUtc();
+        DateTime? sessionCreateTime = _session?.CreateTime.ToDateTime(); // Inherent conversion into UTC DateTime
+
+        if (_session == null || _session.Expired || currentTime - sessionCreateTime >= TimeSpan.FromDays(intervalInDays))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private async Task CreateOrRefreshSessionsAsync(CancellationToken cancellationToken, bool needsRefresh = false)
+    {
+        try
+        {
+            var callSettings = Client.Settings.CreateSessionSettings
+                .WithExpiration(Expiration.FromTimeout(Options.Timeout))
+                .WithCancellationToken(cancellationToken);
+
+            Session multiplexSession;
+
+            bool acquiredSemaphore = false;
+            try
+            {
+                if (needsRefresh && MarkedForRefresh && !SessionHasExpired(ForceRefreshIntervalInDays))
+                {
+                    // If the refresh was triggered for the soft refresh timeline (7 days)
+                    // Some other thread has already marked this session to be refreshed
+                    // Any subsequent request threads can continue using the 'stale' session so let's not block
+                    // On the other hand if the refresh is for the forced refresh timeline (28 days)
+                    // Any subsequent request threads need to be blocked on the Session refresh
+                    return;
+                }
+
+                await _sessionCreateSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                acquiredSemaphore = true;
+
+                if (_session == null || (needsRefresh && SessionHasExpired()))
+                {
+                    Interlocked.Exchange(ref _markedForRefresh, 1);
+                    multiplexSession = await Client.CreateSessionAsync(_createSessionRequestTemplate, callSettings).ConfigureAwait(false);
+
+                    Interlocked.Exchange(ref _session, multiplexSession);
+                    Interlocked.Exchange(ref _markedForRefresh, 0);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.Warn(() => $"Creation request cancelled before we could procure a Multiplex Session for DatabaseName: {DatabaseName}, DatabaseRole: {DatabaseRole}");
+                throw;
+            }
+            finally
+            {
+                if (acquiredSemaphore)
+                {
+                    _sessionCreateSemaphore.Release();
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.Warn(() => $"Failed to create multiplex session for DatabaseName: {DatabaseName}, DatabaseRole: {DatabaseRole}", e);
+            throw;
+        }
+        finally
+        {
+            // Nothing to do here since for legacy SessionPool we had to have some logging for when the pool went from healthy to unhealthy.
+            // This could mean n number of things went wrong in the pool
+            // But with the MUX session, we essentially only have 1 session we need to manage per client.
+            // So there is no case of the mux session going back and forth in terms of its healthiness.
+        }
+
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public sealed partial class MultiplexSessionBuilder
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public MultiplexSessionBuilder(DatabaseName databaseName, SpannerClient client)
+        {
+            DatabaseName = GaxPreconditions.CheckNotNull(databaseName, nameof(databaseName));
+            Client = GaxPreconditions.CheckNotNull(client, nameof(client));
+        }
+
+        /// <summary>
+        /// The options governing this multiplex session.
+        /// </summary>
+        public MultiplexSessionOptions Options { get; set; }
+
+        /// <summary>
+        /// The database for this multiplex session
+        /// </summary>
+        public DatabaseName DatabaseName { get; set; }
+
+        /// <summary>
+        /// The database role of the multiplex session
+        /// </summary>
+        public string DatabaseRole { get; set; }
+
+        /// <summary>
+        /// The client used for all operations in this multiplex session.
+        /// </summary>
+        public SpannerClient Client { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public async Task<MultiplexSession> BuildAsync(CancellationToken cancellationToken = default)
+        {
+            MultiplexSession multiplexSession = new MultiplexSession(Client, DatabaseName, DatabaseRole, Options);
+
+            await multiplexSession.CreateOrRefreshSessionsAsync(cancellationToken).ConfigureAwait(false);
+
+            return multiplexSession;
+        }
+    }
+}

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/MultiplexSessionOptions.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/MultiplexSessionOptions.cs
@@ -1,0 +1,57 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License"):
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Google.Cloud.Spanner.V1;
+
+/// <summary>
+/// 
+/// </summary>
+public class MultiplexSessionOptions
+{
+    private TimeSpan _timeout = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// Constructs a new <see cref="MultiplexSessionOptions"/> with default values.
+    /// </summary>
+    public MultiplexSessionOptions()
+    {
+    }
+
+    /// <summary>
+    /// The total time allowed for a network call to the Cloud Spanner server, including retries. This setting
+    /// is applied to calls to create session as well as beginning transactions.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This value must be positive. The default value is one minute.
+    /// </para>
+    /// </remarks>
+    public TimeSpan Timeout
+    {
+        get => _timeout;
+        set => _timeout = CheckPositiveTimeSpan(value);
+    }
+
+    // TODO: Move to GAX if we find we need it in other libraries. (We have CheckNonNegative already.)
+    private static TimeSpan CheckPositiveTimeSpan(TimeSpan value)
+    {
+        if (value.Ticks <= 0)
+        {
+            throw new ArgumentOutOfRangeException("value", "Value must be a positive TimeSpan");
+        }
+        return value;
+    }
+}

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/ResultStream.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/ResultStream.cs
@@ -19,6 +19,7 @@ using Google.Rpc;
 using Grpc.Core;
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -51,6 +52,7 @@ namespace Google.Cloud.Spanner.V1
         private readonly SpannerClient _client;
         private readonly ReadOrQueryRequest _request;
         private readonly PooledSession _pooledSession;
+        private readonly Transaction _transaction;
         private readonly CallSettings _callSettings;
         private readonly RetrySettings _retrySettings;
         private readonly int _maxBufferSize;
@@ -69,6 +71,34 @@ namespace Google.Cloud.Spanner.V1
         internal ResultStream(SpannerClient client, ReadOrQueryRequest request, PooledSession pooledSession, CallSettings callSettings)
             : this(client, request, pooledSession, callSettings, DefaultMaxBufferSize, s_defaultRetrySettings)
         {
+        }
+
+        /// <summary>
+        /// Constructor for normal usage, taking in a transaction, with default buffer size, backoff settings and jitter.
+        /// </summary>
+        internal ResultStream(SpannerClient client, ReadOrQueryRequest request, Transaction transaction, CallSettings callSettings)
+            : this(client, request, transaction, callSettings, DefaultMaxBufferSize, s_defaultRetrySettings)
+        {
+        }
+
+        /// <summary>
+        /// Constructor with complete control that does not perform any validation.
+        /// </summary>
+        internal ResultStream(
+            SpannerClient client,
+            ReadOrQueryRequest request,
+            Transaction transaction,
+            CallSettings callSettings,
+            int maxBufferSize,
+            RetrySettings retrySettings)
+        {
+            _buffer = new LinkedList<PartialResultSet>();
+            _client = GaxPreconditions.CheckNotNull(client, nameof(client));
+            _request = GaxPreconditions.CheckNotNull(request, nameof(request));
+            _transaction = GaxPreconditions.CheckNotNull(_transaction, nameof(transaction));
+            _callSettings = callSettings;
+            _maxBufferSize = GaxPreconditions.CheckArgumentRange(maxBufferSize, nameof(maxBufferSize), 1, 10_000);
+            _retrySettings = GaxPreconditions.CheckNotNull(retrySettings, nameof(retrySettings));
         }
 
         /// <summary>
@@ -105,6 +135,7 @@ namespace Google.Cloud.Spanner.V1
         {
             var value = await ComputeNextAsync(cancellationToken).ConfigureAwait(false);
             Current = value;
+            _transaction.UpdatePrecommitToken(value.PrecommitToken);
             return value != null;
         }
 
@@ -134,15 +165,14 @@ namespace Google.Cloud.Spanner.V1
                     bool hasNext = false;
                     if (_grpcCall is null)
                     {
-                        // Whenever we have to execute the gRPC streaming call we ask the pooled session
-                        // for the transaction. Only the first time the gRPC streaming call is executed
+                        // Only the first time the gRPC streaming call is executed
                         // the transaction will be inlined, if there's not a transaction already. Subsequent
                         // times will just get the same transacton ID. So in principle, we only need to ask
                         // for the transaction the first and second times the gRPC streaming call is executed,
                         // but doing it every time simplifies implementation and adds little overhead, because
                         // once there's a transaction ID, ExecuteMaybeWithTransactionSelectorAsync returns
                         // inmediately.
-                        await _pooledSession.ExecuteMaybeWithTransactionSelectorAsync(
+                        await _transaction.ExecuteMaybeWithTransactionSelectorAsync(
                             transactionSelectorSetter: SetCommandTransaction,
                             commandAsync: ExecuteStreamingAsync,
                             inlinedTransactionExtractor: GetInlinedTransaction,
@@ -173,7 +203,7 @@ namespace Google.Cloud.Spanner.V1
                         hasNext = await MoveNextAsync().ConfigureAwait(false);
                     }
 
-                    Task<bool> MoveNextAsync() => _grpcCall.ResponseStream.MoveNext(cancellationToken).WithSessionExpiryChecking(_pooledSession.Session);
+                    Task<bool> MoveNextAsync() => _grpcCall.ResponseStream.MoveNext(cancellationToken).WithSessionExpiryChecking(_transaction.Session);
 
                     retryState.Reset();
 

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/TransactionPartial.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/TransactionPartial.cs
@@ -1,0 +1,715 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License"):
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax;
+using Google.Api.Gax.Grpc;
+using Google.Cloud.Spanner.V1.Internal;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using static Google.Cloud.Spanner.V1.TransactionOptions;
+
+namespace Google.Cloud.Spanner.V1
+{
+    public partial class Transaction
+    {
+        private readonly MultiplexSession _multiplexSession;
+        private Transaction _transaction;
+        private readonly object _transactionCreationTaskLock = new object();
+        private Task _transactionCreationTask;
+        private readonly object _precommitTokenUpdateLock = new object();
+
+        /// <summary>
+        /// The name of the session. This is never null.
+        /// </summary>
+        public SessionName SessionName => _multiplexSession.SessionName;
+
+        /// <summary>
+        /// The Spanner session resource associated to this pooled session.
+        /// Won't be null.
+        /// </summary>
+        internal Session Session => _multiplexSession.Session;
+
+        /// <summary>
+        /// The options for the transaction that is or will be associated with this session. Won't be null.
+        /// </summary>
+        /// <remarks>
+        /// Will be <see cref="TransactionOptions.ModeOneofCase.None"/> if <see cref="TransactionId"/>
+        /// is null.
+        /// </remarks>
+        private TransactionOptions TransactionOptions { get; }
+
+        /// <summary>
+        /// The transaction mode for the transaction that is or may be associated with this session.
+        /// Available for testing.
+        /// </summary>
+        internal TransactionOptions.ModeOneofCase TransactionMode => TransactionOptions.ModeCase;
+
+        private SpannerClient Client => _multiplexSession.Client;
+
+        /// <summary>
+        /// Whether the transaction associated to this session is single use or not.
+        /// If this is true then <see cref="TransactionOptions"/> will be <see cref="TransactionOptions.ModeOneofCase.ReadOnly"/>
+        /// and <see cref="TransactionId"/> will be null.
+        /// </summary>
+        internal bool SingleUseTransaction { get; }
+
+        /// <summary>
+        /// The ID of the transaction. May be null.
+        /// </summary>
+        /// <remarks>
+        /// Transactions are acquired when they are needed so this will be null in the
+        /// following cases:
+        /// <list type="bullet">
+        /// <item>
+        /// <see cref="TransactionOptions"/> is <see cref="TransactionOptions.ModeOneofCase.None"/>,
+        /// including when the session is idle in the pool.
+        /// </item>
+        /// <item>
+        /// <see cref="SingleUseTransaction"/> is true. No transactions will exist client side.
+        /// </item>
+        /// <item>
+        /// The session has been acquired from the pool with some transaction options but no command execution has
+        /// been attempted since.
+        /// </item>
+        /// <item>
+        /// The first command execution is underway and the transaction is being created either
+        /// by inlining or explicitly.
+        /// </item>
+        /// </list>
+        /// </remarks>
+        public ByteString TransactionId => Interlocked.CompareExchange(ref _transaction, null, null)?.Id;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="multiplexSession"></param>
+        /// <param name="transactionId"></param>
+        /// <param name="transactionOptions"></param>
+        /// <param name="singleUseTransaction"></param>
+        /// <param name="readTimestamp"></param>
+        public Transaction(MultiplexSession multiplexSession, ByteString transactionId, TransactionOptions transactionOptions, bool singleUseTransaction, Timestamp readTimestamp)
+        {
+            _multiplexSession = multiplexSession;
+
+            TransactionOptions = transactionOptions?.Clone() ?? new TransactionOptions();
+
+            GaxPreconditions.CheckArgument(
+                TransactionOptions.ModeCase == ModeOneofCase.ReadOnly || !singleUseTransaction,
+                nameof(singleUseTransaction),
+                "Single use transactions are only supported for read-only transactions.");
+            GaxPreconditions.CheckArgument(
+                transactionId is null || TransactionOptions.ModeCase != ModeOneofCase.None,
+                nameof(transactionOptions),
+                "No transaction options were specified for the given transasaction ID.");
+            GaxPreconditions.CheckArgument(
+                readTimestamp is null || transactionId is not null,
+                nameof(readTimestamp),
+                "A read timestamp can only be specified if a transaction ID is also being specified.");
+
+            SingleUseTransaction = singleUseTransaction;
+            if (transactionId is not null)
+            {
+                // We don't need to lock here, this is the constructor.
+                _transaction = new Transaction
+                {
+                    Id = transactionId,
+                    ReadTimestamp = readTimestamp,
+                };
+            }
+
+            // Purva: We do not need these, V1 Session lifecycle will be handled by TargetedMultiplexSession class
+            //_evictionTime = evictionTime;
+            //_refreshTicks = refreshTicks;
+        }
+
+        /// <summary>
+        /// Decides whether we need a transaction ID or not and whether that can be obtained by transaction inlining.
+        /// Sets the correct transaction selector before executing the given command.
+        /// </summary>
+        /// <remarks>All RPCs executed within the session should call this method for guaranteeing they are
+        /// using the correct transaction selector.</remarks>
+        /// <typeparam name="TResponse">The type of the command response.</typeparam>
+        /// <param name="transactionSelectorSetter">Called by this method to set the correct transaction selector.</param>
+        /// <param name="commandAsync">The command (RPC) that will be executed after the transaction selector has maybe been set.
+        /// Callers may fail if command is executed but no transaction selector has been set.</param>
+        /// <param name="inlinedTransactionExtractor">Will extract transaction information from the command's response if
+        /// transaction inlining was succesful. May be null, which indicates that command does not support transaction inlining.</param>
+        /// <param name="skipTransactionCreation">If true, transaction creation may be skipped. This is used by commit and rollback
+        /// so that a transaction is not created just for inmediate commit or rollback. Note that if there are pending mutations, commit
+        /// should set this parameter to false.</param>
+        /// <param name="mutationKey"></param>
+        /// <param name="cancellationToken">The cancellation token for the operation.</param>
+        /// <returns>A task whose result will be the result from having executed <paramref name="commandAsync"/>.</returns>
+        internal async Task<TResponse> ExecuteMaybeWithTransactionSelectorAsync<TResponse>(
+            Action<TransactionSelector> transactionSelectorSetter,
+            Func<Task<TResponse>> commandAsync,
+            Func<TResponse, Transaction> inlinedTransactionExtractor,
+            bool skipTransactionCreation,
+            CancellationToken cancellationToken,
+            Mutation mutationKey = null)
+        {
+            // If this session is configured to use no transaction we just execute the command.
+            if (TransactionOptions.ModeCase == ModeOneofCase.None)
+            {
+                return await commandAsync().ConfigureAwait(false);
+            }
+
+            // If this is to be a single use transaction, we set the selector to single use and execute the command.
+            if (SingleUseTransaction)
+            {
+                transactionSelectorSetter(new TransactionSelector { SingleUse = TransactionOptions });
+                return await commandAsync().ConfigureAwait(false);
+            }
+
+            // If we already have a transaction ID, we set the selector to that and execute the command.
+            // TransactionId is accessed and modified via Interlock.CompareExchange so these two are atomic operations.
+            // But also, if TransactionId is about to be modified right after this check, that's not a problem, because next
+            // we'll be awaiting on the task that does the modifying.
+            if (TransactionId is ByteString transactionId)
+            {
+                transactionSelectorSetter(new TransactionSelector { Id = transactionId });
+                return await commandAsync().ConfigureAwait(false);
+            }
+
+            // We now know that we don't have a transaction ID but we need one to execute
+            // the command we have been given.
+            // We now need to check if we are already creating a transaction or not.
+            // If we are, we just get ready to wait for it.
+            // If we are not, but we need to, we start and save the task that does so,
+            // and get ready to wait for it.
+
+            // This is the function that will wait for the transaction task to be done.
+            // We need to initialize a function within the lock, so we can execute
+            // async code, outside the lock.
+            // We initialize it with just command, in case no transaction is being created
+            // and the caller does not require one. This is the case for commits and rollbacks
+            // executed when no transaction has been created before.
+            // Commits and rollbacks will know how to handle transaction absence.
+            Func<Task<TResponse>> commandMaybeWithTransactionAsync = commandAsync;
+
+            lock (_transactionCreationTaskLock)
+            {
+                // We are not creating a transaction. We might need to do so.
+                if (_transactionCreationTask is null)
+                {
+                    // We need to create a transaction.
+                    if (!skipTransactionCreation)
+                    {
+                        // The calling command does not support inlining
+                        // or the transaction mode Partitioned DML, which cannot be inline.
+                        // Either way we need to create a transaction explicitly.
+                        if (inlinedTransactionExtractor is null || TransactionOptions.ModeCase == ModeOneofCase.PartitionedDml)
+                        {
+                            _transactionCreationTask = Task.Run(() => SetExplicitTransactionAsync(cancellationToken), cancellationToken);
+                            commandMaybeWithTransactionAsync = () => CommandWithTransactionAsync(cancellationToken);
+                        }
+                        // The calling command supports inlining.
+                        // We attempt inlining but if that fails, we create a transaction explicitly.
+                        else
+                        {
+                            // Create a task for executing the command which inlines transaction creation.
+                            // If this task succeeds we'll have both the transaction ID and the response from the command.
+                            // If this task fails we'll have to attempt to begin a transaction explicitly, which will give us a transaction ID,
+                            // and then we'll have to execute the command with that transaction.
+                            Task<TResponse> commandWithInliningTask = Task.Run(CommandWithInliningAsync, cancellationToken);
+
+                            // Now, create two tasks, one that is done when we have a transaction ID (via inlining or explicit),
+                            // and one that is done when the command is done (with inlining or explicit).
+
+                            // The transaction creation task is the combination of attempting inlining,
+                            // and if that fails, explicitly creating a transaction.
+                            _transactionCreationTask = Task.Run(async () =>
+                            {
+                                try
+                                {
+                                    await SetInlinedTransactionAsync(commandWithInliningTask).ConfigureAwait(false);
+                                }
+                                catch (Exception ex)
+                                {
+                                    Client.Settings.Logger.Warn("Transaction creation via inlining failed. " +
+                                        "Attempting to begin an explicit transaction.",
+                                        ex);
+                                    await SetExplicitTransactionAsync(cancellationToken).ConfigureAwait(false);
+                                }
+                            }, cancellationToken);
+
+                            // The command execution task is the combination of attempting inlining,
+                            // and if that fails, executing the command with the explicitly created transaction.
+                            commandMaybeWithTransactionAsync = async () =>
+                            {
+                                try
+                                {
+                                    var response = await commandWithInliningTask.ConfigureAwait(false);
+                                    // If we are here, inlining was successful so we have a transaction.
+                                    // We only wait for the _transactionCreationTaks to be done to guarantee
+                                    // that the transaction ID obtained via inlining has been stored and can
+                                    // be access via TransactionId. In turn this guarantees command executors
+                                    // that there's an ID available inmediately after a successful command execution.
+                                    await _transactionCreationTask.ConfigureAwait(false);
+                                    return response;
+                                }
+                                catch (Exception ex)
+                                {
+                                    Client.Settings.Logger.Warn("Command execution with transaction inlining failed. " +
+                                        "Waiting for an explicit transaction to be created to attempt command execution.",
+                                        ex);
+                                    // If we got here, transaction inlining (plus command execution) failed.
+                                    // That means that _transactionCreationTask is attempting to created an explicit
+                                    // transaction.
+                                    // So now we wait for that transaction to be created and the execute the command normally.
+                                    return await CommandWithTransactionAsync(cancellationToken).ConfigureAwait(false);
+                                }
+                            };
+                        }
+                    }
+
+                    // No transaction is being created, but we don't need to do so.
+                    // commandWithTransactionAsync is already initialized to just commandAsync.
+                }
+                // We are creating a transaction, let's get ready to wait for that to be done and use it.
+                else
+                {
+                    commandMaybeWithTransactionAsync = () => CommandWithTransactionAsync(cancellationToken);
+                }
+            }
+
+            return await commandMaybeWithTransactionAsync().ConfigureAwait(false);
+
+            async Task<TResponse> CommandWithTransactionAsync(CancellationToken cancellationToken)
+            {
+                // This is only called when we know the _transactionCreationTask has been initialized
+                await _transactionCreationTask.WithCancellationToken(cancellationToken).ConfigureAwait(false);
+                // Now we know there's a transaction id.
+                transactionSelectorSetter(new TransactionSelector { Id = TransactionId });
+                return await commandAsync().ConfigureAwait(false);
+            }
+
+            Task<TResponse> CommandWithInliningAsync()
+            {
+                transactionSelectorSetter(new TransactionSelector { Begin = TransactionOptions });
+                return commandAsync();
+            }
+
+            async Task SetExplicitTransactionAsync(CancellationToken cancellationToken)
+            {
+                Transaction transaction = await BeginTransactionAsync(cancellationToken, mutationKey).ConfigureAwait(false);
+                SetTransaction(transaction);
+            }
+
+            async Task SetInlinedTransactionAsync(Task<TResponse> commandWithInliningTask)
+            {
+                TResponse response = await commandWithInliningTask.ConfigureAwait(false);
+                Transaction transaction = inlinedTransactionExtractor(response)
+                    ?? throw new InvalidOperationException("The inlined transaction extractor returned a null transaction. " +
+                    "This is possibly because of a bug in library code or because an operation that supported transaction inlining has stopped doing so.");
+                SetTransaction(transaction);
+            }
+
+            void SetTransaction(Transaction transaction)
+            {
+                if (Interlocked.CompareExchange(ref _transaction, transaction, null) is not null)
+                {
+                    throw new InvalidOperationException("A transaction has already been set on this instance. This is a bug in library code.");
+                }
+            }
+
+            async Task<Transaction> BeginTransactionAsync(CancellationToken cancellationToken, Mutation mutationKey = null)
+            {
+                var request = new BeginTransactionRequest
+                {
+                    Options = TransactionOptions,
+                    SessionAsSessionName = SessionName,
+                    MutationKey = mutationKey
+                };
+                var callSettings = Client.Settings.BeginTransactionSettings
+                    .WithExpiration(Expiration.FromTimeout(_multiplexSession.Options.Timeout))
+                    .WithCancellationToken(cancellationToken);
+
+                Transaction response = await RecordSuccessAndExpiredSessions(Client.BeginTransactionAsync(request, callSettings)).ConfigureAwait(false);
+                UpdatePrecommitToken(response.PrecommitToken);
+
+                return response;
+            }
+        }
+
+        /// <summary>
+        /// Executes a Commit RPC asynchronously.
+        /// </summary>
+        /// <param name="request">The commit request. Must not be null. The request will be modified with session and transaction details
+        /// from this object.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A task representing the asynchronous operation. When the task completes, the result is the response from the RPC.</returns>
+        public Task<CommitResponse> CommitAsync(CommitRequest request, CallSettings callSettings)
+        {
+            MaybeWaitOnSessionRefresh();
+            GaxPreconditions.CheckNotNull(request, nameof(request));
+
+            request.SessionAsSessionName = SessionName;
+            request.PrecommitToken = FetchPrecommitToken();
+
+            return ExecuteMaybeWithTransactionSelectorAsync(
+                transactionSelectorSetter: SetCommandTransaction,
+                commandAsync: CommitAsync,
+                inlinedTransactionExtractor: null, // Commit does not support inline transactions.
+                skipTransactionCreation: request.Mutations.Count == 0, // If there are only mutations we won't have a transaction but we need one.
+                callSettings?.CancellationToken ?? default,
+                // Multiplex sessions needs a mutation key in transaction create for a purely mutation based transaction
+                mutationKey: request.Mutations.Count > 0 ? request.Mutations.ElementAt(0) : null);
+
+            void SetCommandTransaction(TransactionSelector transactionSelector)
+            {
+                switch (transactionSelector.SelectorCase)
+                {
+                    case TransactionSelector.SelectorOneofCase.Id:
+                        request.TransactionId = transactionSelector.Id;
+                        break;
+                    case TransactionSelector.SelectorOneofCase.Begin:
+                        throw new InvalidOperationException("Commit does not support inline transactions. This is a bug in library code.");
+                    case TransactionSelector.SelectorOneofCase.SingleUse:
+                        throw new InvalidOperationException("A single use transaction cannot be committed.");
+                    default:
+                        throw new InvalidOperationException("Cannot commit with no associated transaction");
+                }
+            }
+
+            async Task<CommitResponse> CommitAsync()
+            {
+                // If a transaction had been started, by now SetTransaction should have been called with a transaction ID.
+                // If not, there's an attempt to commit a non-existent transaction.
+                if (request.TransactionId is null || request.TransactionId.IsEmpty)
+                {
+                    throw new InvalidOperationException("Cannot commit without an associated transaction. " +
+                        "A transaction has not been acquired because no command execution has been attempted.");
+                }
+
+
+                request.PrecommitToken = FetchPrecommitToken();
+                CommitResponse response = await RecordSuccessAndExpiredSessions(Client.CommitAsync(request, callSettings)).ConfigureAwait(false);
+                UpdatePrecommitToken(response.PrecommitToken);
+
+                if (response.MultiplexedSessionRetryCase == CommitResponse.MultiplexedSessionRetryOneofCase.PrecommitToken)
+                {
+                    // One time retry, if signaled to do so by the server with a new Precommit Token
+                    // Fetch latest precommit token returned in the earlier response for the retry
+                    request.PrecommitToken = FetchPrecommitToken();
+                    response = await RecordSuccessAndExpiredSessions(Client.CommitAsync(request, callSettings)).ConfigureAwait(false);
+                    UpdatePrecommitToken(response.PrecommitToken);
+                }
+
+                return response;
+            }
+        }
+
+        /// <summary>
+        /// Executes a Rollback RPC asynchronously.
+        /// </summary>
+        /// <param name="request">The rollback request. Must not be null. The request will be modified with session and transaction details
+        /// from this object.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        public Task RollbackAsync(RollbackRequest request, CallSettings callSettings)
+        {
+            MaybeWaitOnSessionRefresh();
+            GaxPreconditions.CheckNotNull(request, nameof(request));
+
+            request.SessionAsSessionName = SessionName;
+
+            return ExecuteMaybeWithTransactionSelectorAsync(
+                transactionSelectorSetter: SetCommandTransaction,
+                commandAsync: RollbackAsync,
+                inlinedTransactionExtractor: null, // Rollback does not support inline transactions.
+                skipTransactionCreation: true, // If there's no transaction by the time roll back is called, we fail, we don't need to create one.
+                callSettings?.CancellationToken ?? default);
+
+            void SetCommandTransaction(TransactionSelector transactionSelector)
+            {
+                switch (transactionSelector.SelectorCase)
+                {
+                    case TransactionSelector.SelectorOneofCase.Id:
+                        request.TransactionId = transactionSelector.Id;
+                        break;
+                    case TransactionSelector.SelectorOneofCase.Begin:
+                        throw new InvalidOperationException("Rollback does not support inline transactions. This is a bug in library code.");
+                    case TransactionSelector.SelectorOneofCase.SingleUse:
+                        throw new InvalidOperationException("A single use transaction cannot be rolled back.");
+                    default:
+                        throw new InvalidOperationException("Cannot roll back with no associated transaction");
+                }
+            }
+
+            async Task<bool> RollbackAsync()
+            {
+                // If a transaction had been started, by now SetTransaction should have been called with a transaction ID.
+                // If not, there's an attempt to roll back a transaction that was never started.
+                // Possibly starting the transaction is what failed, but if we fail here as well, we are passing the burden to calling code
+                // to know whether a transaction was actually acquired before calling rollback, and we don't want to do that.
+                // Attemting to roll back an empty transaction is no-op.
+                if (request.TransactionId is null || request.TransactionId.IsEmpty)
+                {
+                    return false;
+                }
+
+                await RecordSuccessAndExpiredSessions(Client.RollbackAsync(request, callSettings)).ConfigureAwait(false);
+                //MarkAsCommittedOrRolledBack();
+                // Just so we can use the same ExecuteMaybeWithTransactionAsync method that expects a result.
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Executes a PartitionRead RPC asynchronously.
+        /// </summary>
+        /// <param name="request">The partitioning request. Must not be null. The request will be modified with session details
+        /// from this object.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A task representing the asynchronous operation. When the task completes, the result is the response from the RPC.</returns>
+        public Task<PartitionResponse> PartitionReadAsync(PartitionReadRequest request, CallSettings callSettings) =>
+            PartitionReadOrQueryAsync(PartitionReadOrQueryRequest.FromRequest(request), callSettings);
+
+        /// <summary>
+        /// Executes a PartitionQuery RPC asynchronously.
+        /// </summary>
+        /// <param name="request">The partitioning request. Must not be null. The request will be modified with session details
+        /// from this object.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A task representing the asynchronous operation. When the task completes, the result is the response from the RPC.</returns>
+        public Task<PartitionResponse> PartitionQueryAsync(PartitionQueryRequest request, CallSettings callSettings) =>
+            PartitionReadOrQueryAsync(PartitionReadOrQueryRequest.FromRequest(request), callSettings);
+
+        /// <summary>
+        /// Executes a PartitionRead RPC asynchronously.
+        /// </summary>
+        /// <param name="request">The partitioning request. Must not be null. The request will be modified with session details
+        /// from this object.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A task representing the asynchronous operation. When the task completes, the result is the response from the RPC.</returns>
+        internal Task<PartitionResponse> PartitionReadOrQueryAsync(PartitionReadOrQueryRequest request, CallSettings callSettings)
+        {
+            MaybeWaitOnSessionRefresh();
+            GaxPreconditions.CheckNotNull(request, nameof(request));
+
+            request.SessionAsSessionName = SessionName;
+
+            return ExecuteMaybeWithTransactionSelectorAsync(
+                transactionSelectorSetter: SetCommandTransaction,
+                commandAsync: PartitionReadOrQueryAsync,
+                inlinedTransactionExtractor: GetInlinedTransaction,
+                skipTransactionCreation: false,
+                callSettings?.CancellationToken ?? default);
+
+            void SetCommandTransaction(TransactionSelector transactionSelector)
+            {
+                switch (transactionSelector.SelectorCase)
+                {
+                    case TransactionSelector.SelectorOneofCase.Id:
+                    case TransactionSelector.SelectorOneofCase.Begin:
+                        request.Transaction = transactionSelector;
+                        break;
+                    case TransactionSelector.SelectorOneofCase.SingleUse:
+                        throw new InvalidOperationException("A single use transaction cannot be used for creating partitioned reads or queries.");
+                    default:
+                        throw new InvalidOperationException("Cannot call PartitionReadOrQueryAsync with no associated transaction.");
+                }
+            }
+
+            Task<PartitionResponse> PartitionReadOrQueryAsync()
+            {
+                // By now SetTransaction should have been called with a valid transaction selector.
+                // If not, there's a bug in code because we said not to skip transaction creation.
+                if (request.Transaction is null)
+                {
+                    throw new InvalidOperationException("Cannot call PartitionReadOrQueryAsync with no associated transaction.");
+                }
+
+                return RecordSuccessAndExpiredSessions(request.PartitionAsync(Client, callSettings));
+            }
+
+            Transaction GetInlinedTransaction(PartitionResponse response) => response?.Transaction;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ReliableStreamReader"/> for the given request.
+        /// </summary>
+        /// <param name="request">
+        /// The read request. Must not be null.
+        /// Will be modified to include session information from this pooled session.
+        /// May be modified to include transaction and directed read options information
+        /// from this pooled session and its underlying <see cref="SpannerClient"/>.
+        /// </param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A <see cref="ReliableStreamReader"/> for the streaming SQL request.</returns>
+        public ReliableStreamReader ReadStreamReader(ReadRequest request, CallSettings callSettings) =>
+            ExecuteReadOrQueryStreamReader(ReadOrQueryRequest.FromRequest(request), callSettings);
+
+        /// <summary>
+        /// Creates a <see cref="ReliableStreamReader"/> for the given request.
+        /// </summary>
+        /// <param name="request">
+        /// The query request. Must not be null.
+        /// Will be modified to include session information from this pooled session.
+        /// May be modified to include transaction and directed read options information
+        /// from this pooled session and its underlying <see cref="SpannerClient"/>.
+        /// </param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A <see cref="ReliableStreamReader"/> for the streaming SQL request.</returns>
+        public ReliableStreamReader ExecuteSqlStreamReader(ExecuteSqlRequest request, CallSettings callSettings) =>
+            ExecuteReadOrQueryStreamReader(ReadOrQueryRequest.FromRequest(request), callSettings);
+
+        /// <summary>
+        /// Creates a <see cref="ReliableStreamReader"/> for the given request
+        /// </summary>
+        /// <param name="request">The read request. Must not be null. The request will be modified with session and transaction details
+        /// from this object. If this object's <see cref="TransactionId"/> is null, the request's transaction is not modified.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A <see cref="ReliableStreamReader"/> for the streaming read request.</returns>
+        internal ReliableStreamReader ExecuteReadOrQueryStreamReader(ReadOrQueryRequest request, CallSettings callSettings)
+        {
+            MaybeWaitOnSessionRefresh();
+            GaxPreconditions.CheckNotNull(request, nameof(request));
+
+            request.SessionAsSessionName = SessionName;
+            SpannerClientImpl.ApplyResourcePrefixHeaderFromSession(ref callSettings, request.Session);
+            Client.MaybeApplyRouteToLeaderHeader(ref callSettings, TransactionMode);
+            MaybeApplyDirectedReadOptions(request.UnderlyingRequest);
+
+            ResultStream stream = new ResultStream(Client, request, this, callSettings);
+            return new ReliableStreamReader(stream, Client.Settings.Logger);
+        }
+
+        /// <summary>
+        /// Executes an ExecuteSql RPC asynchronously.
+        /// </summary>
+        /// <param name="request">The query request. Must not be null.
+        /// Will be modified to include session information from this pooled session.
+        /// May be modified to include transaction and directed read options information
+        /// from this pooled session and its underlying <see cref="SpannerClient"/>.
+        /// </param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A task representing the asynchronous operation. When the task completes, the result is the response from the RPC.</returns>
+        public Task<ResultSet> ExecuteSqlAsync(ExecuteSqlRequest request, CallSettings callSettings)
+        {
+            MaybeWaitOnSessionRefresh();
+            GaxPreconditions.CheckNotNull(request, nameof(request));
+
+            request.SessionAsSessionName = SessionName;
+
+            return ExecuteMaybeWithTransactionSelectorAsync(
+                transactionSelectorSetter: SetCommandTransaction,
+                commandAsync: ExecuteSqlAsync,
+                inlinedTransactionExtractor: GetInlinedTransaction,
+                skipTransactionCreation: false,
+                callSettings?.CancellationToken ?? default);
+
+            void SetCommandTransaction(TransactionSelector transactionSelector) => request.Transaction = transactionSelector;
+
+            async Task<ResultSet> ExecuteSqlAsync() // TODO: Purva check consequences of making this an async method
+            {
+                Client.MaybeApplyRouteToLeaderHeader(ref callSettings, TransactionMode);
+                MaybeApplyDirectedReadOptions(request);
+                ResultSet response = await RecordSuccessAndExpiredSessions(Client.ExecuteSqlAsync(request, callSettings)).ConfigureAwait(false);
+                UpdatePrecommitToken(response.PrecommitToken);
+                return response;
+            }
+
+            Transaction GetInlinedTransaction(ResultSet response) => response?.Metadata?.Transaction;
+        }
+
+        /// <summary>
+        /// Executes an ExecuteBatchDml RPC asynchronously.
+        /// </summary>
+        /// <param name="request">The query request. Must not be null. The request will be modified with session and transaction details
+        /// from this object. If this object's <see cref="TransactionId"/> is null, the request's transaction is not modified.</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A task representing the asynchronous operation. When the task completes, the result is the response from the RPC.</returns>
+        public Task<ExecuteBatchDmlResponse> ExecuteBatchDmlAsync(ExecuteBatchDmlRequest request, CallSettings callSettings)
+        {
+            MaybeWaitOnSessionRefresh();
+            GaxPreconditions.CheckNotNull(request, nameof(request));
+
+            request.SessionAsSessionName = SessionName;
+
+            return ExecuteMaybeWithTransactionSelectorAsync(
+                transactionSelectorSetter: SetCommandTransaction,
+                commandAsync: ExecuteBatchDmlAsync,
+                inlinedTransactionExtractor: GetInlinedTransaction,
+                skipTransactionCreation: false,
+                callSettings?.CancellationToken ?? default);
+
+            void SetCommandTransaction(TransactionSelector transactionSelector) => request.Transaction = transactionSelector;
+
+            async Task<ExecuteBatchDmlResponse> ExecuteBatchDmlAsync() // TODO: Purva to check consequence of making this method async
+            {
+                ExecuteBatchDmlResponse response = await RecordSuccessAndExpiredSessions(Client.ExecuteBatchDmlAsync(request, callSettings)).ConfigureAwait(false);
+                UpdatePrecommitToken(response.PrecommitToken);
+                return response;
+            }
+
+            Transaction GetInlinedTransaction(ExecuteBatchDmlResponse response) => response?.ResultSets?.FirstOrDefault()?.Metadata?.Transaction;
+        }
+
+        private void MaybeApplyDirectedReadOptions(IReadOrQueryRequest request)
+        {
+            if (TransactionMode == ModeOneofCase.ReadOnly // Directed reads apply only to single use or read only transactions. Single use are read only.
+                && request.DirectedReadOptions is null) // Request specific options have priority over client options.
+            {
+                request.DirectedReadOptions = Client.Settings.DirectedReadOptions;
+            }
+
+            // We don't validate that DirectedReadOptions is null when this is a non-read-only transaction.
+            // We just pass the request along as we received it. The service should fail if there are options set.
+            // This was agreed as part of the client library desing.
+        }
+
+        private void MaybeWaitOnSessionRefresh()
+        {
+            _multiplexSession.MaybeRefreshWithTimePeriodCheck();
+        }
+
+        private async Task<T> RecordSuccessAndExpiredSessions<T>(Task<T> task)
+        {
+            var result = await task.WithSessionExpiryChecking(Session).ConfigureAwait(false);
+            return result;
+        }
+
+        private async Task RecordSuccessAndExpiredSessions(Task task)
+        {
+            await task.WithSessionExpiryChecking(Session).ConfigureAwait(false);
+        }
+
+        internal void UpdatePrecommitToken(MultiplexedSessionPrecommitToken token)
+        {
+            lock (_precommitTokenUpdateLock)
+            {
+                if (PrecommitToken == null || PrecommitToken.SeqNum < token?.SeqNum)
+                {
+                    PrecommitToken = token;
+                }
+            }
+        }
+
+        internal MultiplexedSessionPrecommitToken FetchPrecommitToken()
+        {
+            lock (_precommitTokenUpdateLock)
+            {
+                return PrecommitToken;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Creating a draft PR for early review.

Idea here is SessionPool translates to the MultiplexSession class. And PooledSession translates to the Transaction wrapper in this new design.

Lifecycle of the MulitplexSession -- Each query/operation coming in as part of the transaction checks for the expiry of the session. There is a proactive 'refresh' of the session every 7 days. If an operation comes in when the session is past this 7 day period, it can still safely use the existing session and we fire a session refresh in the background asynchronously. If the session is past 28 days of expiry, this session can no longer be safely used since there is already cleanup on the backend. The transaction needs to block till we get a new Session.

TODO: 
1. Add in summary for public methods
2. Add in more Unit tests covering MultiplexSession class