### PR TITLE
chore: unblock release of Capacity Planner

### DIFF
--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -4532,7 +4532,7 @@
             "id": "Google.Cloud.CapacityPlanner.V1Beta",
             "nextVersion": "1.0.0-beta01",
             "generationAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
-            "releaseAutomationLevel": "AUTOMATION_LEVEL_BLOCKED",
+            "releaseAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "lastGeneratedCommit": "2954ae6003c9cfb49ef49c4cbc2e12dc43a97546",
             "apiPaths": [
                 "google/cloud/capacityplanner/v1beta"


### PR DESCRIPTION
(The smoke tests pass locally now, and the breaking change has been merged.)