### PR TITLE
docs: improve authentication section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,8 @@ Next, choose a method for authenticating API requests from within your project:
 
       ```
       set GOOGLE_APPLICATION_CREDENTIALS=/path/to/my/key.json
-      ``` 
+      ```
+    * Specify the credentials as explained in the [client configuration documentation](https://cloud.google.com/dotnet/docs/reference/help/client-configuration#specifying-credentials)
     * If running locally for development/testing, you can authenticate using the [Google Cloud SDK](https://cloud.google.com/sdk/).
       Download the SDK if you haven't already, then login by running the following in the command line:
 


### PR DESCRIPTION
The [Authentication](https://github.com/googleapis/google-cloud-dotnet?tab=readme-ov-file#authentication) section in [README.md](https://github.com/googleapis/google-cloud-dotnet?tab=readme-ov-file#) does not describe how the users may configure the client to authenticate using `GoogleCredential`,`CredentialsPath` and `JsonCredentials` to implement the following scenario:

```
As a software engineer,
I want to build mutliple google cloud dotnet client instances,
And each client instance should have a unique service account key,
So that my application can authenticate and use multiple service accounts
```

Given this scenario, the approach would be straightforward. For example:

1. Instantiate two or more clients

```
GoogleCredential firstGoogleCredential = GoogleCredential.FromFile(/path/to/my/key-1.json);
RecaptchaEnterpriseServiceClientBuilder firstBuilder = new()
{
    GoogleCredential = firstGoogleCredential,
};
RecaptchaEnterpriseServiceClient firstClient = builder.Build();


GoogleCredential secondGoogleCredential = GoogleCredential.FromFile(/path/to/my/key-2.json);
RecaptchaEnterpriseServiceClientBuilder secondBuilder = new()
{
    GoogleCredential = secondGoogleCredential,
};
RecaptchaEnterpriseServiceClient secondClient = builder.Build();
```

2. Resolve the corrent instance (`firstClient` or `secondClient`) at runtime and use it to perform a reCaptcha assessment.