### PR TITLE
doc(auth): Reference secure credential loading

### DIFF
--- a/docs/devsite-help/client-configuration.md
+++ b/docs/devsite-help/client-configuration.md
@@ -4,14 +4,18 @@ Every client has a corresponding builder class (e.g. `ExampleClientBuilder`) wit
 methods.
 
 The builder allows you to customize various aspects of the client, most notably credentials. For example,
-if you load JSON containing the relevant credentials to use, you might construct a client with:
+if you load JSON containing the relevant service account credentials to use, you might construct a client with:
 
 ```csharp
+var credential = CredentialFactory.FromJson<ServiceAccountCredential>(json).ToGoogleCredential();
 var client = new ExampleClientBuilder
 {
-    JsonCredentials = json
+    GoogleCredential = credential
 }.Build();
 ```
+Other credential types (UserCredential, ImpersonatedCredential, ExternalAccountAuthorizedUserCredential) may be
+loaded in a similar way, by specifying the type `T` of `CredentialFactory.FromJson<T>(string json)` or any of the other
+`CredentialFactory` methods.
 
 Clients can also be configured via dependency injection, but that's just a (very) convenient approach to using the
 builder: everything can be configured via the builder. See the [client lifecycle documentation](client-lifecycle.md)
@@ -33,11 +37,9 @@ The following properties are used for specifying and configuring which credentia
 uses to authenticate and authorize requests. When no properties are set,
 [application default credentials](https://cloud.google.com/docs/authentication/production#automatically) are used.
 
-### CredentialsPath, JsonCredentials or GoogleCredential
-
-These three (mutually-exclusive) properties represent different ways of providing a `GoogleCredential`. Specifying
-`CredentialsPath` or `JsonCredentials` is equivalent to specifying the result of `GoogleCredential.FromFile` or
-`GoogleCredential.FromJson` for the `GoogleCredential` property.
+### GoogleCredential
+This property is a `GoogleCredential` used for authorizing calls. This credential may be modified by
+`Scopes`, `UseJwtAccessWithScopes` and `QuotaProject`.
 
 ### Scopes, UseJwtAccessWithScopes and QuotaProject
 


### PR DESCRIPTION
In the docs use CredentialFactory and remove references to ClientBuilderBase.CredentialsPath and ClientBuilderBase.JsonCredentials