### PR TITLE
fix: Tweak a few things in Google.Cloud.VertexAI.Extensions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,7 +30,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version= "8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.AI" Version= "9.9.1" />
+    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version= "9.10.0" />
 
     <!-- Misc packages (might warrant a reorganization at some point) -->
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions.Tests/AsIChatClientTest.cs
+++ b/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions.Tests/AsIChatClientTest.cs
@@ -31,7 +31,23 @@ namespace Google.Cloud.VertexAI.Extensions.Tests;
 public class AsIChatClientTest
 {
     [Fact]
-    public void InvalidArguments_Throws()
+    public void AsIChatClient_ValidArguments_CreatesIChatClientSuccessfully()
+    {
+        PredictionServiceClient client = CreateClient();
+        IChatClient chatClient = client.AsIChatClient();
+        Assert.NotNull(chatClient);
+        Assert.Same(client, chatClient.GetService<PredictionServiceClient>());
+    }
+
+    [Fact]
+    public void BuildIChatClient_ValidArguments_CreatesIChatClientSuccessfully()
+    {
+        IChatClient chatClient = new PredictionServiceClientBuilder() { ApiKey = "fake-api-key" }.BuildIChatClient();
+        Assert.NotNull(chatClient.GetService<PredictionServiceClient>());
+    }
+
+    [Fact]
+    public void AsIChatClient_InvalidArguments_Throws()
     {
         Assert.Throws<ArgumentNullException>("client", () => VertexAIExtensions.AsIChatClient(null!));
     }

--- a/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions.Tests/AsIEmbeddingGeneratorTest.cs
+++ b/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions.Tests/AsIEmbeddingGeneratorTest.cs
@@ -26,7 +26,23 @@ namespace Google.Cloud.VertexAI.Extensions.Tests;
 public class AsIEmbeddingGeneratorTest
 {
     [Fact]
-    public void InvalidArguments_Throws()
+    public void AsIEmbeddingGenerator_ValidArguments_CreatesIEmbeddingGeneratorSuccessfully()
+    {
+        PredictionServiceClient client = CreateClient();
+        IEmbeddingGenerator generator = client.AsIEmbeddingGenerator();
+        Assert.NotNull(generator);
+        Assert.Same(client, generator.GetService<PredictionServiceClient>());
+    }
+
+    [Fact]
+    public void BuildIEmbeddingGenerator_ValidArguments_CreatesIEmbeddingGeneratorSuccessfully()
+    {
+        IEmbeddingGenerator generator = new PredictionServiceClientBuilder() { ApiKey = "fake-api-key" }.BuildIEmbeddingGenerator();
+        Assert.NotNull(generator.GetService<PredictionServiceClient>());
+    }
+
+    [Fact]
+    public void AsIEmbeddingGenerator_InvalidArguments_Throws()
     {
         Assert.Throws<ArgumentNullException>("client", () => VertexAIExtensions.AsIEmbeddingGenerator(null!));
     }

--- a/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions.Tests/AsIImageGeneratorTest.cs
+++ b/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions.Tests/AsIImageGeneratorTest.cs
@@ -27,7 +27,24 @@ namespace Google.Cloud.VertexAI.Extensions.Tests;
 public class AsIImageGeneratorTest
 {
     [Fact]
-    public void InvalidArguments_Throws()
+    public void AsIImageGenerator_ValidArguments_CreatesIImageGeneratorSuccessfully()
+    {
+        PredictionServiceClient client = CreateClient();
+        IImageGenerator generator = client.AsIImageGenerator();
+        Assert.NotNull(generator);
+        Assert.Same(client, generator.GetService<PredictionServiceClient>());
+    }
+
+    [Fact]
+    public void BuildIImageGenerator_ValidArguments_CreatesIImageGeneratorSuccessfully()
+    {
+        IImageGenerator generator = new PredictionServiceClientBuilder() { ApiKey = "fake-api-key" }.BuildIImageGenerator();
+        Assert.NotNull(generator.GetService<PredictionServiceClient>());
+    }
+
+
+    [Fact]
+    public void AsIImageGenerator_InvalidArguments_Throws()
     {
         Assert.Throws<ArgumentNullException>("client", () => VertexAIExtensions.AsIImageGenerator(null!));
     }

--- a/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions.csproj
+++ b/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Google.Cloud.AIPlatform.V1\Google.Cloud.AIPlatform.V1\Google.Cloud.AIPlatform.V1.csproj" />
-    <PackageReference Include="Microsoft.Extensions.AI" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
   </ItemGroup>
   <ItemGroup>

--- a/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions/VertexAIExtensions.cs
+++ b/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions/VertexAIExtensions.cs
@@ -56,7 +56,11 @@ public static class VertexAIExtensions
     {
         GaxPreconditions.CheckNotNull(builder, nameof(builder));
 
-        return builder.Build(provider).AsIChatClient(defaultModelId);
+        PredictionServiceClient client = provider is not null ?
+            builder.Build(provider) :
+            builder.Build();
+
+        return client.AsIChatClient(defaultModelId);
     }
 
     /// <summary>
@@ -94,7 +98,11 @@ public static class VertexAIExtensions
     {
         GaxPreconditions.CheckNotNull(builder, nameof(builder));
 
-        return builder.Build(provider).AsIEmbeddingGenerator(defaultModelId);
+        PredictionServiceClient client = provider is not null ?
+            builder.Build(provider) :
+            builder.Build();
+
+        return client.AsIEmbeddingGenerator(defaultModelId);
     }
 
     /// <summary>
@@ -131,7 +139,11 @@ public static class VertexAIExtensions
     {
         GaxPreconditions.CheckNotNull(builder, nameof(builder));
 
-        return builder.Build(provider).AsIImageGenerator(defaultModelId);
+        PredictionServiceClient client = provider is not null ?
+            builder.Build(provider) :
+            builder.Build();
+
+        return client.AsIImageGenerator(defaultModelId);
     }
 
     /// <summary>Gets the name of the provider for use as the metadata provider name.</summary>


### PR DESCRIPTION
- Changed dependency to be on M.E.AI.Abstractions rather than on M.E.AI. The latter contains additional middleware that's not used or needed by this implementation.
- Updated M.E.AI.Abstractions dependency from 9.9.1 to 9.10.0
- Fixed handling of null IServiceProvider in BuildXx methods (I didn't realize it wasn't optional in Build(IServiceProvider)).

Contributes to https://github.com/googleapis/google-cloud-dotnet/issues/13815

cc: @amanda-tarafa, @jskeet 