### PR TITLE
fix: update Microsoft.AspNetCore.Server.Kestrel.Core 2.3.0 -> 2.3.6

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -61,6 +61,6 @@
     <PackageVersion Include="log4net" Version="2.0.17" />
     <PackageVersion Include="NLog" Version="5.5.1" />
     <PackageVersion Include="Grpc.AspNetCore" Version="2.40.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.3.6" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Microsoft.AspNetCore.Server.Kestrel.Core has a security vulnerability and needs to be updated to the 2.3.6 a patched version fixing this issue. See [CVE-2025-55315](https://github.com/advisories/GHSA-5rrx-jjjq-q2r5).

This warning is currently breaking our build pipeline: [BUILD](https://github.com/googleapis/google-cloud-dotnet/actions/runs/18535557478/job/52829603585)