### PR TITLE
chore: revert incorrect Storage version changes

### DIFF
--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -3053,12 +3053,11 @@
         },
         {
             "id": "Google.Cloud.Storage.V1",
-            "currentVersion": "4.14.0",
+            "currentVersion": "4.13.0",
             "generationAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
-            "releaseTimestamp": "2025-10-20T16:16:52.493030050Z",
+            "releaseTimestamp": "2025-04-25T08:34:24Z",
             "lastGeneratedCommit": "7e795c44dae36500aeb8715536eedc3597c56e5e",
-            "lastReleasedCommit": "7e795c44dae36500aeb8715536eedc3597c56e5e",
             "sourcePaths": [
                 "apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1"
             ]


### PR DESCRIPTION
These occurred due to a known bug in Librarian v0.1.0 when a library fails in integration tests.