### PR TITLE
chore: add timestamps for running integration tests

### DIFF
--- a/tools/Google.Cloud.Tools.ReleaseManager/ContainerCommands/IntegrationTestLibraryCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/ContainerCommands/IntegrationTestLibraryCommand.cs
@@ -39,6 +39,7 @@ internal class IntegrationTestLibraryCommand : IContainerCommand
         var rootLayout = RootLayout.ForRepositoryRoot(repoRoot);
         var catalog = ApiCatalog.Load(rootLayout);
         var apis = options.GetApisFromLibraryId(catalog);
+        Console.WriteLine($"{DateTime.UtcNow:yyyy-MM-dd'T'HH:mm:ss.fff}Z Starting integration tests for {options.LibraryId}");
         for (int attempt = 1; true; attempt++)
         {
             var args = attempt == 1 ? apis.Select(api => api.Id).ToList() : new List<string> { "--retry" };
@@ -56,6 +57,7 @@ internal class IntegrationTestLibraryCommand : IContainerCommand
                 Console.WriteLine($"Failure running integration tests on attempt {attempt}. (Max attempts = {MaxAttempts})");
             }
         }
+        Console.WriteLine($"{DateTime.UtcNow:yyyy-MM-dd'T'HH:mm:ss.fff}Z Completed integration tests for {options.LibraryId}");
         return 0;
     }
 


### PR DESCRIPTION
Note that this is used within actual containers, and also in the run-windows-release-tests job.