### PR TITLE
feat(Storage): Add ReturnPartialSuccess support to ListBuckets 

### DIFF
--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/ListBucketsOptionsTest.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.Tests/ListBucketsOptionsTest.cs
@@ -31,6 +31,7 @@ namespace Google.Cloud.Storage.V1.Tests
             Assert.Null(request.MaxResults);
             Assert.Null(request.PageToken);
             Assert.Null(request.SoftDeleted);
+            Assert.Null(request.ReturnPartialSuccess);
         }
 
         [Fact]
@@ -45,6 +46,7 @@ namespace Google.Cloud.Storage.V1.Tests
                 PageToken = "nextpage",
                 Fields = "items(name),nextPageToken",
                 SoftDeletedOnly = true,
+                ReturnPartialSuccess = true
             };
             options.ModifyRequest(request);
             Assert.Equal(10, request.MaxResults);
@@ -53,6 +55,7 @@ namespace Google.Cloud.Storage.V1.Tests
             Assert.Equal("nextpage", request.PageToken);
             Assert.Equal("items(name),nextPageToken", request.Fields);
             Assert.True(request.SoftDeleted);
+            Assert.True(request.ReturnPartialSuccess);
         }
     }
 }

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Rest" />
-    <PackageReference Include="Google.Apis.Storage.v1" VersionOverride="[1.69.0.3707, 2.0.0.0)" />
+    <PackageReference Include="Google.Apis.Storage.v1" VersionOverride="[1.71.0.3920, 2.0.0.0)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="StorageClient.*.cs">

--- a/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/ListBucketsOptions.cs
+++ b/apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1/ListBucketsOptions.cs
@@ -68,6 +68,12 @@ namespace Google.Cloud.Storage.V1
         public bool? SoftDeletedOnly { get; set; }
 
         /// <summary>
+        /// If true, buckets from reachable locations are returned. The resource names of buckets from unreachable locations will be available on the <c>Unreachable</c>
+        /// property of a raw response from <see cref="PagedEnumerable{TResponse, TResource}.AsRawResponses"/>. The default is false.
+        /// </summary>
+        public bool? ReturnPartialSuccess { get; set; }
+
+        /// <summary>
         /// Modifies the specified request for all non-null properties of this options object.
         /// </summary>
         /// <param name="request">The request to modify</param>
@@ -96,6 +102,10 @@ namespace Google.Cloud.Storage.V1
             if (SoftDeletedOnly != null)
             {
                 request.SoftDeleted = SoftDeletedOnly;
+            }
+            if (ReturnPartialSuccess != null)
+            {
+                request.ReturnPartialSuccess = ReturnPartialSuccess;
             }
         }
     }

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -5599,7 +5599,7 @@
       "description": "Recommended Google client library to access the Google Cloud Storage API. It wraps the Google.Apis.Storage.v1 client library, making common operations simpler in client code. Google Cloud Storage stores and retrieves potentially large, immutable data objects.",
       "dependencies": {
         "Google.Api.Gax.Rest": "default",
-        "Google.Apis.Storage.v1": "1.69.0.3707"
+        "Google.Apis.Storage.v1": "1.71.0.3920"
       },
       "testDependencies": {
         "Google.Api.Gax.Testing": "default",


### PR DESCRIPTION
This PR introduces the `returnPartialSuccess` flag (via `ListBucketsOptions`). When set to true, the method will return buckets from reachable locations and populate the resource names of the buckets from `unreachable`  locations, rather than failing the entire request. Please see [b/459649174](https://b.corp.google.com/issues/401332989)