### PR TITLE
feat: Spanner non-awaiting DDL

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/AdminTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/AdminTests.cs
@@ -12,7 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Api.Gax.Grpc;
+using Google.Cloud.Spanner.Admin.Database.V1;
 using Google.Cloud.Spanner.Data.CommonTesting;
+using Google.LongRunning;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
 using System;
 using System.Threading.Tasks;
 using Xunit;
@@ -239,19 +244,76 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             using (var connection = new SpannerConnection(builder.WithDatabase(dbName)))
             {
                 var dropSingersCmd = connection.CreateDdlCommand("DROP TABLE Singers");
-                var dropBothTablesCmd = connection.CreateDdlCommand("DROP TABLE Albums", "DROP TABLE Singers");
+                var dropAlbumsCmd = connection.CreateDdlCommand("DROP TABLE Albums");
 
                 await Assert.ThrowsAsync<SpannerException>(() => dropSingersCmd.ExecuteNonQueryAsync());
-                var operationName = await dropBothTablesCmd.StartDdlAsync();
-                Assert.NotEqual("", operationName);
+                await dropAlbumsCmd.ExecuteNonQueryAsync();
+                await dropSingersCmd.ExecuteNonQueryAsync();
             }
 
             using (var connection = new SpannerConnection(builder))
             {
                 var dropCommand = connection.CreateDdlCommand($"DROP DATABASE {dbName}");
-                var operationName = await dropCommand.StartDdlAsync();
-                // DropDatabase does not return a long-running operation.
-                Assert.Equal("", operationName);
+                await dropCommand.ExecuteNonQueryAsync();
+            }
+        }
+
+        [Fact]
+        public async Task StartDdlReturnsOperationName()
+        {
+            string dbName = GenerateDatabaseName();
+            var builder = new SpannerConnectionStringBuilder(_fixture.Database.NoDbConnectionString);
+            var connectionOptions = new SpannerClientCreationOptions(builder);
+            var adminClientBuilder = connectionOptions.CreateDatabaseAdminClientBuilder();
+            var adminClient = await adminClientBuilder.BuildAsync();
+            var channel = adminClientBuilder.LastCreatedChannel;
+
+            try
+            {
+                using (var connection = new SpannerConnection(builder))
+                {
+                    var createDbCommand = connection.CreateDdlCommand($"CREATE DATABASE {dbName}");
+                    var operationName = await createDbCommand.StartDdlAsync();
+                    Assert.False(string.IsNullOrEmpty(operationName));
+
+                    await HandleLro<Database, CreateDatabaseMetadata>(
+                        adminClient.CreateDatabaseOperationsClient, operationName);
+                }
+
+                using (var connection = new SpannerConnection(builder.WithDatabase(dbName)))
+                {
+                    var createTableCommand = connection.CreateDdlCommand(
+                        "CREATE TABLE Singers (SingerId INT64 PRIMARY KEY, Name STRING(1024))");
+                    var operationName = await createTableCommand.StartDdlAsync();
+                    Assert.False(string.IsNullOrEmpty(operationName));
+
+                    await HandleLro<Empty, UpdateDatabaseDdlMetadata>(
+                        adminClient.UpdateDatabaseDdlOperationsClient, operationName);
+                }
+
+                using (var connection = new SpannerConnection(builder))
+                {
+                    var dropCommand = connection.CreateDdlCommand($"DROP DATABASE {dbName}");
+                    var operationName = await dropCommand.StartDdlAsync();
+                    // DropDatabase does not return a long-running operation.
+                    Assert.Null(operationName);
+                }
+            }
+            finally
+            {
+                channel?.Shutdown();
+            }
+
+            async Task HandleLro<TResponse, TMetadata>(OperationsClient client, string operationName)
+                where TResponse : class, IMessage<TResponse>, new()
+                where TMetadata : class, IMessage<TMetadata>, new()
+            {
+                var rawOperation = await client.GetOperationAsync(operationName);
+                var operation = new Operation<TResponse, TMetadata>(rawOperation, client);
+                var completedOperation = await operation.PollUntilCompletedAsync();
+
+                Assert.True(completedOperation.IsCompleted);
+                Assert.Null(completedOperation.Exception);
             }
         }
     }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerCommand.cs
@@ -14,7 +14,6 @@
 
 using Google.Api.Gax;
 using Google.Cloud.Spanner.V1;
-using Google.LongRunning;
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -522,6 +521,7 @@ namespace Google.Cloud.Spanner.Data
         /// The command must contain one or more DDL statements;
         /// <see cref="SpannerConnection.CreateDdlCommand(string, string[])"/> for details.
         /// </summary>
+        /// <param name="cancellationToken">An optional token for canceling the call.</param>
         /// <returns>
         /// The name of the long-running operation that was started for the DDL statement(s).
         /// Note: The ID is empty for DropDatabase commands.


### PR DESCRIPTION
Adds a method to execute DDL on Spanner without having the client awaiting the long-running operation to finish. This makes it possible to for example start the creation of a secondary index using the client library, without having the library waiting for that operation to finish. Creating a secondary index on a table with a large amount of data can take a very long time (several days).