### PR TITLE
chore: ignore google/cloud/networksecurity/v1alpha1

### DIFF
--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -4773,7 +4773,7 @@
         "google/cloud/configdelivery/v1alpha",
         "google/cloud/geminidataanalytics/v1alpha",
         "google/shopping/merchant/reports/v1alpha",
-        "google/cloud/hypercomputecluster/v1beta",
+        "google/cloud/networksecurity/v1alpha1",
         "google/cloud/securesourcemanager/v1",
         "google/maps/weather/v1"
     ]


### PR DESCRIPTION
And stop ignoring google/cloud/hypercomputercluster/v1beta at the same time. See b/454797234 for the background to that part.