### PR TITLE
chore: fix last-generated-commit for GkeMultiCloud

### DIFF
--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -1792,7 +1792,7 @@
             "generationAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseTimestamp": "2025-11-05T17:10:45.968624470Z",
-            "lastGeneratedCommit": "9f786b58f34980b058b854d1e5d33f4435946d0a",
+            "lastGeneratedCommit": "36533b09a6b383f3c30d13c3c26092154ecf5388",
             "lastReleasedCommit": "36533b09a6b383f3c30d13c3c26092154ecf5388",
             "apiPaths": [
                 "google/cloud/gkemulticloud/v1"


### PR DESCRIPTION
(This failed at the build step yesterday, and it looks like Librarian didn't revert the pipeline state change for it.)