### PR TITLE
fix: NRE in PredictionServiceChatClient

### DIFF
--- a/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions.IntegrationTests/VertexAIExtensionsTest.cs
+++ b/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions.IntegrationTests/VertexAIExtensionsTest.cs
@@ -39,6 +39,33 @@ public class VertexAIExtensionsTest
     }
 
     [Fact]
+    public async Task AsIChatClient_TextReasoningContent_WithToolCall_DoesNotThrow()
+    {
+        IChatClient client = await new PredictionServiceClientBuilder()
+            .BuildIChatClientAsync(EndpointName.FormatProjectLocationPublisherModel(s_projectId, s_location, "google", "gemini-2.5-pro"));
+
+        ChatMessage[] messages =
+        [
+            new(ChatRole.User, "Tell me something I don't know"),
+            new(ChatRole.Assistant,
+            [
+                new TextContent("I'm not quite sure what you mean."),
+                new TextReasoningContent(null) { ProtectedData = "CqEDAY89a18A3AfzAjWZZvPxwakP5Fx0TRN6OH2t" },
+            ]),
+            new(ChatRole.Assistant,
+            [
+                new FunctionCallContent("final_result", "final_result"),
+            ]),
+            new(ChatRole.Tool,
+            [
+                new FunctionResultContent("final_result", "Success: Function completed."),
+            ]),
+        ];
+
+        await client.GetResponseAsync(messages);
+    }
+
+    [Fact]
     public async Task AsIChatClient_BasicRequestResponse_Streaming()
     {
         IChatClient client = await new PredictionServiceClientBuilder()

--- a/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions/PredictionServiceChatClient.cs
+++ b/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions/PredictionServiceChatClient.cs
@@ -417,7 +417,9 @@ internal sealed class PredictionServiceChatClient(PredictionServiceClient client
                                 Struct.Parser.ParseJson(JsonSerializer.Serialize(functionCallContent.Arguments, AIJsonUtilities.DefaultOptions)) :
                                 new(),
                         },
-                        ThoughtSignature = ByteString.CopyFrom(thoughtSignature) ?? s_skipThoughtValidation,
+                        ThoughtSignature = thoughtSignature == null
+                            ? s_skipThoughtValidation
+                            : ByteString.CopyFrom(thoughtSignature),
                     };
                     break;
 


### PR DESCRIPTION
Fix #15314

I added a minimal repro as a test. The interaction is a little unusual as the assistant answers with two messages, one with text, one with a tool with the same text as argument. The reason is probably that we ask the assistant to always end an interaction with a specific tool call.