### PR TITLE
fix: Handling of tool calls without thought signatures

### DIFF
--- a/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions/PredictionServiceChatClient.cs
+++ b/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions/PredictionServiceChatClient.cs
@@ -417,7 +417,7 @@ internal sealed class PredictionServiceChatClient(PredictionServiceClient client
                                 Struct.Parser.ParseJson(JsonSerializer.Serialize(functionCallContent.Arguments, AIJsonUtilities.DefaultOptions)) :
                                 new(),
                         },
-                        ThoughtSignature = ByteString.CopyFrom(thoughtSignature) ?? s_skipThoughtValidation,
+                        ThoughtSignature = thoughtSignature is not null ? ByteString.CopyFrom(thoughtSignature) : s_skipThoughtValidation,
                     };
                     break;
 


### PR DESCRIPTION
Copy/paste mistake. It was intending to be a null check on thoughtSignature (`thoughtSignature ?? defaultValue), but then thoughtSignature got wrapped in a ByteString.CopyFrom, changing the meaning of the line.

Fixes https://github.com/googleapis/google-cloud-dotnet/issues/15314
cc: @amanda-tarafa, @verdie-g