### PR TITLE
Reference Microsoft.Bcl.AsyncInterfaces from package Google.Cloud.VertexAI.Extensions

### DIFF
--- a/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions.csproj
+++ b/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
     <PackageReference Include="Google.Cloud.AIPlatform.V1" VersionOverride="[3.54.0, 4.0.0)" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The `Google.Cloud.VertexAI.Extensions` assembly references types from `Microsoft.Bcl.AsyncInterfaces` like `IAsyncEnumerable`. The `Google.Cloud.VertexAI.Extensions` Nuget package needs to declare a dependency on the `Microsoft.Bcl.AsyncInterfaces` package so that a compatible version is restored when consumed from .NET Core projects.

Fixes #15350