### PR TITLE
chore: unblock generation of docs-google-apis

### DIFF
--- a/docs/fake-source-path.txt
+++ b/docs/fake-source-path.txt
@@ -1,0 +1,4 @@
+This file only exists to work around an issue in Librarian v0.1.0
+where libraries without source paths couldn't be released.
+
+Do not change this file without consulting jonskeet@.

--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -4348,7 +4348,10 @@
         {
             "id": "docs-google-apis",
             "generationAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
-            "releaseAutomationLevel": "AUTOMATION_LEVEL_BLOCKED"
+            "releaseAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "sourcePaths": [
+                "docs/fake-source-path.txt"
+            ]
         },
         {
             "id": "docs-grpc",


### PR DESCRIPTION
This is a bit of a hack, but if it works we can apply the same approach to other docs libraries. We want to make sure we don't accidentally start including them in release PRs, but we do to be able to release them manually. A "fake" source path, referring to a file that never changes, accomplishes this.