### PR TITLE
feat(spanner): Add support for UUID data type.

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/AllTypesTableFixture.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/AllTypesTableFixture.cs
@@ -52,6 +52,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                  ProtobufRectangleValue,
                  ProtobufPersonValue,
                  ProtobufValueWrapperValue,
+                 UuidValue,
                  BoolArrayValue,
                  Int64ArrayValue,
                  Float32ArrayValue,
@@ -67,6 +68,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                  ProtobufDurationArrayValue,
                  ProtobufRectangleArrayValue,
                  ProtobufPersonArrayValue,
+                 UuidArrayValue,
                  ProtobufValueWrapperArrayValue) VALUES(
                  @K,
                  @BoolValue,
@@ -84,6 +86,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                  @ProtobufRectangleValue,
                  @ProtobufPersonValue,
                  @ProtobufValueWrapperValue,
+                 @UuidValue,
                  @BoolArrayValue,
                  @Int64ArrayValue,
                  @Float32ArrayValue,
@@ -99,6 +102,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                  @ProtobufDurationArrayValue,
                  @ProtobufRectangleArrayValue,
                  @ProtobufPersonArrayValue,
+                 @UuidArrayValue,
                  @ProtobufValueWrapperArrayValue
                )";
 
@@ -120,6 +124,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                             ProtobufRectangleValue              {Rectangle.Descriptor.FullName},
                             ProtobufPersonValue                 {Person.Descriptor.FullName},
                             ProtobufValueWrapperValue           {ValueWrapper.Descriptor.FullName},
+                            UuidValue                           UUID,
                             BoolArrayValue                      ARRAY<BOOL>,
                             Int64ArrayValue                     ARRAY<INT64>,
                             Float32ArrayValue                   ARRAY<FLOAT32>,
@@ -135,7 +140,8 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                             ProtobufDurationArrayValue          ARRAY<{Duration.Descriptor.FullName}>,
                             ProtobufRectangleArrayValue         ARRAY<{Rectangle.Descriptor.FullName}>,
                             ProtobufPersonArrayValue            ARRAY<{Person.Descriptor.FullName}>,
-                            ProtobufValueWrapperArrayValue      ARRAY<{ValueWrapper.Descriptor.FullName}>
+                            UuidArrayValue                      ARRAY<UUID>,
+                            ProtobufValueWrapperArrayValue      ARRAY<{ValueWrapper.Descriptor.FullName}>,
                           ) PRIMARY KEY(K)");
 
         private string MaybeEmptyOnProduction(string text, bool skip) => skip && !RunningOnEmulator ? "" : text;

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/BindingTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/BindingTests.cs
@@ -61,6 +61,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             SpannerDbType.Float32,
             SpannerDbType.Json,
             SpannerDbType.Interval,
+            SpannerDbType.Uuid,
             SpannerDbType.FromClrType(typeof(Duration)),
             SpannerDbType.FromClrType(typeof(Rectangle)),
             SpannerDbType.FromClrType(typeof(Person)),
@@ -76,6 +77,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             SpannerDbType.ArrayOf(SpannerDbType.Float32),
             SpannerDbType.ArrayOf(SpannerDbType.Json),
             SpannerDbType.ArrayOf(SpannerDbType.Interval),
+            SpannerDbType.ArrayOf(SpannerDbType.Uuid),
             SpannerDbType.ArrayOf(SpannerDbType.FromClrType(typeof(Duration))),
             SpannerDbType.ArrayOf(SpannerDbType.FromClrType(typeof(Rectangle))),
             SpannerDbType.ArrayOf(SpannerDbType.FromClrType(typeof(Person))),
@@ -393,5 +395,21 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
         private void MaybeSkipIfOnProduction(SpannerDbType spannerDbType) =>
             Skip.If(!_fixture.RunningOnEmulator && BindProductionUnsupportedNullData.Any<SpannerDbType>(spannerDbType.Equals),
                 $"Production does not support {spannerDbType}.");
+
+        [Fact]
+        public Task BindUuid() => TestBindNonNull(
+            SpannerDbType.Uuid,
+            Guid.NewGuid(),
+            r => r.GetGuid(0));
+
+        [Fact]
+        public Task BindUuidArray() => TestBindNonNull(
+            SpannerDbType.ArrayOf(SpannerDbType.Uuid),
+            new Guid?[] { Guid.NewGuid(), null, Guid.NewGuid() });
+
+        [Fact]
+        public Task BindUuidEmptyArray() => TestBindNonNull(
+            SpannerDbType.ArrayOf(SpannerDbType.Uuid),
+            new Guid[] { });
     }
 }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/GetSchemaTableTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/GetSchemaTableTests.cs
@@ -76,7 +76,8 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 { "ProtobufValueValue", typeof(Value), SpannerDbType.FromClrType(typeof(Value)) },
                 { "ProtobufPersonValue", typeof(Value), SpannerDbType.FromClrType(typeof(Person)) },
                 { "ProtobufValueWrapperValue", typeof(Value), SpannerDbType.FromClrType(typeof(ValueWrapper)) },
-                
+                { "UuidValue", typeof(Guid), SpannerDbType.Uuid },
+
                 // Array types.
                 { "BoolArrayValue", typeof(List<bool>), SpannerDbType.ArrayOf(SpannerDbType.Bool) },
                 { "Int64ArrayValue", typeof(List<long>), SpannerDbType.ArrayOf(SpannerDbType.Int64) },
@@ -94,6 +95,7 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 { "ProtobufValueArrayValue", typeof(List<Value>), SpannerDbType.ArrayOf(SpannerDbType.FromClrType(typeof(Value))) },
                 { "ProtobufPersonArrayValue", typeof(List<Value>), SpannerDbType.ArrayOf(SpannerDbType.FromClrType(typeof(Person))) },
                 { "ProtobufValueWrapperArrayValue", typeof(List<Value>), SpannerDbType.ArrayOf(SpannerDbType.FromClrType(typeof(ValueWrapper))) },
+                { "UuidArrayValue", typeof(List<Guid>), SpannerDbType.ArrayOf(SpannerDbType.Uuid) },
             };
 
         internal static async Task GetSchemaTable_WithFlagEnabled_ReturnsSchema_Impl(string columnName, System.Type type, SpannerDbType spannerDbType, string connectionString, string selectQuery)

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/WriteTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.IntegrationTests/WriteTests.cs
@@ -110,6 +110,8 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 { "ProtobufValueArrayValue", SpannerDbType.ArrayOf(SpannerDbType.FromClrType(typeof(Value))), null },
                 { "ProtobufPersonArrayValue", SpannerDbType.ArrayOf(SpannerDbType.FromClrType(typeof(Person))), null },
                 { "ProtobufValueWrapperArrayValue", SpannerDbType.ArrayOf(SpannerDbType.FromClrType(typeof(ValueWrapper))), null },
+                { "UuidValue", SpannerDbType.Uuid, null },
+                { "UuidArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Uuid), null },
             };
 
             if (_fixture.RunningOnEmulator || !isDml)
@@ -209,6 +211,9 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
             ValueWrapper testValueWrapper = new ValueWrapper { OneValue = Value.ForString("Hello") };
             ValueWrapper[] vwArray = { testValueWrapper, null, new ValueWrapper() };
 
+            var testUuid = Guid.NewGuid();
+            Guid?[] testUuidArray = { Guid.NewGuid(), null, Guid.NewGuid() };
+
             var parameters = new SpannerParameterCollection
             {
                 { "BoolValue", SpannerDbType.Bool, true },
@@ -241,7 +246,10 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 { "ProtobufPersonArrayValue", SpannerDbType.ArrayOf(SpannerDbType.FromClrType(typeof(Person))), pArray },
                 { "ProtobufValueWrapperArrayValue", SpannerDbType.ArrayOf(SpannerDbType.FromClrType(typeof(ValueWrapper))), vwArray },
                 { "ProtobufValueArrayValue", SpannerDbType.ArrayOf(SpannerDbType.FromClrType(typeof(Value))), pvArray },
+                { "UuidValue", SpannerDbType.Uuid, testUuid },
+                { "UuidArrayValue", SpannerDbType.ArrayOf(SpannerDbType.Uuid), testUuidArray },
             };
+
 
             if (_fixture.RunningOnEmulator || !isDml)
             {
@@ -286,6 +294,8 @@ namespace Google.Cloud.Spanner.Data.IntegrationTests
                 Assert.Equal(pArray, reader.GetFieldValue<Person[]>(reader.GetOrdinal("ProtobufPersonArrayValue")));
                 Assert.Equal(vwArray, reader.GetFieldValue<ValueWrapper[]>(reader.GetOrdinal("ProtobufValueWrapperArrayValue")));
                 Assert.Equal(pvArray, reader.GetFieldValue<Value[]>(reader.GetOrdinal("ProtobufValueArrayValue")));
+                Assert.Equal(testUuid, reader.GetFieldValue<Guid>(reader.GetOrdinal("UuidValue")));
+                Assert.Equal(testUuidArray, reader.GetFieldValue<Guid?[]>(reader.GetOrdinal("UuidArrayValue")));
                 if (_fixture.RunningOnEmulator || !isDml)
                 {
                     // b/348711708

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/KeysTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/KeysTests.cs
@@ -40,7 +40,8 @@ namespace Google.Cloud.Spanner.Data.Tests
                     { "", SpannerDbType.Interval, Interval.Parse("P1Y2M3D") },
                     { "", SpannerDbType.PgOid, 2 },
                     { "", SpannerDbType.String, "test" },
-                    { "", SpannerDbType.Timestamp, new DateTime(2021, 9, 10, 9, 37, 10, DateTimeKind.Utc) }
+                    { "", SpannerDbType.Timestamp, new DateTime(2021, 9, 10, 9, 37, 10, DateTimeKind.Utc) },
+                    { "", SpannerDbType.Uuid, Guid.Parse("8f8c4746-17b1-4d9f-a634-58e11942095f") }
                 });
 
             var actual = key.ToProtobuf(SpannerConversionOptions.Default);
@@ -61,7 +62,8 @@ namespace Google.Cloud.Spanner.Data.Tests
                     Value.ForString("P1Y2M3D"),
                     Value.ForString("2"),
                     Value.ForString("test"),
-                    Value.ForString("2021-09-10T09:37:10Z")
+                    Value.ForString("2021-09-10T09:37:10Z"),
+                    Value.ForString("8f8c4746-17b1-4d9f-a634-58e11942095f")
                 }
             };
             Assert.Equal(expected, actual);

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerCommandTests.cs
@@ -1344,6 +1344,7 @@ namespace Google.Cloud.Spanner.Data.Tests
                     {"timestamp", SpannerDbType.Timestamp, new DateTime(2021, 9, 8, 15, 22, 59, DateTimeKind.Utc)},
                     {"bool", SpannerDbType.Bool, true},
                     {"interval", SpannerDbType.Interval, Interval.Parse("P1Y2M3D")},
+                    {"uuid", SpannerDbType.Uuid, new Guid("8f8c4746-17b1-4d9f-a634-58e11942095f")},
                 }));
             using var reader = await command.ExecuteReaderAsync();
             Assert.True(reader.HasRows);
@@ -1365,6 +1366,7 @@ namespace Google.Cloud.Spanner.Data.Tests
                     new Value { StringValue = "2021-09-08T15:22:59Z" },
                     new Value { BoolValue = true },
                     new Value { StringValue = "P1Y2M3D" },
+                    new Value { StringValue = "8f8c4746-17b1-4d9f-a634-58e11942095f"},
                 } } } })),
                 Arg.Any<CallSettings>());
         }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerDbTypeTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerDbTypeTests.cs
@@ -84,6 +84,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             yield return new object[] { "NUMERIC", SpannerDbType.Numeric };
             yield return new object[] { "NUMERIC{PG}", SpannerDbType.PgNumeric };
             yield return new object[] { "INTERVAL", SpannerDbType.Interval };
+            yield return new object[] { "UUID", SpannerDbType.Uuid };
 
             yield return new object[] { " STRING  ", SpannerDbType.String };
             yield return new object[] { " BOOL  ", SpannerDbType.Bool };
@@ -99,6 +100,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             yield return new object[] { " NUMERIC  ", SpannerDbType.Numeric };
             yield return new object[] { " NUMERIC{PG}  ", SpannerDbType.PgNumeric };
             yield return new object[] { " INTERVAL  ", SpannerDbType.Interval };
+            yield return new object[] { " UUID  ", SpannerDbType.Uuid };
 
             yield return new object[] { "STRING(2)", SpannerDbType.String.WithSize(2) };
             yield return new object[] { "STRING(100)", SpannerDbType.String.WithSize(100) };
@@ -126,6 +128,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             yield return new object[] { "ARRAY<OID{PG}>", SpannerDbType.ArrayOf(SpannerDbType.PgOid) };
             yield return new object[] { "ARRAY<TIMESTAMP>", SpannerDbType.ArrayOf(SpannerDbType.Timestamp) };
             yield return new object[] { "ARRAY<INTERVAL>", SpannerDbType.ArrayOf(SpannerDbType.Interval) };
+            yield return new object[] { "ARRAY<UUID>", SpannerDbType.ArrayOf(SpannerDbType.Uuid) };
 
             yield return new object[] { "ARRAY<STRING(5)>", SpannerDbType.ArrayOf(SpannerDbType.String), false };
             yield return new object[] { "ARRAY<BYTES(5)>", SpannerDbType.ArrayOf(SpannerDbType.Bytes), false };
@@ -186,9 +189,10 @@ namespace Google.Cloud.Spanner.Data.Tests
                 { "F11", SpannerDbType.PgNumeric, null },
                 { "F12", SpannerDbType.PgJsonb, null },
                 { "F13", SpannerDbType.PgOid, null },
-                { "F14", SpannerDbType.Interval, null}
+                { "F14", SpannerDbType.Interval, null},
+                { "F15", SpannerDbType.Uuid, null}
             };
-            yield return new object[] { "STRUCT<F1:STRING,F2:INT64,F3:BOOL,F4:BYTES,F5:DATE,F6:FLOAT32,F7:FLOAT64,F8:TIMESTAMP,F9:NUMERIC,F10:JSON,F11:NUMERIC{PG},F12:JSONB{PG},F13:OID{PG},F14:INTERVAL>", sampleStruct.GetSpannerDbType() };
+            yield return new object[] { "STRUCT<F1:STRING,F2:INT64,F3:BOOL,F4:BYTES,F5:DATE,F6:FLOAT32,F7:FLOAT64,F8:TIMESTAMP,F9:NUMERIC,F10:JSON,F11:NUMERIC{PG},F12:JSONB{PG},F13:OID{PG},F14:INTERVAL,F15:UUID>", sampleStruct.GetSpannerDbType() };
 
             sampleStruct = new SpannerStruct
             {

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerParameterTests.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data.Tests/SpannerParameterTests.cs
@@ -45,6 +45,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             yield return new object[] { SpannerDbType.Numeric, DbType.VarNumeric, true };
             yield return new object[] { SpannerDbType.Unspecified, DbType.Object, true };
             yield return new object[] { SpannerDbType.String, DbType.String, true };
+            yield return new object[] { SpannerDbType.Uuid, DbType.Guid, true };
             // There is no DbType that will map automatically to SpannerDbType.Json, SpannerDbType.PgJsonb,
             // SpannerDbType.PgOid, SpannerDbType protobuf or SpannerDbType.Interval.
             yield return new object[] { SpannerDbType.Json, DbType.String, false };
@@ -98,6 +99,8 @@ namespace Google.Cloud.Spanner.Data.Tests
             yield return new object[] { "test", SpannerDbType.String, DbType.String, typeof(string) };
 
             yield return new object[] { Interval.Parse("P1Y2M3D"), SpannerDbType.Interval, DbType.Object, typeof(Interval) };
+
+            yield return new object[] { Guid.Parse("8f8c4746-17b1-4d9f-a634-58e11942095f"), SpannerDbType.Uuid, DbType.Guid, typeof(Guid) };
 
             // Tests for protobuf
             // Note that the default CLR type here is always Value, because in general, we only know the the name of the protobuf type and from there
@@ -208,6 +211,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             yield return new object[] { SpannerDbType.Json };
             yield return new object[] { SpannerDbType.PgJsonb };
             yield return new object[] { SpannerDbType.Interval };
+            yield return new object[] { SpannerDbType.Uuid };
             yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.Bytes) };
             yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.String) };
             yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.Bool) };
@@ -222,6 +226,7 @@ namespace Google.Cloud.Spanner.Data.Tests
             yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.Json) };
             yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.PgJsonb) };
             yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.Interval) };
+            yield return new object[] { SpannerDbType.ArrayOf(SpannerDbType.Uuid) };
         }
 
         [Theory]

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.StringParsing.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.StringParsing.cs
@@ -51,9 +51,10 @@ namespace Google.Cloud.Spanner.Data
                 case TypeCode.Json:
                 case TypeCode.Numeric:
                 case TypeCode.Interval:
+                case TypeCode.Uuid:
                     if (!string.IsNullOrEmpty(remainder))
                     {
-                        //unexepected inner remainder on simple type
+                        // Unexpected inner remainder on simple type.
                         return false;
                     }
                     // If there's no size, we can use cached values.

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.ValueConversion.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.ValueConversion.cs
@@ -191,6 +191,16 @@ namespace Google.Cloud.Spanner.Data
                         StringValue = StripTimePart(
                             XmlConvert.ToString(Convert.ToDateTime(value, InvariantCulture), XmlDateTimeSerializationMode.Utc))
                     };
+                case TypeCode.Uuid:
+                    if (value is Guid guidValue)
+                    {
+                        return new Value { StringValue = guidValue.ToString() };
+                    }
+                    if (value is string guidStringValue)
+                    {
+                        return new Value { StringValue = Guid.Parse(guidStringValue).ToString() };
+                    }
+                    throw new ArgumentException($"TypeCode.Uuid only supports {typeof(string).FullName} and {typeof(Guid).FullName}", nameof(value));
                 case TypeCode.Array:
                     if (value is IEnumerable enumerable)
                     {
@@ -520,6 +530,20 @@ namespace Google.Cloud.Spanner.Data
                         return null;
                     case Value.KindOneofCase.StringValue:
                         return Protobuf.WellKnownTypes.Timestamp.Parser.ParseJson(wireValue.StringValue);
+                    default:
+                        throw new InvalidOperationException(
+                            $"Invalid Type conversion from {wireValue.KindCase} to {targetClrType.FullName}");
+                }
+            }
+
+            if (targetClrType == typeof(Guid))
+            {
+                switch (wireValue.KindCase)
+                {
+                    case Value.KindOneofCase.NullValue:
+                        return null;
+                    case Value.KindOneofCase.StringValue:
+                        return Guid.Parse(wireValue.StringValue);
                     default:
                         throw new InvalidOperationException(
                             $"Invalid Type conversion from {wireValue.KindCase} to {targetClrType.FullName}");

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerDbType.cs
@@ -106,6 +106,11 @@ namespace Google.Cloud.Spanner.Data
         /// </summary>
         public static SpannerDbType Interval { get; } = new SpannerDbType(TypeCode.Interval);
 
+        /// <summary>
+        /// Representation of Spanner UUID type.
+        /// </summary>
+        public static SpannerDbType Uuid { get; } = new SpannerDbType(TypeCode.Uuid);
+
         private static readonly Dictionary<V1.Type, SpannerDbType> s_simpleTypes
             = new Dictionary<V1.Type, SpannerDbType>
             {
@@ -123,7 +128,8 @@ namespace Google.Cloud.Spanner.Data
                 { new V1.Type { Code = TypeCode.Numeric }, Numeric },
                 { new V1.Type { Code = TypeCode.Numeric, TypeAnnotation = TypeAnnotationCode.PgNumeric }, PgNumeric },
                 { new V1.Type { Code = TypeCode.Int64, TypeAnnotation = TypeAnnotationCode.PgOid }, PgOid },
-                { new V1.Type { Code = TypeCode.Interval }, Interval }
+                { new V1.Type { Code = TypeCode.Interval }, Interval },
+                { new V1.Type { Code = TypeCode.Uuid }, Uuid }
             };
 
         internal static SpannerDbType FromType(V1.Type type) =>
@@ -215,6 +221,8 @@ namespace Google.Cloud.Spanner.Data
                         return DbType.Binary;
                     case TypeCode.Json:
                         return DbType.String;
+                    case TypeCode.Uuid:
+                        return DbType.Guid;
                     default:
                         return DbType.Object;
                 }
@@ -261,6 +269,8 @@ namespace Google.Cloud.Spanner.Data
                     return typeof(string);
                 case TypeCode.Interval:
                     return typeof(Interval);
+                case TypeCode.Uuid:
+                    return typeof(Guid);
                 default:
                     // If we don't recognize it, we use the protobuf Value well-known type.
                     // But since, as of June 2024, we support protobuf, we need to handle Value
@@ -291,6 +301,7 @@ namespace Google.Cloud.Spanner.Data
             DbType.VarNumeric => Numeric,
             DbType.Object => Unspecified,
             DbType.String => String,
+            DbType.Guid => Uuid,
             _ => throw new ArgumentOutOfRangeException(nameof(DbType), dbType, null),
         };
 
@@ -419,6 +430,10 @@ namespace Google.Cloud.Spanner.Data
             if (type == typeof(Interval))
             {
                 return Interval;
+            }
+            if (type == typeof(Guid))
+            {
+                return Uuid;
             }
             return Unspecified;
         }

--- a/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameter.cs
+++ b/apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data/SpannerParameter.cs
@@ -150,7 +150,7 @@ namespace Google.Cloud.Spanner.Data
                     + $"({nameof(SpannerDbType.Bool)}, {nameof(SpannerDbType.Int64)}, {nameof(SpannerDbType.Float32)} ,{nameof(SpannerDbType.Float64)},"
                     + $" {nameof(SpannerDbType.Timestamp)}, {nameof(SpannerDbType.Date)}, {nameof(SpannerDbType.String)},"
                     + $" {nameof(SpannerDbType.Bytes)}, {nameof(SpannerDbType.Json)}, {nameof(SpannerDbType.PgJsonb)}, {nameof(SpannerDbType.Numeric)},"
-                    + $" {nameof(SpannerDbType.PgNumeric)}, {nameof(SpannerDbType.PgOid)}), {nameof(SpannerDbType.Interval)}");
+                    + $" {nameof(SpannerDbType.PgNumeric)}, {nameof(SpannerDbType.PgOid)}), {nameof(SpannerDbType.Interval)}, {nameof(SpannerDbType.Uuid)}");
             }
             return Value;
         }


### PR DESCRIPTION
Add support for UUID data type for Spanner.

b/327986023

NOTE: Emulator doesn't support UUID, but i've run the integration tests against an actual spanner isntance and all pass:
<img width="1138" height="120" alt="image" src="https://github.com/user-attachments/assets/e84f5d22-f8d1-42ee-8176-ca44ae6c0de4" />
