### PR TITLE
chore: temporarily block release of Dialogflow CX

### DIFF
--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -1385,7 +1385,7 @@
             "id": "Google.Cloud.Dialogflow.Cx.V3",
             "currentVersion": "2.25.0",
             "generationAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
-            "releaseAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseAutomationLevel": "AUTOMATION_LEVEL_BLOCKED",
             "releaseTimestamp": "2025-11-05T16:43:34.709246096Z",
             "lastGeneratedCommit": "b8d149138be9552543ed2ad7700d2d0bc1a0045d",
             "lastReleasedCommit": "888ae95dd6125f754650d55410b8c117b618a268",


### PR DESCRIPTION
This is so that we can manually do a major version bump without it interfering with the automated release.