### PR TITLE
chore: remove generator-input/tweaks/global.json

### DIFF
--- a/generator-input/tweaks/global.json
+++ b/generator-input/tweaks/global.json
@@ -1,7 +1,0 @@
-{
-  "sdk": {
-    "version": "8.0.417",
-    "allowPrerelease": false,
-    "rollForward": "latestMinor"
-  }
-}


### PR DESCRIPTION
This is no longer necessary, but causes some confusion.

Fixes #15394