### PR TITLE
chore: enable release of Google.Cloud.VisionAI.V1

### DIFF
--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -3505,6 +3505,7 @@
         },
         {
             "id": "Google.Cloud.VisionAI.V1",
+            "nextVersion": "1.0.0-beta01",
             "generationAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "lastGeneratedCommit": "fe4d9b3bcaae6282d1d6ee57a42fed53b334931b",


### PR DESCRIPTION
The final failing smoke test is still skipped as it requires a project number rather than a project ID, but at least the host is now correct.