### PR TITLE
chore: add Google.LongRunning dependency to Google.Cloud.Dataform.V1Beta

### DIFF
--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.csproj
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Google.Api.Gax.Grpc" />
     <PackageReference Include="Google.Cloud.Iam.V1" VersionOverride="[3.5.0, 4.0.0)" />
     <PackageReference Include="Google.Cloud.Location" VersionOverride="[2.4.0, 3.0.0)" />
+    <PackageReference Include="Google.LongRunning" VersionOverride="[3.5.0, 4.0.0)" />
     <PackageReference Include="Grpc.Core" PrivateAssets="None" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 </Project>

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -2076,7 +2076,8 @@
       ],
       "dependencies": {
         "Google.Cloud.Iam.V1": "3.5.0",
-        "Google.Cloud.Location": "2.4.0"
+        "Google.Cloud.Location": "2.4.0",
+        "Google.LongRunning": "3.5.0"
       },
       "generator": "micro",
       "protoPath": "google/cloud/dataform/v1beta1",


### PR DESCRIPTION
This should fix tomorrow's generation run.