### PR TITLE
chore: update dependency in Google.Cloud.VertexAI.Extensions

### DIFF
--- a/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions.csproj
+++ b/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="All" />
-    <PackageReference Include="Google.Cloud.AIPlatform.V1" VersionOverride="[3.61.0, 4.0.0)" />
+    <PackageReference Include="Google.Cloud.AIPlatform.V1" VersionOverride="[3.63.0, 4.0.0)" />
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
   </ItemGroup>
 </Project>

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -6101,7 +6101,7 @@
         "AI Extensions"
       ],
       "dependencies": {
-        "Google.Cloud.AIPlatform.V1": "3.54.0",
+        "Google.Cloud.AIPlatform.V1": "3.63.0",
         "Microsoft.Extensions.AI.Abstractions": "default"
       },
       "testDependencies": {


### PR DESCRIPTION
The dependency on Google.Cloud.AIPlatform.V1 was inconsistent in apis.json vs the project file. This updates both to 3.63.0.