### PR TITLE
chore: update SharpCompress to 0.46.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -51,7 +51,7 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
-    <PackageVersion Include="SharpCompress" Version="0.44.1" />
+    <PackageVersion Include="SharpCompress" Version="0.46.0" />
     <PackageVersion Include="NodaTime" Version="3.3.0" />
     <PackageVersion Include="LibGit2Sharp" Version="0.30.0" />
     <PackageVersion Include="NuGet.Protocol" Version="7.0.1" />

--- a/tools/Google.Cloud.Tools.DocUploader/Program.cs
+++ b/tools/Google.Cloud.Tools.DocUploader/Program.cs
@@ -103,7 +103,7 @@ MemoryStream CompressDirectory(string directory)
         throw new InvalidOperationException($"The documentation path `{directory}` is empty");
     }
 
-    using var archive = TarArchive.Create();
+    using var archive = TarArchive.CreateArchive();
     archive.AddAllFromDirectory(directory);
     var writerOptions = new TarWriterOptions(CompressionType.GZip, finalizeArchiveOnClose: true);
     var memoryStream = new MemoryStream();

--- a/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerCommandTest.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager.IntegrationTests/ContainerCommands/DockerCommandTest.cs
@@ -74,7 +74,7 @@ public class DockerCommandTest
             // within a .tar.gz file...
             var path = Path.Combine(outputDirectory, archiveAssertion.File);
             var data = File.ReadAllBytes(path);
-            using var reader = ReaderFactory.Open(new MemoryStream(data));
+            using var reader = ReaderFactory.OpenReader(new MemoryStream(data));
             var archivePaths = new List<string>();
             while (reader.MoveToNextEntry())
             {

--- a/tools/Google.Cloud.Tools.ReleaseManager/ContainerCommands/PackageLibraryCommand.cs
+++ b/tools/Google.Cloud.Tools.ReleaseManager/ContainerCommands/PackageLibraryCommand.cs
@@ -150,7 +150,7 @@ internal class PackageLibraryCommand : IContainerCommand
             throw new InvalidOperationException($"The documentation path `{directory}` is empty");
         }
 
-        using var archive = TarArchive.Create();
+        using var archive = TarArchive.CreateArchive();
         archive.AddAllFromDirectory(directory);
         var writerOptions = new TarWriterOptions(CompressionType.GZip, finalizeArchiveOnClose: true);
         archive.SaveTo(output, writerOptions);

--- a/tools/Google.Cloud.Tools.VersionCompat/Assemblies.cs
+++ b/tools/Google.Cloud.Tools.VersionCompat/Assemblies.cs
@@ -117,7 +117,7 @@ namespace Google.Cloud.Tools.VersionCompat
             
             Regex pattern = new Regex($@"lib/([a-z0-9.]+)/{Regex.Escape(assemblyName)}\.dll");
             var tfms = new List<string>();
-            using (var zip = ZipArchive.Open(new MemoryStream(bytes)))
+            using (var zip = ZipArchive.OpenArchive(new MemoryStream(bytes)))
             {
                 foreach (var entry in zip.Entries)
                 {
@@ -143,7 +143,7 @@ namespace Google.Cloud.Tools.VersionCompat
             }
             string expectedPath = $"lib/{tfm}/{assemblyName}.dll";
 
-            using (var zip = ZipArchive.Open(new MemoryStream(bytes)))
+            using (var zip = ZipArchive.OpenArchive(new MemoryStream(bytes)))
             {
                 foreach (var entry in zip.Entries)
                 {


### PR DESCRIPTION
This has some breaking changes, but they're trivial renames (to support async, basically).