### PR TITLE
chore: allow Google.Cloud.WorkloadManager.V1 to be released next cycle

### DIFF
--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -4871,7 +4871,7 @@
             "id": "Google.Cloud.WorkloadManager.V1",
             "nextVersion": "1.0.0-beta01",
             "generationAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
-            "releaseAutomationLevel": "AUTOMATION_LEVEL_BLOCKED",
+            "releaseAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "apiPaths": [
                 "google/cloud/workloadmanager/v1"
             ],


### PR DESCRIPTION
(I've generated and run a smoke test locally.)