### PR TITLE
chore: unblock release of Google.Cloud.VectorSearch.V1

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -278,6 +278,7 @@
     "apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/**",
     "apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/**",
     "apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2/**",
+    "apis/Google.Cloud.VectorSearch.V1/Google.Cloud.VectorSearch.V1/**",
     "apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions/**",
     "apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1/**",
     "apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1/**",

--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -4886,7 +4886,7 @@
             "id": "Google.Cloud.VectorSearch.V1",
             "nextVersion": "1.0.0-beta01",
             "generationAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
-            "releaseAutomationLevel": "AUTOMATION_LEVEL_BLOCKED",
+            "releaseAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "apiPaths": [
                 "google/cloud/vectorsearch/v1"
             ],


### PR DESCRIPTION
I've generated and smoke-tested this locally.