### PR TITLE
fix: Fix PredictionServiceChatClient to skip empty TextReasoningContent

### DIFF
--- a/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions/PredictionServiceChatClient.cs
+++ b/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions/PredictionServiceChatClient.cs
@@ -509,12 +509,13 @@ internal sealed class PredictionServiceChatClient(PredictionServiceClient client
                     };
                     break;
 
-                case TextReasoningContent reasoningContent:
-                    part = new Part()
+                case TextReasoningContent reasoningContent when !string.IsNullOrEmpty(reasoningContent.Text) || reasoningContent.ProtectedData is not null:
+                    part = new Part() { Thought = true };
+
+                    if (!string.IsNullOrEmpty(reasoningContent.Text))
                     {
-                        Thought = true,
-                        Text = !string.IsNullOrEmpty(reasoningContent.Text) ? reasoningContent.Text : null,
-                    };
+                        part.Text = reasoningContent.Text;
+                    }
 
                     if (reasoningContent.ProtectedData is not null)
                     {


### PR DESCRIPTION
When TextReasoningContent has no text and no protected data, the Part is now skipped entirely instead of setting Part.Text to null, which throws via Protobuf's CheckNotNull.

cc: @amanda-tarafa 