### PR TITLE
chore: update docfx to v2.78.5

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "docfx": {
-      "version": "2.78.4",
+      "version": "2.78.5",
       "commands": [
         "docfx"
       ]


### PR DESCRIPTION
(This won't actually be important until we next create an image for the container used by Librarian, but I don't expect that to matter.)