### PR TITLE
fix(Log4Net): Implement new Append method on GoogleStackDriver

### DIFF
--- a/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/GoogleStackdriverAppender.cs
+++ b/apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net/GoogleStackdriverAppender.cs
@@ -510,6 +510,12 @@ namespace Google.Cloud.Logging.Log4Net
         /// <inheritdoc/>
         protected override void Append(LoggingEvent[] loggingEvents)
         {
+            Append((IEnumerable<LoggingEvent>)loggingEvents);
+        }
+
+        /// <inheritdoc/>
+        protected override void Append(IEnumerable<LoggingEvent> loggingEvents)
+        {
             if (!_isActivated)
             {
                 throw new InvalidOperationException($"{nameof(ActivateOptions)}() must be called before using this appender.");


### PR DESCRIPTION
Using `log4net` 3.3.0 should have `Append(IEnumerable<LoggingEvent>)` implemented otherwise the bulk append method resolves to multiple single log entry appends (breaking some of our tests).