### PR TITLE
fix: for BigQuery.V2, DataStore.V1, Firestore

### DIFF
--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryClientImplTest.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2.Tests/BigQueryClientImplTest.cs
@@ -328,7 +328,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
             var service = new FakeBigqueryService();
             var client = new BigQueryClientImpl("project", service);
             var sql = "SELECT * FROM dataset.table";
-            var request = new QueryRequest { Query = sql, UseLegacySql = false, MaxResults = 10, Location = "us" };
+            var request = new QueryRequest { Query = sql, UseLegacySql = false, MaxResults = 10, Location = "us", FormatOptions = new DataFormatOptions { UseInt64Timestamp = true } };
             service.ExpectRequest(service.Jobs.Query(request, "project"), CreateStatelessResponse("value"));
 
             var results = client.ExecuteStatelessQuery(sql, parameters: null, queryOptions: new StatelessQueryOptions { MaxResults = 10, Location = "us" });
@@ -341,7 +341,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
             var service = new FakeBigqueryService();
             var client = new BigQueryClientImpl("project", service);
             var sql = "SELECT * FROM dataset.table";
-            var request = new QueryRequest { Query = sql, UseLegacySql = false, MaxResults = 10, Location = "us" };
+            var request = new QueryRequest { Query = sql, UseLegacySql = false, MaxResults = 10, Location = "us", FormatOptions = new DataFormatOptions { UseInt64Timestamp = true } };
             service.ExpectRequest(service.Jobs.Query(request, "project"), CreateStatelessResponse("value"));
 
             var results = await client.ExecuteStatelessQueryAsync(sql, parameters: null, queryOptions: new StatelessQueryOptions { MaxResults = 10, Location = "us" });
@@ -355,7 +355,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
             var client = new BigQueryClientImpl("project", service);
             var sql = "SELECT * FROM dataset.table WHERE col = @val";
             var parameters = new[] { new BigQueryParameter("val", BigQueryDbType.String, "foo") };
-            var request = new QueryRequest { Query = sql, UseLegacySql = false, ParameterMode = "named", QueryParameters = new[] { parameters[0].ToQueryParameter() } };
+            var request = new QueryRequest { Query = sql, UseLegacySql = false, ParameterMode = "named", QueryParameters = new[] { parameters[0].ToQueryParameter() }, FormatOptions = new DataFormatOptions { UseInt64Timestamp = true } };
             service.ExpectRequest(service.Jobs.Query(request, "project"), CreateStatelessResponse("foo"));
 
             var results = client.ExecuteStatelessQuery(sql, parameters);
@@ -394,7 +394,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
             var queryOptions = new QueryOptions { UseQueryCache = true };
             var resultsOptions = new GetQueryResultsOptions { PageSize = 10 };
             
-            var request = new QueryRequest { Query = sql, UseLegacySql = false, UseQueryCache = true, MaxResults = 10 };
+            var request = new QueryRequest { Query = sql, UseLegacySql = false, UseQueryCache = true, MaxResults = 10, FormatOptions = new DataFormatOptions { UseInt64Timestamp = true } };
             service.ExpectRequest(service.Jobs.Query(request, "project"), CreateStatelessResponse("value"));
 
             var results = client.ExecuteQuery(sql, parameters: null, queryOptions: queryOptions, resultsOptions: resultsOptions);
@@ -412,7 +412,7 @@ namespace Google.Cloud.BigQuery.V2.Tests
             var queryOptions = new QueryOptions { UseQueryCache = true };
             var resultsOptions = new GetQueryResultsOptions { PageSize = 10 };
             
-            var request = new QueryRequest { Query = sql, UseLegacySql = false, UseQueryCache = true, MaxResults = 10 };
+            var request = new QueryRequest { Query = sql, UseLegacySql = false, UseQueryCache = true, MaxResults = 10, FormatOptions = new DataFormatOptions { UseInt64Timestamp = true } };
             service.ExpectRequest(service.Jobs.Query(request, "project"), CreateStatelessResponse("value"));
 
             var results = await client.ExecuteQueryAsync(sql, parameters: null, queryOptions: queryOptions, resultsOptions: resultsOptions);

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.Queries.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/BigQueryClientImpl.Queries.cs
@@ -240,7 +240,8 @@ namespace Google.Cloud.BigQuery.V2
                 ParameterMode = "named",
                 QueryParameters = parameters?.Select(p => p.ToQueryParameter()).ToList(),
             };
-            options?.ModifyRequest(request);
+            // If no options are provided, we create an empty query options and propagate any defaults to the request
+            (options ?? new StatelessQueryOptions()).ModifyRequest(request);
             request.Location ??= DefaultLocation;
             // If there aren't any parameters, set ParameterMode to null - otherwise legacy SQL queries fail,
             // even if haven't set any parameters.

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/GetQueryResultsOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/GetQueryResultsOptions.cs
@@ -95,7 +95,8 @@ namespace Google.Cloud.BigQuery.V2
             PageSize = PageSize,
             PageToken = PageToken,
             StartIndex = StartIndex,
-            Timeout = Timeout
+            Timeout = Timeout,
+            UseInt64Timestamp = UseInt64Timestamp
         };
 
     }

--- a/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/StatelessQueryOptions.cs
+++ b/apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2/StatelessQueryOptions.cs
@@ -61,7 +61,7 @@ internal sealed class StatelessQueryOptions
     /// <summary>
     /// Optional output format adjustments.
     /// </summary>
-    internal DataFormatOptions FormatOptions { get; set; }
+    internal DataFormatOptions FormatOptions { get; set; } = new DataFormatOptions {UseInt64Timestamp = true};
 
     /// <summary>
     /// Specifies whether a job is required to be created.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/DatastoreFixture.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.IntegrationTests/DatastoreFixture.cs
@@ -49,7 +49,7 @@ namespace Google.Cloud.Datastore.V1.IntegrationTests
         // We don't want to wait *forever* (which would be the behavior of default poll settings)
         // but we need to have a timeout of more than a minute.
         private static readonly PollSettings AdminOperationPollSettings =
-            new PollSettings(expiration: Expiration.FromTimeout(TimeSpan.FromMinutes(5)), delay: TimeSpan.FromSeconds(5));
+            new PollSettings(expiration: Expiration.FromTimeout(TimeSpan.FromMinutes(10)), delay: TimeSpan.FromSeconds(5));
 
         public string NamespaceId { get; }
         public PartitionId PartitionId => new PartitionId { ProjectId = ProjectId, NamespaceId = NamespaceId };

--- a/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/FirestoreFixture.cs
+++ b/apis/Google.Cloud.Firestore/Google.Cloud.Firestore.IntegrationTests/FirestoreFixture.cs
@@ -37,7 +37,7 @@ namespace Google.Cloud.Firestore.IntegrationTests
         // We don't want to wait *forever* (which would be the behavior of default poll settings)
         // but we need to have a timeout of more than a minute.
         private static readonly PollSettings AdminOperationPollSettings =
-            new PollSettings(expiration: Expiration.FromTimeout(TimeSpan.FromMinutes(5)), delay: TimeSpan.FromSeconds(5));
+            new PollSettings(expiration: Expiration.FromTimeout(TimeSpan.FromMinutes(10)), delay: TimeSpan.FromSeconds(5));
 
         // How long we should wait after creating an index, before returning to the caller
         // (who is expecting to be able to use the index immediately). Sometimes the CreateIndex operation


### PR DESCRIPTION
Fixes the following:

* **BigQuery Timestamp Parsing:**
  * **Issue:** The default value for UseInt64Timestamp should default to true in the client during stateless query optimization, otherwise we get the service default of not using Int64Timestamps
    ```System.FormatException: The input string '1.48709313E9' was not in a correct format.```
  * **Fix:** Default `UseInt64Timestamp` to `true`.

* **Firestore & Datastore Database Index Timeouts:**
  * **Issue:** Index creation is exceeding the default 5-minute polling limit during fixture setup:
    ```System.TimeoutException: Operation did not complete within the specified expiry time```
  * **Fix:** Increased polling timeouts in `FirestoreFixture` and `DatastoreFixture` to accommodate slower backend indexing.
  
  ### Validations
  The corresponding integration and unit tests have been run and successfully pass now.
  
  b/502217142