### PR TITLE
feat: Update to M.E.AI.Abstractions 10.5.1 

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,7 +27,7 @@
     <PackageVersion Include="Google.Protobuf" Version="3.31.1" />
 
     <!-- System packages -->
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.4" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.6" />
 
     <!-- MS Extensions packages -->
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
@@ -37,7 +37,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version= "8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version= "10.4.1" />
+    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version= "10.5.1" />
 
     <!-- Misc packages (might warrant a reorganization at some point) -->
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions.Tests/BuildIChatClientTest.cs
+++ b/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions.Tests/BuildIChatClientTest.cs
@@ -2495,6 +2495,138 @@ public class BuildIChatClientTest
     }
 
     [Fact]
+    public async Task IChatClient_GetResponseAsync_WithGroundingMetadata()
+    {
+        DelegateCallInvoker invoker = new()
+        {
+            OnGenerateContentRequest = request =>
+            {
+                GenerateContentResponse response = CreateResponse(new() { Role = "model", Parts = { new Part() { Text = "Grounded answer." } } });
+                response.Candidates[0].GroundingMetadata = new()
+                {
+                    WebSearchQueries = { "weather in Seattle", "Seattle forecast" },
+                    GroundingChunks =
+                    {
+                        new GroundingChunk { Web = new GroundingChunk.Types.Web { Uri = "https://example.com/seattle", Title = "Seattle weather" } },
+                        new GroundingChunk { Web = new GroundingChunk.Types.Web { Uri = "https://example.org/forecast" } },
+                        new GroundingChunk { Web = new GroundingChunk.Types.Web() },
+                    }
+                };
+
+                return response;
+            }
+        };
+
+        IChatClient chatClient = CreateClientBuilder(invoker).BuildIChatClient("projects/test-project/locations/us-central1/publishers/google/models/mymodel");
+        ChatMessage[] messages = [new(ChatRole.User, "What's the weather?")];
+
+        ChatResponse result = await chatClient.GetResponseAsync(messages, new ChatOptions { Tools = [new HostedWebSearchTool()] });
+
+        Assert.NotNull(result);
+        IList<AIContent> contents = result.Messages[0].Contents;
+
+        TextContent textContent = Assert.IsType<TextContent>(contents[0]);
+        Assert.Equal("Grounded answer.", textContent.Text);
+
+        WebSearchToolCallContent call = Assert.IsType<WebSearchToolCallContent>(contents[1]);
+        Assert.Equal(new[] { "weather in Seattle", "Seattle forecast" }, call.Queries);
+        Assert.IsType<GroundingMetadata>(call.RawRepresentation);
+
+        WebSearchToolResultContent webSearchResult = Assert.IsType<WebSearchToolResultContent>(contents[2]);
+        Assert.Equal(call.CallId, webSearchResult.CallId);
+        Assert.NotNull(webSearchResult.Outputs);
+        Assert.Equal(2, webSearchResult.Outputs.Count);
+
+        UriContent first = Assert.IsType<UriContent>(webSearchResult.Outputs[0]);
+        Assert.Equal("https://example.com/seattle", first.Uri.ToString());
+        Assert.NotNull(first.AdditionalProperties);
+        Assert.Equal("Seattle weather", first.AdditionalProperties["title"]);
+
+        UriContent second = Assert.IsType<UriContent>(webSearchResult.Outputs[1]);
+        Assert.Equal("https://example.org/forecast", second.Uri.ToString());
+        Assert.True(second.AdditionalProperties is null || !second.AdditionalProperties.ContainsKey("title"));
+    }
+
+    [Fact]
+    public async Task IChatClient_GetStreamingResponseAsync_WithGroundingMetadata()
+    {
+        GenerateContentResponse[] responses =
+        [
+            new()
+            {
+                Candidates = { new Candidate { Content = new() { Role = "model", Parts = { new Part { Text = "Grounded " } } } } },
+                CreateTime = Timestamp.FromDateTime(DateTime.UtcNow),
+                ModelVersion = "test-model",
+                ResponseId = "response-1"
+            },
+            new()
+            {
+                Candidates =
+                {
+                    new Candidate
+                    {
+                        Content = new() { Role = "model", Parts = { new Part { Text = "answer." } } },
+                        GroundingMetadata = new()
+                        {
+                            WebSearchQueries = { "weather in Seattle", "Seattle forecast" },
+                            GroundingChunks =
+                            {
+                                new GroundingChunk { Web = new GroundingChunk.Types.Web { Uri = "https://example.com/seattle", Title = "Seattle weather" } },
+                                new GroundingChunk { Web = new GroundingChunk.Types.Web { Uri = "https://example.org/forecast" } },
+                                new GroundingChunk { Web = new GroundingChunk.Types.Web() },
+                            }
+                        }
+                    }
+                },
+                CreateTime = Timestamp.FromDateTime(DateTime.UtcNow),
+                ModelVersion = "test-model",
+                ResponseId = "response-2"
+            }
+        ];
+
+        DelegateCallInvoker invoker = new()
+        {
+            OnGenerateContentRequestStreaming = request => responses
+        };
+
+        IChatClient chatClient = CreateClientBuilder(invoker).BuildIChatClient("projects/test-project/locations/us-central1/publishers/google/models/mymodel");
+        ChatMessage[] messages = [new(ChatRole.User, "What's the weather?")];
+
+        List<ChatResponseUpdate> updates = [];
+        await foreach (ChatResponseUpdate update in chatClient.GetStreamingResponseAsync(messages, new ChatOptions { Tools = [new HostedWebSearchTool()] }))
+        {
+            updates.Add(update);
+        }
+
+        Assert.Equal(2, updates.Count);
+
+        TextContent firstText = Assert.IsType<TextContent>(Assert.Single(updates[0].Contents));
+        Assert.Equal("Grounded ", firstText.Text);
+
+        IList<AIContent> contents = updates[1].Contents;
+        TextContent secondText = Assert.IsType<TextContent>(contents[0]);
+        Assert.Equal("answer.", secondText.Text);
+
+        WebSearchToolCallContent call = Assert.IsType<WebSearchToolCallContent>(contents[1]);
+        Assert.Equal(new[] { "weather in Seattle", "Seattle forecast" }, call.Queries);
+        Assert.IsType<GroundingMetadata>(call.RawRepresentation);
+
+        WebSearchToolResultContent webSearchResult = Assert.IsType<WebSearchToolResultContent>(contents[2]);
+        Assert.Equal(call.CallId, webSearchResult.CallId);
+        Assert.NotNull(webSearchResult.Outputs);
+        Assert.Equal(2, webSearchResult.Outputs.Count);
+
+        UriContent first = Assert.IsType<UriContent>(webSearchResult.Outputs[0]);
+        Assert.Equal("https://example.com/seattle", first.Uri.ToString());
+        Assert.NotNull(first.AdditionalProperties);
+        Assert.Equal("Seattle weather", first.AdditionalProperties["title"]);
+
+        UriContent second = Assert.IsType<UriContent>(webSearchResult.Outputs[1]);
+        Assert.Equal("https://example.org/forecast", second.Uri.ToString());
+        Assert.True(second.AdditionalProperties is null || !second.AdditionalProperties.ContainsKey("title"));
+    }
+
+    [Fact]
     public async Task IChatClient_GetResponseAsync_NullMessages_ThrowsArgumentNullException()
     {
         IChatClient chatClient = CreateClientBuilder().BuildIChatClient("projects/test-project/locations/us-central1/publishers/google/models/mymodel");

--- a/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions/PredictionServiceChatClient.cs
+++ b/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions/PredictionServiceChatClient.cs
@@ -689,6 +689,41 @@ internal sealed class PredictionServiceChatClient(PredictionServiceClient client
                     ];
                 }
             }
+
+            // Add web search grounding metadata as WebSearchToolCallContent/WebSearchToolResultContent.
+            if (candidate.GroundingMetadata is { } groundingMetadata &&
+                (groundingMetadata.WebSearchQueries is { Count: > 0 } || groundingMetadata.GroundingChunks is { Count: > 0 }))
+            {
+                string searchCallId = Guid.NewGuid().ToString("N");
+
+                responseContents.Add(new WebSearchToolCallContent(searchCallId)
+                {
+                    Queries = groundingMetadata.WebSearchQueries,
+                    RawRepresentation = groundingMetadata,
+                });
+
+                List<AIContent>? searchResults = null;
+                if (groundingMetadata.GroundingChunks is { } chunks)
+                {
+                    foreach (var chunk in chunks)
+                    {
+                        if (chunk.Web is { Uri: { Length: > 0 } } web)
+                        {
+                            UriContent result = new(new Uri(web.Uri));
+                            if (web.Title is { Length: > 0 })
+                            {
+                                (result.AdditionalProperties ??= new())["title"] = web.Title;
+                            }
+                            (searchResults ??= new()).Add(result);
+                        }
+                    }
+                }
+
+                responseContents.Add(new WebSearchToolResultContent(searchCallId)
+                {
+                    Outputs = searchResults,
+                });
+            }
         }
 
         // Populate error information if there is any.


### PR DESCRIPTION
Bumps Microsoft.Bcl.AsyncInterfaces from 10.0.4 to 10.0.6 required by the transitive System.Text.Json in MEAI 10.5.1.

Adds projection of Vertex AI `Candidate.GroundingMetadata` (web search queries and grounding chunks) onto MEAI `WebSearchToolCallContent`/ `WebSearchToolResultContent` content types, mirroring the existing implementation in [`Google.GenAI.GoogleGenAIChatClient`](https://github.com/googleapis/dotnet-genai/blob/75b52c7078b433dba4ef527cc7a2e8c38f4474a0/Google.GenAI/GoogleGenAIChatClient.cs#L697-L728).