### PR TITLE
tests(Diagnostics): Relax the check on trace span labes.

### DIFF
--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/SimpleManagedTracerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/SimpleManagedTracerTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -131,7 +131,7 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
             TraceProto trace = TraceEntryPolling.Default.GetTrace(rootSpanName, _startTime);
 
             TraceEntryVerifiers.AssertSingleSpan(trace, rootSpanName);
-            TraceEntryVerifiers.AssertSpanLabelsExact(trace.Spans.First(), labels);
+            TraceEntryVerifiers.AssertSpanLabelsContains(trace.Spans.First(), labels);
         }
 
         [Fact]
@@ -208,7 +208,7 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
 
             Assert.Equal(childTwo.SpanId, grandchildTwo.ParentSpanId);
             Assert.Equal(TraceSpan.Types.SpanKind.Unspecified, grandchildTwo.Kind);
-            TraceEntryVerifiers.AssertSpanLabelsExact(grandchildTwo, labels);
+            TraceEntryVerifiers.AssertSpanLabelsContains(grandchildTwo, labels);
         }
 
         [Fact]

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/TraceEntryVerifiers.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/TraceEntryVerifiers.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 Google Inc. All Rights Reserved.
+// Copyright 2018 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -72,18 +72,6 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
                     mainSpan = innerSpan;
                 }
             }
-        }
-
-        /// <summary>
-        /// Verifies that the span has the exact set of expected labels.
-        /// </list>
-        /// </summary>
-        /// <param name="span">The spna to check.</param>
-        /// <param name="expectedLabels">The set of labels expected to be present on the span.</param>
-        public static void AssertSpanLabelsExact(TraceSpan span, IDictionary<string, string> expectedLabels)
-        {
-            Assert.Equal(expectedLabels.Count, span.Labels.Count);
-            AssertSpanLabelsContains(span, expectedLabels);
         }
 
         /// <summary>

--- a/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/UnchainedTraceHeaderPropagatingHandlerTest.cs
+++ b/apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common.IntegrationTests/Trace/UnchainedTraceHeaderPropagatingHandlerTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
             var trace = TraceEntryPolling.Default.GetTrace(spanName, _startTime);
 
             TraceEntryVerifiers.AssertParentChildSpan(trace, spanName, googleUri);
-            TraceEntryVerifiers.AssertSpanLabelsExact(
+            TraceEntryVerifiers.AssertSpanLabelsContains(
                 trace.Spans.First(s => s.Name == googleUri), TraceEntryData.HttpGetSuccessLabels);
         }
 
@@ -93,7 +93,7 @@ namespace Google.Cloud.Diagnostics.Common.IntegrationTests
             var trace = TraceEntryPolling.Default.GetTrace(spanName, _startTime);
 
             TraceEntryVerifiers.AssertParentChildSpan(trace, spanName, fakeUri);
-            TraceEntryVerifiers.AssertSpanLabelsExact(trace.Spans.Where(s => s.Name == fakeUri).Single(),
+            TraceEntryVerifiers.AssertSpanLabelsContains(trace.Spans.Where(s => s.Name == fakeUri).Single(),
                 new Dictionary<string, string>
                 {
                     {TraceLabels.HttpMethod, "GET" },


### PR DESCRIPTION
When running on GCP (our CI) a few more ambien labels are now being added to the trace spans.