### PR TITLE
test(Spanner): Update spanner run-emulator-tests.sh to stop the emulator after finishing

### DIFF
--- a/apis/Google.Cloud.Spanner.Data/run-emulator-tests.sh
+++ b/apis/Google.Cloud.Spanner.Data/run-emulator-tests.sh
@@ -27,7 +27,7 @@ gcloud emulators spanner start &
 
 EMULATOR_PID=$!
 # When this shell exits, stop the emulator.
-trap "kill -15 $EMULATOR_PID; echo \"Cleaned up the emulator\";" EXIT
+trap "kill -- "-$EMULATOR_PID" || true; echo \"Cleaned up the emulator\";" EXIT
 
 # Run the tests.
 dotnet test -c Release Google.Cloud.Spanner.Data.IntegrationTests --filter SupportedOnEmulator\!=No


### PR DESCRIPTION
b/518016803

This fixes an issue with the spanner integration tests when run against the emulator. Current behavior tries to stop the emulator with `kill -15 $EMULATOR_PID`, however `$EMULATOR_PID` is the top level python process and does not stop the other processes related to the emulator, more specifically `emulator_main` persists and keeps listening on port 9010. This causing subsequent tests to fail.