### PR TITLE
feat(Pub/Sub): Add snippets for using PubSub SMT with Topics and Subscriptions

### DIFF
--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/PublisherServiceApiClientSnippets.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/PublisherServiceApiClientSnippets.cs
@@ -100,6 +100,42 @@ namespace Google.Cloud.PubSub.V1.Snippets
         }
 
         [Fact]
+        public void CreateTopicWithSMT()
+        {
+            string projectId = _fixture.ProjectId;
+            string topicId = _fixture.CreateTopicId();
+
+            // Snippet: CreateTopicWithSMT(TopicName,*,*,*,*)
+
+            // Create the javascript UDF. FunctionName and name in the javascript function definition must match
+            JavaScriptUDF javaScriptUDF = new JavaScriptUDF
+            {
+                FunctionName = "process",
+                Code =  "function process(message, metadata) {"
+                    +   "   var data = JSON.parse(message.data);"
+                    +   "   delete data['ssn'];"
+                    +   "   message.data = JSON.stringify(data);"
+                    +   "   return message;"
+                    +   "}"
+            };
+
+            MessageTransform messageTransform = new MessageTransform
+            {
+                JavascriptUdf = javaScriptUDF,
+            };
+
+            Topic createTopicRequest = new Topic
+            {
+                TopicName = new TopicName(projectId, topicId),
+                MessageTransforms = { messageTransform }
+            };
+            Topic topic = PublisherServiceApiClient.Create().CreateTopic(createTopicRequest);
+
+            Console.WriteLine($"Created {topic.Name} with {topic.MessageTransforms.Count} transforms");
+            // End Snippet
+        }
+
+        [Fact]
         public void Publish()
         {
             string projectId = _fixture.ProjectId;

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/SubscriberServiceApiClientSnippets.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/SubscriberServiceApiClientSnippets.cs
@@ -218,6 +218,49 @@ namespace Google.Cloud.PubSub.V1.Snippets
         }
 
         [Fact]
+        public void CreateSubscriptionWithSMT()
+        {
+            string projectId = _fixture.ProjectId;
+            string topicId = _fixture.CreateTopicId();
+            string subscriptionId = _fixture.CreateSubscriptionId();
+
+            PublisherServiceApiClient.Create().CreateTopic(new TopicName(projectId, topicId));
+
+            // Snippet: CreateSubscriptionWithSMT(SubscriptionName,*,*,*,*)
+            SubscriberServiceApiClient client = SubscriberServiceApiClient.Create();
+
+            // Create the javascript UDF. FunctionName and name in the javascript function definition must match
+            JavaScriptUDF javaScriptUDF = new JavaScriptUDF
+            {
+                FunctionName = "process",
+                Code =  "function process(message, metadata) {"
+                    +   "   var data = JSON.parse(message.data);"
+                    +   "   delete data['ssn'];"
+                    +   "   message.data = JSON.stringify(data);"
+                    +   "   return message;"
+                    +   "}"
+            };
+
+            MessageTransform messageTransform = new MessageTransform
+            {
+                JavascriptUdf = javaScriptUDF,
+            };
+
+            SubscriptionName subscriptionName = new SubscriptionName(projectId, subscriptionId);
+            Subscription createSubscriptionRequest = new Subscription
+            {
+                SubscriptionName = subscriptionName,
+                TopicAsTopicName = new TopicName(projectId, topicId),
+                AckDeadlineSeconds = 60,
+                MessageTransforms = { messageTransform },
+            };
+
+            Subscription subscription = client.CreateSubscription(createSubscriptionRequest);
+            Console.WriteLine($"Created {subscription.Name} with {subscription.MessageTransforms.Count} transforms");
+            // End Snippet
+        }
+
+        [Fact]
         public void Pull()
         {
             string projectId = _fixture.ProjectId;


### PR DESCRIPTION
b/427316649
This adds two new snippets to demonstrate how to add a SMT to a Topic or Subscription as a JavaScript UDF