### PR TITLE
chore(Renovate): Limit to nuget, dockerfiles, github actions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -357,6 +357,11 @@
   "ignoreDeps": [
     "Grpc.Core"
   ],
+  "enabledManagers": [
+    "github-actions",
+    "dockerfile",
+    "nuget"
+  ],
   "packageRules": [
     {
       "matchPackagePrefixes": [

--- a/generator-input/renovate-template.json
+++ b/generator-input/renovate-template.json
@@ -12,6 +12,11 @@
   "ignoreDeps": [
     "Grpc.Core"
   ],
+  "enabledManagers": [
+    "github-actions",
+    "dockerfile",
+    "nuget"
+  ],
   "packageRules": [
     {
       "matchPackagePrefixes": [


### PR DESCRIPTION
b/521971428

Our repository is too large to run renovate normally. This change adds `enabledManagers` in the config with three managers:

- github-actions
- dockerfile
- nuget

This should be all that we need for now