### PR TITLE
build: restrict Renovate to nuget and github-actions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,8 @@
 {
+  "enabledManagers": [
+    "nuget",
+    "github-actions"
+  ],
   "extends": [
     "config:base",
     ":disableDependencyDashboard"


### PR DESCRIPTION
I am hoping this helps renovate to create a PR. I can see in the logs it was processing many other types which may be the issue.