### PR TITLE
chore(Renovate): Update Renovate config names

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -373,7 +373,7 @@
       "allowedVersions": "<9.0.0"
     },
     {
-      "matchPaths": [
+      "matchFileNames": [
         "apis/Google.Cloud.Diagnostics.AspNetCore3/**"
       ],
       "matchPackagePrefixes": [
@@ -382,7 +382,7 @@
       "allowedVersions": "<3.2.0"
     },
     {
-      "matchPaths": [
+      "matchFileNames": [
         "apis/Google.Cloud.Dialogflow.V2/**"
       ],
       "matchPackagePrefixes": [

--- a/generator-input/renovate-template.json
+++ b/generator-input/renovate-template.json
@@ -28,7 +28,7 @@
       "allowedVersions": "<9.0.0"
     },
     {
-      "matchPaths": [
+      "matchFileNames": [
         "apis/Google.Cloud.Diagnostics.AspNetCore3/**"
       ],
       "matchPackagePrefixes": [
@@ -37,7 +37,7 @@
       "allowedVersions": "<3.2.0"
     },
     {
-      "matchPaths": [
+      "matchFileNames": [
         "apis/Google.Cloud.Dialogflow.V2/**"
       ],
       "matchPackagePrefixes": [


### PR DESCRIPTION
b/521971428

This config change will have Renovate create PRs with up-to-date option names. We regenerate the renovate config `ReleaseManager`, using the template so once "the most up-to-date" option names change again, renovate will update it's own configs at `/.github/renovate.json`, which will be overwritten by `ReleaseManager` and likely continue in a cycle. Need to think what to do here, we could commit these changes and let them run as a one-time change, and mirror those changes over to the template. Or we could figure how to remove renovate regeneration in `ReleaseManager`, if that's even possible right now.