### PR TITLE
chore(actions): address zizmor findings

### DIFF
--- a/.github/workflows/bigtable-conformance.yml
+++ b/.github/workflows/bigtable-conformance.yml
@@ -14,6 +14,9 @@
 # Github action job to test core java library features on
 # downstream client libraries before they are released.
 on:
+
+permissions:
+  contents: read
   push:
     branches:
     - main

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,5 +1,8 @@
 name: Build and test PR (changed APIs only)
 
+permissions:
+  contents: read
+
 on: [pull_request]
 
 jobs:
@@ -13,13 +16,14 @@ jobs:
         regex: ["'Google\\.Cloud\\.[A-L].*'", "'Google\\.Cloud\\.[M-Z].*'", "'!Google\\.Cloud'"]
     
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         submodules: true
         fetch-depth: 100
+        persist-credentials: false
         
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
         dotnet-version: |
           6.0.x

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -1,5 +1,8 @@
 name: Build push
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -13,12 +16,13 @@ jobs:
       DOTNET_NOLOGO: true
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         submodules: true
+        persist-credentials: false
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
         dotnet-version: |
           6.0.x

--- a/.github/workflows/build-tools.yml
+++ b/.github/workflows/build-tools.yml
@@ -1,5 +1,8 @@
 name: Build and test PR (tools)
 
+permissions:
+  contents: read
+
 on: [pull_request]
 
 jobs:
@@ -10,12 +13,13 @@ jobs:
       DOTNET_NOLOGO: true
     
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         submodules: true
+        persist-credentials: false
         
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
         dotnet-version: |
           8.0.x

--- a/.github/workflows/check-api-catalog.yml
+++ b/.github/workflows/check-api-catalog.yml
@@ -1,5 +1,8 @@
 name: Check that apis.json is valid JSON
 
+permissions:
+  contents: read
+
 on: [pull_request, push]
 
 jobs:
@@ -8,7 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
         
     - name: Validate API catalog
       run: python -c 'import json; json.load(open("generator-input/apis.json", "r"))'

--- a/.github/workflows/check-script-permissions.yml
+++ b/.github/workflows/check-script-permissions.yml
@@ -1,5 +1,8 @@
 name: Check that all pre and post-generation scripts are executable
 
+permissions:
+  contents: read
+
 on: [pull_request, push]
 
 jobs:
@@ -8,7 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
         
     - name: Validate script permissions
       run: '! stat -c "%a %n" generator-input/tweaks/*/p*.sh | grep -v 755'

--- a/.github/workflows/diff-pr.yml
+++ b/.github/workflows/diff-pr.yml
@@ -14,10 +14,11 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         submodules: true
         fetch-depth: 100
+        persist-credentials: false
 
     # The GitHub checkout action leaves the repo in a slightly awkward
     # state. This tidies it up.
@@ -28,7 +29,7 @@ jobs:
         git checkout pr-head
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
         dotnet-version: |
           6.0.x

--- a/.github/workflows/spanner-emulator-pr-push.yml
+++ b/.github/workflows/spanner-emulator-pr-push.yml
@@ -1,5 +1,8 @@
 name: Spanner tests against emulator (Spanner changes only)
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:
@@ -23,12 +26,13 @@ jobs:
           - 9020:9020
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         submodules: true
+        persist-credentials: false
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
         dotnet-version: |
           6.0.x

--- a/.github/workflows/storage-retry-conformance.yml
+++ b/.github/workflows/storage-retry-conformance.yml
@@ -1,5 +1,8 @@
 name: Run Storage Retry conformance tests against service emulator
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]
@@ -19,17 +22,18 @@ jobs:
 
     services:
       emulator:
-        image: gcr.io/cloud-devrel-public-resources/storage-testbench:latest
+        image: gcr.io/cloud-devrel-public-resources/storage-testbench:latest # zizmor: ignore[unpinned-images]
         ports:
           - 9000:9000
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         submodules: true
+        persist-credentials: false
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
         dotnet-version: |
           6.0.x


### PR DESCRIPTION
This PR is an auto-generated attempt to address zizmor findings. It may not catch everything, and should be reviewed by repository owners.

These changes were generated by running `zizmor --fix=all --gh-token=$(gh auth token) ./.github/workflows`, and then applying some fixes for any remaining issues reported by zizmor. See go/github-zizmor-help for instructions to install and run.

If this PR is unhelpful, feel free to close the PR and address separately. If it is helpful, feel free to approve and merge, or edit/modify as needed to get it to the right state. Repository owners must ultimately ensure compliance by 2026-07-13. The purpose of this PR is to provide some assistance with achieving that as a first pass. This will become a blocking check for new changes to github workflows on 2026-07-13 within the `googleapis` org.

There may be some ignored findings (with the comment `# zizmor: ignore[...]`), which you may fix if feasible.
