### PR TITLE
chore(actions): address zizmor findings

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base",
+    "config:best-practices",
     ":disableDependencyDashboard"
   ],
   "ignorePresets": [

--- a/.github/workflows/bigtable-conformance.yml
+++ b/.github/workflows/bigtable-conformance.yml
@@ -25,20 +25,22 @@ jobs:
   conformance:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         submodules: true
-    - uses: actions/checkout@v7
+        persist-credentials: false
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         repository: googleapis/cloud-bigtable-clients-test
         ref: main
         path: cloud-bigtable-clients-test
-    - uses: actions/setup-dotnet@v5
+        persist-credentials: false
+    - uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
         dotnet-version: |
           6.0.x
           8.0.x
-    - uses: actions/setup-go@v6
+    - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
         go-version: '>=1.20.2'
     - run: dotnet --version

--- a/.github/workflows/bigtable-conformance.yml
+++ b/.github/workflows/bigtable-conformance.yml
@@ -21,6 +21,9 @@ on:
     paths:
     - '**[Bb]ig[Tt]able**'
 name: bigtable-conformance
+permissions:
+  contents: read
+
 jobs:
   conformance:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -2,6 +2,9 @@ name: Build and test PR (changed APIs only)
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -13,13 +13,14 @@ jobs:
         regex: ["'Google\\.Cloud\\.[A-L].*'", "'Google\\.Cloud\\.[M-Z].*'", "'!Google\\.Cloud'"]
     
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         submodules: true
         fetch-depth: 100
+        persist-credentials: false
         
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
         dotnet-version: |
           6.0.x

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
 
   build:

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -13,12 +13,13 @@ jobs:
       DOTNET_NOLOGO: true
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         submodules: true
+        persist-credentials: false
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
         dotnet-version: |
           6.0.x

--- a/.github/workflows/build-tools.yml
+++ b/.github/workflows/build-tools.yml
@@ -10,12 +10,13 @@ jobs:
       DOTNET_NOLOGO: true
     
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         submodules: true
+        persist-credentials: false
         
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
         dotnet-version: |
           8.0.x

--- a/.github/workflows/build-tools.yml
+++ b/.github/workflows/build-tools.yml
@@ -2,6 +2,9 @@ name: Build and test PR (tools)
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:

--- a/.github/workflows/check-api-catalog.yml
+++ b/.github/workflows/check-api-catalog.yml
@@ -2,6 +2,9 @@ name: Check that apis.json is valid JSON
 
 on: [pull_request, push]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:

--- a/.github/workflows/check-api-catalog.yml
+++ b/.github/workflows/check-api-catalog.yml
@@ -8,7 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
         
     - name: Validate API catalog
       run: python -c 'import json; json.load(open("generator-input/apis.json", "r"))'

--- a/.github/workflows/check-script-permissions.yml
+++ b/.github/workflows/check-script-permissions.yml
@@ -2,6 +2,9 @@ name: Check that all pre and post-generation scripts are executable
 
 on: [pull_request, push]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:

--- a/.github/workflows/check-script-permissions.yml
+++ b/.github/workflows/check-script-permissions.yml
@@ -8,7 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
         
     - name: Validate script permissions
       run: '! stat -c "%a %n" generator-input/tweaks/*/p*.sh | grep -v 755'

--- a/.github/workflows/diff-pr.yml
+++ b/.github/workflows/diff-pr.yml
@@ -14,10 +14,11 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         submodules: true
         fetch-depth: 100
+        persist-credentials: false
 
     # The GitHub checkout action leaves the repo in a slightly awkward
     # state. This tidies it up.
@@ -28,7 +29,7 @@ jobs:
         git checkout pr-head
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
         dotnet-version: |
           6.0.x

--- a/.github/workflows/spanner-emulator-pr-push.yml
+++ b/.github/workflows/spanner-emulator-pr-push.yml
@@ -10,6 +10,9 @@ on:
     paths:
     - '**[Ss]panner**'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/spanner-emulator-pr-push.yml
+++ b/.github/workflows/spanner-emulator-pr-push.yml
@@ -23,12 +23,13 @@ jobs:
           - 9020:9020
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         submodules: true
+        persist-credentials: false
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
         dotnet-version: |
           6.0.x

--- a/.github/workflows/storage-retry-conformance.yml
+++ b/.github/workflows/storage-retry-conformance.yml
@@ -24,12 +24,13 @@ jobs:
           - 9000:9000
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         submodules: true
+        persist-credentials: false
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
         dotnet-version: |
           6.0.x

--- a/.github/workflows/storage-retry-conformance.yml
+++ b/.github/workflows/storage-retry-conformance.yml
@@ -9,6 +9,9 @@ on:
     paths:
     - 'apis/Google.Cloud.Storage.V1/**'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -19,7 +22,7 @@ jobs:
 
     services:
       emulator:
-        image: gcr.io/cloud-devrel-public-resources/storage-testbench:latest
+        image: gcr.io/cloud-devrel-public-resources/storage-testbench@sha256:600fa5c3cfc8be26435c38591cc094fb4ef648f760ffabf77f93237b1ebee027
         ports:
           - 9000:9000
 


### PR DESCRIPTION
This PR is an auto-generated attempt to address zizmor findings. It may not catch everything, and should be reviewed by repository owners.

These changes were generated by running `zizmor --fix=all --gh-token=$(gh auth token) ./.github/workflows`, and then applying some fixes for any remaining issues reported by zizmor. See go/github-zizmor-help for instructions to install and run. 

Additionally, it updates renovate configuration (if present) to extend [best-practices](https://docs.renovatebot.com/presets-config/#configbest-practices), which includes pinning action digests and image digests, among other things.

If this PR is unhelpful, feel free to close the PR and address separately. If it is helpful, feel free to approve and merge, or edit/modify as needed to get it to the right state. Repository owners must ultimately ensure compliance by 2026-07-13. The purpose of this PR is to provide some assistance with achieving that as a first pass. This will become a blocking check for new changes to github workflows on 2026-07-13 within the `googleapis` org.

There may be some ignored findings (with the comment `# zizmor: ignore[...]`), which you may fix if feasible.
