### PR TITLE
chore: update generation image tag to v2026-08-03

### DIFF
--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -1,5 +1,5 @@
 {
-    "imageTag": "v2026-06-25",
+    "imageTag": "v2026-08-03",
     "libraries": [
         {
             "id": "Google.Ads.AdManager.V1",


### PR DESCRIPTION
b/542253770