### PR TITLE
chore: update image generator integration test to gemini-2.5-flash-image

### DIFF
--- a/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions.IntegrationTests/VertexAIExtensionsTest.cs
+++ b/apis/Google.Cloud.VertexAI.Extensions/Google.Cloud.VertexAI.Extensions.IntegrationTests/VertexAIExtensionsTest.cs
@@ -71,7 +71,7 @@ public class VertexAIExtensionsTest
     public async Task AsIImageGenerator_GenerateImage()
     {
         IImageGenerator generator = await new PredictionServiceClientBuilder()
-            .BuildIImageGeneratorAsync(EndpointName.FormatProjectLocationPublisherModel(s_projectId, s_location, "google", "imagen-4.0-fast-generate-001"));
+            .BuildIImageGeneratorAsync(EndpointName.FormatProjectLocationPublisherModel(s_projectId, s_location, "google", "gemini-2.5-flash-image"));
         Assert.NotNull(generator);
 
         ImageGenerationResponse response = await generator.GenerateImagesAsync("A cute baby sea otter");


### PR DESCRIPTION
`imagen-4.0-fast-generate-001` has been deprecated in favor of `gemini-2.5-flash-image`.

https://cloud.google.com/vertex-ai/generative-ai/docs/release-notes#March_24_2026

Noticed failure in `cloud-libraries-dotnet/google-cloud-dotnet/rbe_windows/daily-integration-tests`