### PR TITLE
fix: Revert upgrade of Roslyn packagers in tweaks dir

### DIFF
--- a/generator-input/tweaks/Directory.Packages.props
+++ b/generator-input/tweaks/Directory.Packages.props
@@ -8,8 +8,8 @@
     <PackageVersion Include="Google.LongRunning" Version="[3.4.0, 4.0.0)" />
     <PackageVersion Include="Google.Protobuf" Version="3.31.1"/>
     
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.9.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.9.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.6.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Latest librarian run failure caused by package upgrades from #15835 