### PR TITLE
chore(renovate): limit Microsoft.CodeAnalysis.CSharp renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -423,6 +423,12 @@
       "allowedVersions": "<0.14.0"
     },
     {
+      "matchPackageNames": [
+        "Microsoft.CodeAnalysis*"
+      ],
+      "allowedVersions": "<5.9.0"
+    },
+    {
       "matchFileNames": [
         "Dockerfile.generator"
       ],

--- a/generator-input/renovate-template.json
+++ b/generator-input/renovate-template.json
@@ -71,6 +71,12 @@
       "allowedVersions": "<0.14.0"
     },
     {
+      "matchPackageNames": [
+        "Microsoft.CodeAnalysis*"
+      ],
+      "allowedVersions": "<5.9.0"
+    },
+    {
       "matchFileNames": [
         "Dockerfile.generator"
       ],


### PR DESCRIPTION
edit: Renovate has some immortal updates for these updates, but we can't minor updates without breaking our build system